### PR TITLE
fix: add deepseek- dash-prefix routing to UPSTREAM_ROUTES

### DIFF
--- a/packages/gateway/src/config.ts
+++ b/packages/gateway/src/config.ts
@@ -106,6 +106,8 @@ const UPSTREAM_ROUTES: Array<{ prefix: string; url: string; protocol: "anthropic
   { prefix: "google/",        url: "https://integrate.api.nvidia.com",   protocol: "openai" },
   { prefix: "qwen/",          url: "https://integrate.api.nvidia.com",   protocol: "openai" },
   { prefix: "deepseek/",      url: "https://integrate.api.nvidia.com",   protocol: "openai" },
+  // DeepSeek (direct API, dash-prefix)
+  { prefix: "deepseek-",      url: "https://api.deepseek.com",           protocol: "openai" },
   // OpenAI
   { prefix: "gpt-",           url: "https://api.openai.com",             protocol: "openai" },
   { prefix: "o1-",            url: "https://api.openai.com",             protocol: "openai" },

--- a/packages/gateway/test/upstream-routes.test.ts
+++ b/packages/gateway/test/upstream-routes.test.ts
@@ -8,110 +8,141 @@ import { resolveUpstreamRoute } from "../src/config";
 describe("resolveUpstreamRoute", () => {
   describe("Anthropic", () => {
     test("routes claude- models to Anthropic API", () => {
-      const result = resolveUpstreamRoute("claude-sonnet-4-5");
-      expect(result).not.toBeNull();
-      expect(result!.url).toBe("https://api.anthropic.com");
-      expect(result!.protocol).toBe("anthropic");
+      expect(resolveUpstreamRoute("claude-sonnet-4-5")).toEqual({
+        url: "https://api.anthropic.com",
+        protocol: "anthropic",
+      });
     });
   });
 
   describe("OpenAI", () => {
     test("routes gpt- models to OpenAI API", () => {
-      const result = resolveUpstreamRoute("gpt-4o");
-      expect(result).not.toBeNull();
-      expect(result!.url).toBe("https://api.openai.com");
-      expect(result!.protocol).toBe("openai");
+      expect(resolveUpstreamRoute("gpt-4o")).toEqual({
+        url: "https://api.openai.com",
+        protocol: "openai",
+      });
     });
 
     test("routes o1- models to OpenAI API", () => {
-      const result = resolveUpstreamRoute("o1-pro");
-      expect(result).not.toBeNull();
-      expect(result!.url).toBe("https://api.openai.com");
-      expect(result!.protocol).toBe("openai");
+      expect(resolveUpstreamRoute("o1-pro")).toEqual({
+        url: "https://api.openai.com",
+        protocol: "openai",
+      });
+    });
+
+    test("routes o3- models to OpenAI API", () => {
+      expect(resolveUpstreamRoute("o3-mini")).toEqual({
+        url: "https://api.openai.com",
+        protocol: "openai",
+      });
+    });
+
+    test("routes o4- models to OpenAI API", () => {
+      expect(resolveUpstreamRoute("o4-mini")).toEqual({
+        url: "https://api.openai.com",
+        protocol: "openai",
+      });
     });
   });
 
   describe("xAI", () => {
     test("routes grok- models to xAI API", () => {
-      const result = resolveUpstreamRoute("grok-3-beta");
-      expect(result).not.toBeNull();
-      expect(result!.url).toBe("https://api.x.ai");
-      expect(result!.protocol).toBe("openai");
+      expect(resolveUpstreamRoute("grok-3-beta")).toEqual({
+        url: "https://api.x.ai",
+        protocol: "openai",
+      });
     });
   });
 
   describe("Mistral (direct)", () => {
     test("routes mistral- models to Mistral API", () => {
-      const result = resolveUpstreamRoute("mistral-large-latest");
-      expect(result).not.toBeNull();
-      expect(result!.url).toBe("https://api.mistral.ai");
-      expect(result!.protocol).toBe("openai");
+      expect(resolveUpstreamRoute("mistral-large-latest")).toEqual({
+        url: "https://api.mistral.ai",
+        protocol: "openai",
+      });
     });
 
     test("routes codestral- models to Mistral API", () => {
-      const result = resolveUpstreamRoute("codestral-latest");
-      expect(result).not.toBeNull();
-      expect(result!.url).toBe("https://api.mistral.ai");
-      expect(result!.protocol).toBe("openai");
+      expect(resolveUpstreamRoute("codestral-latest")).toEqual({
+        url: "https://api.mistral.ai",
+        protocol: "openai",
+      });
     });
   });
 
   describe("Google (direct)", () => {
     test("routes gemini- models to Google API", () => {
-      const result = resolveUpstreamRoute("gemini-2.5-pro");
-      expect(result).not.toBeNull();
-      expect(result!.url).toBe("https://generativelanguage.googleapis.com");
-      expect(result!.protocol).toBe("openai");
+      expect(resolveUpstreamRoute("gemini-2.5-pro")).toEqual({
+        url: "https://generativelanguage.googleapis.com",
+        protocol: "openai",
+      });
     });
   });
 
   describe("DeepSeek", () => {
     test("routes deepseek- (dash) models to DeepSeek direct API", () => {
-      const result = resolveUpstreamRoute("deepseek-v4-pro");
-      expect(result).not.toBeNull();
-      expect(result!.url).toBe("https://api.deepseek.com");
-      expect(result!.protocol).toBe("openai");
+      expect(resolveUpstreamRoute("deepseek-v4-pro")).toEqual({
+        url: "https://api.deepseek.com",
+        protocol: "openai",
+      });
     });
 
     test("routes deepseek-chat to DeepSeek direct API", () => {
-      const result = resolveUpstreamRoute("deepseek-chat");
-      expect(result).not.toBeNull();
-      expect(result!.url).toBe("https://api.deepseek.com");
-      expect(result!.protocol).toBe("openai");
+      expect(resolveUpstreamRoute("deepseek-chat")).toEqual({
+        url: "https://api.deepseek.com",
+        protocol: "openai",
+      });
     });
 
     test("routes deepseek-reasoner to DeepSeek direct API", () => {
-      const result = resolveUpstreamRoute("deepseek-reasoner");
-      expect(result).not.toBeNull();
-      expect(result!.url).toBe("https://api.deepseek.com");
-      expect(result!.protocol).toBe("openai");
+      expect(resolveUpstreamRoute("deepseek-reasoner")).toEqual({
+        url: "https://api.deepseek.com",
+        protocol: "openai",
+      });
     });
 
     test("routes deepseek/ (slash) models to Nvidia NIM", () => {
-      const result = resolveUpstreamRoute("deepseek/deepseek-r1");
-      expect(result).not.toBeNull();
-      expect(result!.url).toBe("https://integrate.api.nvidia.com");
-      expect(result!.protocol).toBe("openai");
+      expect(resolveUpstreamRoute("deepseek/deepseek-r1")).toEqual({
+        url: "https://integrate.api.nvidia.com",
+        protocol: "openai",
+      });
     });
   });
 
   describe("Nvidia NIM (slash-prefix)", () => {
     test("routes nvidia/ models to Nvidia NIM", () => {
-      const result = resolveUpstreamRoute("nvidia/llama-3.1-nemotron");
-      expect(result).not.toBeNull();
-      expect(result!.url).toBe("https://integrate.api.nvidia.com");
+      expect(resolveUpstreamRoute("nvidia/llama-3.1-nemotron")).toEqual({
+        url: "https://integrate.api.nvidia.com",
+        protocol: "openai",
+      });
     });
 
     test("routes meta/ models to Nvidia NIM", () => {
-      const result = resolveUpstreamRoute("meta/llama-4-maverick");
-      expect(result).not.toBeNull();
-      expect(result!.url).toBe("https://integrate.api.nvidia.com");
+      expect(resolveUpstreamRoute("meta/llama-4-maverick")).toEqual({
+        url: "https://integrate.api.nvidia.com",
+        protocol: "openai",
+      });
+    });
+
+    test("routes mistralai/ models to Nvidia NIM", () => {
+      expect(resolveUpstreamRoute("mistralai/mistral-large")).toEqual({
+        url: "https://integrate.api.nvidia.com",
+        protocol: "openai",
+      });
+    });
+
+    test("routes google/ models to Nvidia NIM", () => {
+      expect(resolveUpstreamRoute("google/gemma-3")).toEqual({
+        url: "https://integrate.api.nvidia.com",
+        protocol: "openai",
+      });
     });
 
     test("routes qwen/ models to Nvidia NIM", () => {
-      const result = resolveUpstreamRoute("qwen/qwen3-235b-a22b");
-      expect(result).not.toBeNull();
-      expect(result!.url).toBe("https://integrate.api.nvidia.com");
+      expect(resolveUpstreamRoute("qwen/qwen3-235b-a22b")).toEqual({
+        url: "https://integrate.api.nvidia.com",
+        protocol: "openai",
+      });
     });
   });
 

--- a/packages/gateway/test/upstream-routes.test.ts
+++ b/packages/gateway/test/upstream-routes.test.ts
@@ -1,0 +1,127 @@
+import { describe, test, expect } from "bun:test";
+import { resolveUpstreamRoute } from "../src/config";
+
+// ---------------------------------------------------------------------------
+// resolveUpstreamRoute
+// ---------------------------------------------------------------------------
+
+describe("resolveUpstreamRoute", () => {
+  describe("Anthropic", () => {
+    test("routes claude- models to Anthropic API", () => {
+      const result = resolveUpstreamRoute("claude-sonnet-4-5");
+      expect(result).not.toBeNull();
+      expect(result!.url).toBe("https://api.anthropic.com");
+      expect(result!.protocol).toBe("anthropic");
+    });
+  });
+
+  describe("OpenAI", () => {
+    test("routes gpt- models to OpenAI API", () => {
+      const result = resolveUpstreamRoute("gpt-4o");
+      expect(result).not.toBeNull();
+      expect(result!.url).toBe("https://api.openai.com");
+      expect(result!.protocol).toBe("openai");
+    });
+
+    test("routes o1- models to OpenAI API", () => {
+      const result = resolveUpstreamRoute("o1-pro");
+      expect(result).not.toBeNull();
+      expect(result!.url).toBe("https://api.openai.com");
+      expect(result!.protocol).toBe("openai");
+    });
+  });
+
+  describe("xAI", () => {
+    test("routes grok- models to xAI API", () => {
+      const result = resolveUpstreamRoute("grok-3-beta");
+      expect(result).not.toBeNull();
+      expect(result!.url).toBe("https://api.x.ai");
+      expect(result!.protocol).toBe("openai");
+    });
+  });
+
+  describe("Mistral (direct)", () => {
+    test("routes mistral- models to Mistral API", () => {
+      const result = resolveUpstreamRoute("mistral-large-latest");
+      expect(result).not.toBeNull();
+      expect(result!.url).toBe("https://api.mistral.ai");
+      expect(result!.protocol).toBe("openai");
+    });
+
+    test("routes codestral- models to Mistral API", () => {
+      const result = resolveUpstreamRoute("codestral-latest");
+      expect(result).not.toBeNull();
+      expect(result!.url).toBe("https://api.mistral.ai");
+      expect(result!.protocol).toBe("openai");
+    });
+  });
+
+  describe("Google (direct)", () => {
+    test("routes gemini- models to Google API", () => {
+      const result = resolveUpstreamRoute("gemini-2.5-pro");
+      expect(result).not.toBeNull();
+      expect(result!.url).toBe("https://generativelanguage.googleapis.com");
+      expect(result!.protocol).toBe("openai");
+    });
+  });
+
+  describe("DeepSeek", () => {
+    test("routes deepseek- (dash) models to DeepSeek direct API", () => {
+      const result = resolveUpstreamRoute("deepseek-v4-pro");
+      expect(result).not.toBeNull();
+      expect(result!.url).toBe("https://api.deepseek.com");
+      expect(result!.protocol).toBe("openai");
+    });
+
+    test("routes deepseek-chat to DeepSeek direct API", () => {
+      const result = resolveUpstreamRoute("deepseek-chat");
+      expect(result).not.toBeNull();
+      expect(result!.url).toBe("https://api.deepseek.com");
+      expect(result!.protocol).toBe("openai");
+    });
+
+    test("routes deepseek-reasoner to DeepSeek direct API", () => {
+      const result = resolveUpstreamRoute("deepseek-reasoner");
+      expect(result).not.toBeNull();
+      expect(result!.url).toBe("https://api.deepseek.com");
+      expect(result!.protocol).toBe("openai");
+    });
+
+    test("routes deepseek/ (slash) models to Nvidia NIM", () => {
+      const result = resolveUpstreamRoute("deepseek/deepseek-r1");
+      expect(result).not.toBeNull();
+      expect(result!.url).toBe("https://integrate.api.nvidia.com");
+      expect(result!.protocol).toBe("openai");
+    });
+  });
+
+  describe("Nvidia NIM (slash-prefix)", () => {
+    test("routes nvidia/ models to Nvidia NIM", () => {
+      const result = resolveUpstreamRoute("nvidia/llama-3.1-nemotron");
+      expect(result).not.toBeNull();
+      expect(result!.url).toBe("https://integrate.api.nvidia.com");
+    });
+
+    test("routes meta/ models to Nvidia NIM", () => {
+      const result = resolveUpstreamRoute("meta/llama-4-maverick");
+      expect(result).not.toBeNull();
+      expect(result!.url).toBe("https://integrate.api.nvidia.com");
+    });
+
+    test("routes qwen/ models to Nvidia NIM", () => {
+      const result = resolveUpstreamRoute("qwen/qwen3-235b-a22b");
+      expect(result).not.toBeNull();
+      expect(result!.url).toBe("https://integrate.api.nvidia.com");
+    });
+  });
+
+  describe("Unknown models", () => {
+    test("returns null for unknown model prefix", () => {
+      expect(resolveUpstreamRoute("llama-4-maverick")).toBeNull();
+    });
+
+    test("returns null for model without prefix", () => {
+      expect(resolveUpstreamRoute("some-random-model")).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
- Add { prefix: 'deepseek-', url: 'https://api.deepseek.com', protocol: 'openai' } to UPSTREAM_ROUTES in config.ts for direct DeepSeek API access
- Models like deepseek-v4-pro now correctly route to api.deepseek.com instead of falling back to OpenAI with a DeepSeek API key (401 error)
- Add upstream-routes.test.ts with 16 tests covering all route prefixes including DeepSeek dash-prefix (deepseek-v4-pro, deepseek-chat) and slash-prefix (deepseek/deepseek-r1 to Nvidia NIM)