### PR TITLE
fix(gateway): diagnose recall continuation failures

### DIFF
--- a/packages/gateway/instrument.ts
+++ b/packages/gateway/instrument.ts
@@ -48,6 +48,7 @@ import { VERSION } from "./src/cli/version";
 import { eventHasTransientError } from "./src/transient-errors";
 import {
   SENTRY_DATA_COLLECTION,
+  isolateRecallContinuationEvent,
   scrubTelemetryEvent,
   scrubTelemetryValue,
   wrapTelemetryTransport,
@@ -175,6 +176,9 @@ export function buildSentryOptions(
     // Each exception in the chain is tested independently so a real bug
     // wrapping a transient cause isn't accidentally silenced.
     beforeSend(event) {
+      if (event.message === "Recall continuation failed") {
+        return isolateRecallContinuationEvent(event);
+      }
       return eventHasTransientError(event) ? null : scrubTelemetryEvent(event);
     },
 

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -232,6 +232,7 @@ import {
   AnthropicSSEValidator,
   cancelAndReleaseReader,
   readStreamChunk,
+  SSEStreamLimitError,
   SSEStreamTransportError,
   DEFAULT_MAX_SSE_FRAMES,
   type StreamAccumulator,
@@ -333,6 +334,11 @@ import {
   captureEmptyCompletion,
   type AnthropicUsage,
 } from "./sentry";
+import {
+  RecallContinuationFailure,
+  reportRecallContinuationFailure,
+  type RecallContinuationFailureCategory,
+} from "./recall-continuation-failure";
 import {
   recordConversationCost,
   updateShadowContext,
@@ -8880,10 +8886,14 @@ export function streamResponsesRecallAware(
       lifecycle.terminal = true;
     }
   };
-  const assertOutputLifecyclesComplete = (acc: ResponsesAccState): void => {
+  const assertOutputLifecyclesComplete = (
+    acc: ResponsesAccState,
+    allowedIncompleteIndices: ReadonlySet<number> = new Set(),
+  ): void => {
     const lifecycles = lifecyclesFor(acc);
     for (const index of acc.rawItems.keys()) {
       if (lifecycles.get(index)?.outputDone) continue;
+      if (allowedIncompleteIndices.has(index)) continue;
       if (opts.validation !== "codex") {
         throw new Error(
           `Responses stream ended before output_item.done for index ${index}`,
@@ -9609,6 +9619,18 @@ export function streamResponsesRecallAware(
         };
         let principalReader: ReadableStreamDefaultReader<Uint8Array> | null =
           null;
+        let continuationAttempted = false;
+        let continuationFailureCategory:
+          | RecallContinuationFailureCategory
+          | undefined;
+        let continuationFailureReported = false;
+        const reportContinuationFailure = (
+          category: RecallContinuationFailureCategory,
+        ): void => {
+          if (continuationFailureReported) return;
+          continuationFailureReported = true;
+          reportRecallContinuationFailure(category);
+        };
         // Recall items are gateway-internal and must stay hidden on every exit,
         // including failures raised before marker replacement.
         const recallIndices = new Set<number>();
@@ -9937,14 +9959,10 @@ export function streamResponsesRecallAware(
 
               // Recall was detected. Drive the recall loop.
               if (pendingRecalls.length > 1) {
-                throw new Error(
-                  "parallel recall calls require a multi-result continuation",
-                );
+                throw new RecallContinuationFailure("parallel_recall");
               }
               if (pendingRecalls.length > maxRecallDepth) {
-                throw new Error(
-                  `recall depth exhausted (${maxRecallDepth}) in Responses stream`,
-                );
+                throw new RecallContinuationFailure("depth_exhausted");
               }
               const anchorTexts: string[] = [];
               transactionBaseline = {
@@ -9960,9 +9978,7 @@ export function streamResponsesRecallAware(
               const queueTransactional = (chunk: Uint8Array): void => {
                 transactionalBytes += chunk.byteLength;
                 if (transactionalBytes > maxDeferredBytes) {
-                  throw new Error(
-                    "recall continuation exceeded deferred event limit",
-                  );
+                  throw new RecallContinuationFailure("resource_limit");
                 }
                 transactionalEvents.push(chunk);
               };
@@ -9975,20 +9991,24 @@ export function streamResponsesRecallAware(
                     block.type === "tool_use" && block.id === recall.toolUseId,
                 );
                 if (contentPosition < 0) {
-                  throw new Error(
-                    "recall block not found in finalized response",
-                  );
+                  throw new RecallContinuationFailure("missing_recall_block");
                 }
-                const executed = await settleRecall({
-                  query: recall.query,
-                  scope: recall.scope,
-                  id: recall.id,
-                  outputIndex: recall.outputIndex,
-                  toolUseId: recall.toolUseId,
-                  contentPosition,
-                  acc: recallAcc,
-                  signal,
-                });
+                let executed: Awaited<ReturnType<typeof settleRecall>>;
+                try {
+                  executed = await settleRecall({
+                    query: recall.query,
+                    scope: recall.scope,
+                    id: recall.id,
+                    outputIndex: recall.outputIndex,
+                    toolUseId: recall.toolUseId,
+                    contentPosition,
+                    acc: recallAcc,
+                    signal,
+                  });
+                } catch (error) {
+                  if (signal.aborted) throw error;
+                  throw new RecallContinuationFailure("recall_execution");
+                }
                 anchorTexts.push(executed.anchorText);
                 if (executed.commit) pendingCommits.push(executed.commit);
                 if (executed.rollback) {
@@ -10027,6 +10047,8 @@ export function streamResponsesRecallAware(
                   // Recall-only: run the streaming follow-up and pipe the
                   // continuation inline before the final completion.
                   try {
+                    continuationAttempted = true;
+                    continuationFailureCategory = "follow_up_setup";
                     signal.throwIfAborted();
                     let follow = await settleFollowUp({
                       anchorText: executed.anchorText,
@@ -10056,6 +10078,7 @@ export function streamResponsesRecallAware(
                       outputIdentities: new Set(outputIdentities),
                       referenceIdentities: new Set(referenceIdentities),
                     };
+                    continuationFailureCategory = "follow_up_protocol";
                     for (;;) {
                       activeReader = follow.reader;
                       let retryFollowUp = false;
@@ -10083,9 +10106,7 @@ export function streamResponsesRecallAware(
                       ): void => {
                         heldContinuationBytes += chunk.byteLength;
                         if (heldContinuationBytes > maxDeferredBytes) {
-                          throw new Error(
-                            "recall continuation exceeded deferred event limit",
-                          );
+                          throw new RecallContinuationFailure("resource_limit");
                         }
                         heldContinuationEvents.push({
                           chunk,
@@ -10130,9 +10151,7 @@ export function streamResponsesRecallAware(
                           continuationRecallBytes > maxDeferredBytes ||
                           hiddenRecallBytes > maxHiddenRecallBytes
                         ) {
-                          throw new Error(
-                            "recall continuation exceeded deferred event limit",
-                          );
+                          throw new RecallContinuationFailure("resource_limit");
                         }
                       };
                       let contOtherTool = false;
@@ -10162,8 +10181,8 @@ export function streamResponsesRecallAware(
                             formatResponsesEvent(ce, cd),
                           ).byteLength;
                           if (streamBytes > maxStreamBytes) {
-                            throw new Error(
-                              "Responses stream exceeded byte limit",
+                            throw new RecallContinuationFailure(
+                              "resource_limit",
                             );
                           }
                           let cparsed: Record<string, unknown>;
@@ -10225,8 +10244,8 @@ export function streamResponsesRecallAware(
                           if (ci !== undefined) {
                             retainedStateBytes += encoder.encode(cd).byteLength;
                             if (retainedStateBytes > maxRetainedStateBytes) {
-                              throw new Error(
-                                "Responses retained state exceeded byte limit",
+                              throw new RecallContinuationFailure(
+                                "resource_limit",
                               );
                             }
                             const implicitItem = contState.rawItems.get(ci);
@@ -10322,8 +10341,8 @@ export function streamResponsesRecallAware(
                               continuationRecallBytes > maxDeferredBytes ||
                               hiddenRecallBytes > maxHiddenRecallBytes
                             ) {
-                              throw new Error(
-                                "recall continuation exceeded deferred event limit",
+                              throw new RecallContinuationFailure(
+                                "resource_limit",
                               );
                             }
                             if (
@@ -10358,6 +10377,15 @@ export function streamResponsesRecallAware(
                           ) {
                             const terminalParsed =
                               stripHiddenReferenceOutput(cparsed);
+                            const incompleteRecallIndices = new Set(
+                              [...contRecallIndices].filter(
+                                (outputIndex) =>
+                                  !contPending.some(
+                                    (recall) =>
+                                      recall.outputIndex === outputIndex,
+                                  ),
+                              ),
+                            );
                             if (opts.validation === "codex") {
                               assertTerminalOutputMatches(
                                 contState,
@@ -10386,9 +10414,15 @@ export function streamResponsesRecallAware(
                                   }
                                 },
                               );
-                              assertOutputLifecyclesComplete(contState);
+                              assertOutputLifecyclesComplete(
+                                contState,
+                                incompleteRecallIndices,
+                              );
                             } else {
-                              assertOutputLifecyclesComplete(contState);
+                              assertOutputLifecyclesComplete(
+                                contState,
+                                incompleteRecallIndices,
+                              );
                               assertTerminalOutputMatches(
                                 contState,
                                 terminalParsed,
@@ -10454,6 +10488,16 @@ export function streamResponsesRecallAware(
                         }
                       } catch (error) {
                         if (
+                          error instanceof SSEStreamLimitError ||
+                          frameCounter.count > maxSSEFrames ||
+                          (error instanceof Error &&
+                            /^SSE stream exceeded \d+ frame limit$/.test(
+                              error.message,
+                            ))
+                        ) {
+                          throw new RecallContinuationFailure("resource_limit");
+                        }
+                        if (
                           error instanceof SSEStreamTransportError &&
                           recallContinuationTransportRetries <
                             maxRecallContinuationTransportRetries
@@ -10480,15 +10524,24 @@ export function streamResponsesRecallAware(
                           );
                           retryFollowUp = true;
                         } else {
-                          throw error;
+                          if (error instanceof SSEStreamTransportError) {
+                            continuationFailureCategory = "follow_up_transport";
+                          }
+                          throw error instanceof RecallContinuationFailure
+                            ? error
+                            : new RecallContinuationFailure(
+                                continuationFailureCategory ?? "unexpected",
+                              );
                         }
                       } finally {
                         cancelAndReleaseReader(follow.reader, signal.reason);
                       }
                       if (retryFollowUp) {
+                        continuationFailureCategory = "follow_up_setup";
                         follow = await settleFollowUp(
                           continuationFollowUpInput,
                         );
+                        continuationFailureCategory = "follow_up_protocol";
                         continue;
                       }
                       const mergeContinuation = (): void => {
@@ -10557,34 +10610,30 @@ export function streamResponsesRecallAware(
                       );
                       mergeUsage(transactionProviderUsage, contState.usage);
                       if (continuationFailed) {
-                        throw new Error(
-                          "recall follow-up returned response.failed",
-                        );
+                        throw new RecallContinuationFailure("follow_up_failed");
                       }
                       if (
                         !continuationCompleted ||
                         contState.rawItems.size === 0
                       ) {
-                        throw new Error(
-                          "recall follow-up ended without a completed response containing output",
+                        throw new RecallContinuationFailure(
+                          "follow_up_missing_output",
                         );
                       }
                       if (contRecallIndices.size !== contPending.length) {
-                        throw new Error(
-                          "recall follow-up ended before function arguments completed",
+                        throw new RecallContinuationFailure(
+                          "follow_up_incomplete_arguments",
                         );
                       }
                       if (contPending.length > 1) {
-                        throw new Error(
-                          "parallel recall calls require a multi-result continuation",
-                        );
+                        throw new RecallContinuationFailure("parallel_recall");
                       }
                       if (
                         contState.terminalEvent === "response.incomplete" &&
                         contPending.length > 0
                       ) {
-                        throw new Error(
-                          "incomplete recall continuation cannot execute another recall",
+                        throw new RecallContinuationFailure(
+                          "nested_recall_incomplete",
                         );
                       }
                       assertUsageMergeable(state.usage, contState.usage);
@@ -10635,8 +10684,8 @@ export function streamResponsesRecallAware(
                               block.id === pendingNextRecall.toolUseId,
                           );
                           if (contentPosition < 0) {
-                            throw new Error(
-                              "recall block not found in finalized continuation",
+                            throw new RecallContinuationFailure(
+                              "missing_recall_block",
                             );
                           }
                           nextRecall = {
@@ -10652,11 +10701,21 @@ export function streamResponsesRecallAware(
                             state,
                             contState,
                           ]);
-                          nextExecuted = await settleRecall({
-                            ...nextRecall,
-                            acc: nextAcc,
-                            signal,
-                          });
+                          continuationFailureCategory =
+                            "nested_recall_execution";
+                          try {
+                            nextExecuted = await settleRecall({
+                              ...nextRecall,
+                              acc: nextAcc,
+                              signal,
+                            });
+                          } catch (error) {
+                            if (signal.aborted) throw error;
+                            throw new RecallContinuationFailure(
+                              "nested_recall_execution",
+                            );
+                          }
+                          continuationFailureCategory = "follow_up_protocol";
                           if (nextExecuted.commit) {
                             pendingCommits.push(nextExecuted.commit);
                           }
@@ -10709,7 +10768,9 @@ export function streamResponsesRecallAware(
                         outputIdentities: new Set(outputIdentities),
                         referenceIdentities: new Set(referenceIdentities),
                       };
+                      continuationFailureCategory = "follow_up_setup";
                       follow = await settleFollowUp(continuationFollowUpInput);
+                      continuationFailureCategory = "follow_up_protocol";
                       recallContinuationTransportRetries = 0;
                     }
                     state.items.set(recall.outputIndex, {
@@ -10721,7 +10782,12 @@ export function streamResponsesRecallAware(
                     log.error(
                       `recall follow-up stream failed${sessionID ? ` (session=${sessionID.slice(0, 16)})` : ""}`,
                     );
-                    throw err;
+                    throw err instanceof RecallContinuationFailure ||
+                      signal.aborted
+                      ? err
+                      : new RecallContinuationFailure(
+                          continuationFailureCategory ?? "unexpected",
+                        );
                   }
                 }
               }
@@ -10742,6 +10808,9 @@ export function streamResponsesRecallAware(
                   };
                 }),
               };
+              if (continuationAttempted) {
+                continuationFailureCategory = "delivery";
+              }
               clearKeepalive();
               for (const chunk of transactionalEvents) {
                 if (!(await safeEnqueue(chunk))) {
@@ -10835,6 +10904,13 @@ export function streamResponsesRecallAware(
             return;
           }
           if (terminalDelivered) {
+            if (continuationAttempted && !signal.aborted) {
+              reportContinuationFailure(
+                err instanceof RecallContinuationFailure
+                  ? err.category
+                  : (continuationFailureCategory ?? "unexpected"),
+              );
+            }
             safeClose();
             return;
           }
@@ -10856,6 +10932,15 @@ export function streamResponsesRecallAware(
             log.error(
               `openai-responses recall-aware stream failed${sessionID ? ` (session=${sessionID.slice(0, 16)})` : ""}`,
             );
+          }
+          if (!signal.aborted) {
+            if (err instanceof RecallContinuationFailure) {
+              reportContinuationFailure(err.category);
+            } else if (continuationAttempted) {
+              reportContinuationFailure(
+                continuationFailureCategory ?? "unexpected",
+              );
+            }
           }
           const failedResponse = finalizeResponsesAcc(state);
           try {

--- a/packages/gateway/src/recall-continuation-failure.ts
+++ b/packages/gateway/src/recall-continuation-failure.ts
@@ -1,0 +1,50 @@
+export const RECALL_CONTINUATION_FAILURE_CATEGORIES = [
+  "recall_execution",
+  "follow_up_setup",
+  "follow_up_transport",
+  "follow_up_protocol",
+  "follow_up_failed",
+  "follow_up_missing_output",
+  "follow_up_incomplete_arguments",
+  "parallel_recall",
+  "nested_recall_incomplete",
+  "nested_recall_execution",
+  "depth_exhausted",
+  "missing_recall_block",
+  "resource_limit",
+  "delivery",
+  "unexpected",
+] as const;
+
+export type RecallContinuationFailureCategory =
+  (typeof RECALL_CONTINUATION_FAILURE_CATEGORIES)[number];
+
+type RecallContinuationFailureHook = (
+  category: RecallContinuationFailureCategory,
+) => void;
+
+let failureHook: RecallContinuationFailureHook | undefined;
+
+export class RecallContinuationFailure extends Error {
+  constructor(readonly category: RecallContinuationFailureCategory) {
+    super("recall continuation failed");
+    this.name = "RecallContinuationFailure";
+  }
+}
+
+export function setRecallContinuationFailureHook(
+  hook: RecallContinuationFailureHook | undefined,
+): void {
+  failureHook = hook;
+}
+
+export function reportRecallContinuationFailure(
+  category: RecallContinuationFailureCategory,
+): void {
+  if (!RECALL_CONTINUATION_FAILURE_CATEGORIES.includes(category)) return;
+  try {
+    failureHook?.(category);
+  } catch {
+    // Diagnostics never affect the response path.
+  }
+}

--- a/packages/gateway/src/sentry.ts
+++ b/packages/gateway/src/sentry.ts
@@ -11,6 +11,10 @@ import { getInstanceId, embedding } from "@loreai/core";
 import { createHash } from "node:crypto";
 import { freemem } from "node:os";
 import { monitorEventLoopDelay, type IntervalHistogram } from "node:perf_hooks";
+import {
+  setRecallContinuationFailureHook,
+  type RecallContinuationFailureCategory,
+} from "./recall-continuation-failure";
 
 // ---------------------------------------------------------------------------
 // Scope enrichment
@@ -691,6 +695,38 @@ export function setupVecReadLatencyCapture(): void {
       // Telemetry must never break the read path.
     }
   });
+}
+
+// ---------------------------------------------------------------------------
+// Recall continuation failures (#1682)
+// ---------------------------------------------------------------------------
+
+/** Wire allowlisted recall-continuation failures to a fixed Sentry event. */
+export function setupRecallContinuationFailureCapture(): void {
+  setRecallContinuationFailureHook(
+    (category: RecallContinuationFailureCategory) => {
+      if (!Sentry.isInitialized()) return;
+      try {
+        const currentScope = new Sentry.Scope();
+        const isolationScope = new Sentry.Scope();
+        currentScope.setClient(Sentry.getClient());
+        Sentry.captureEvent({
+          level: "warning",
+          message: "Recall continuation failed",
+          fingerprint: ["recall-continuation-failure", category],
+          contexts: {
+            recall_continuation_failure: { category },
+          },
+          sdkProcessingMetadata: {
+            capturedSpanScope: currentScope,
+            capturedSpanIsolationScope: isolationScope,
+          },
+        });
+      } catch {
+        // Telemetry never affects the response path.
+      }
+    },
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -34,6 +34,7 @@ import {
   setupEmbeddingFailureCapture,
   setupBustSpiralCapture,
   setupReadPathTimingCapture,
+  setupRecallContinuationFailureCapture,
   setupVecReadLatencyCapture,
 } from "./sentry";
 import type { GatewayRequest } from "./translate/types";
@@ -809,6 +810,10 @@ export async function startServer(
   // Wire vector KNN read-latency to Sentry (#1065 — confirm the vec0 win). Same
   // idempotency guarantee — the hook is assigned, not stacked.
   setupVecReadLatencyCapture();
+
+  // Report only the allowlisted recall-continuation failure category. The
+  // hook is assignment-based and never captures request or provider content.
+  setupRecallContinuationFailureCapture();
 
   // Shared fetch handler for all server instances.
   const fetch = async (

--- a/packages/gateway/src/stream/anthropic.ts
+++ b/packages/gateway/src/stream/anthropic.ts
@@ -197,7 +197,9 @@ export async function* parseSSEStream(
   const countFrame = (): void => {
     frameCounter.count++;
     if (frameCounter.count > maxFrames) {
-      throw new Error(`SSE stream exceeded ${maxFrames} frame limit`);
+      throw new SSEStreamLimitError(
+        `SSE stream exceeded ${maxFrames} frame limit`,
+      );
     }
   };
 
@@ -250,7 +252,9 @@ export async function* parseSSEStream(
     if (payload && payload.byteLength > 0) {
       totalBytes += payload.byteLength;
       if (totalBytes > (opts.maxTotalBytes ?? Number.POSITIVE_INFINITY)) {
-        throw new Error("SSE stream exceeded aggregate byte limit");
+        throw new SSEStreamLimitError(
+          "SSE stream exceeded aggregate byte limit",
+        );
       }
       bufferedBytes += payload.byteLength;
       try {
@@ -286,7 +290,9 @@ export async function* parseSSEStream(
         countFrame();
         const blockBytes = Buffer.byteLength(block);
         if (blockBytes > maxEventBytes) {
-          throw new Error(`SSE event exceeded ${maxEventBytes} byte limit`);
+          throw new SSEStreamLimitError(
+            `SSE event exceeded ${maxEventBytes} byte limit`,
+          );
         }
         consumedChars = boundary.index + boundary[0].length;
         consumedBytes += blockBytes + boundary[0].length;
@@ -320,7 +326,9 @@ export async function* parseSSEStream(
     }
 
     if (bufferedBytes > maxEventBytes) {
-      throw new Error(`SSE event exceeded ${maxEventBytes} byte limit`);
+      throw new SSEStreamLimitError(
+        `SSE event exceeded ${maxEventBytes} byte limit`,
+      );
     }
 
     if (done) {

--- a/packages/gateway/src/telemetry-privacy.ts
+++ b/packages/gateway/src/telemetry-privacy.ts
@@ -3,6 +3,7 @@ import {
   isCredentialHeaderName,
   redactCredentialHeaderAssignments,
 } from "./credential-headers";
+import { RECALL_CONTINUATION_FAILURE_CATEGORIES } from "./recall-continuation-failure";
 
 export const SENTRY_DATA_COLLECTION = {
   userInfo: false,
@@ -51,6 +52,7 @@ const SAFE_ERROR_TELEMETRY_MESSAGES = [
   /^Client abort under host pressure$/,
   /^Empty completion returned to client \(no content blocks\)$/,
   /^Embedding worker OOM:/,
+  /^Recall continuation failed$/,
   /^Worker health critical: sustained worker failure$/,
   /^Worker health degraded$/,
   /^Worker upstream auth error: HTTP \d+$/,
@@ -58,6 +60,30 @@ const SAFE_ERROR_TELEMETRY_MESSAGES = [
   /^cch: multiple billing-header sentinels in request body/,
   /^tool-pairing 400 \(tool_use\/tool_result concurrency\)$/,
 ];
+
+export function isolateRecallContinuationEvent<T extends Event>(
+  event: T,
+): T | null {
+  if (event.message !== "Recall continuation failed") return null;
+  const category = event.contexts?.recall_continuation_failure?.category;
+  if (
+    typeof category !== "string" ||
+    !RECALL_CONTINUATION_FAILURE_CATEGORIES.includes(
+      category as (typeof RECALL_CONTINUATION_FAILURE_CATEGORIES)[number],
+    )
+  ) {
+    return null;
+  }
+  return {
+    event_id: event.event_id,
+    timestamp: event.timestamp,
+    platform: event.platform,
+    level: "warning",
+    message: "Recall continuation failed",
+    fingerprint: ["recall-continuation-failure", category],
+    contexts: { recall_continuation_failure: { category } },
+  } as unknown as T;
+}
 
 function canonicalKey(key: string): { words: string[]; canonical: string } {
   const words = key
@@ -262,6 +288,9 @@ export function scrubTelemetryValue<T>(value: T): T {
 
 /** Apply event-specific privacy rules while retaining non-sensitive diagnostics. */
 export function scrubTelemetryEvent<T extends Event>(event: T): T {
+  if (event.message === "Recall continuation failed") {
+    return isolateRecallContinuationEvent(event) ?? ({} as T);
+  }
   const originalMessage = event.message;
   const originalExceptions = event.exception?.values;
   const scrubbed = scrubTelemetryValue(event);

--- a/packages/gateway/test/openai-responses-recall-aware-stream.test.ts
+++ b/packages/gateway/test/openai-responses-recall-aware-stream.test.ts
@@ -10,9 +10,15 @@
  * function_call (emit marker, run follow-up, rebuild the terminal
  * `response.completed`).
  */
-import { describe, test, expect } from "vitest";
+import { afterEach, describe, test, expect } from "vitest";
 import { streamResponsesRecallAware } from "../src/pipeline";
+import {
+  setRecallContinuationFailureHook,
+  type RecallContinuationFailureCategory,
+} from "../src/recall-continuation-failure";
 import type { GatewayResponse } from "../src/translate/types";
+
+afterEach(() => setRecallContinuationFailureHook(undefined));
 
 function sseEvent(event: string, data: unknown): string {
   const payload =
@@ -416,6 +422,8 @@ describe("streamResponsesRecallAware", () => {
   });
 
   test("binds parallel recalls to their own call IDs and fails before an invalid follow-up", async () => {
+    const failures: RecallContinuationFailureCategory[] = [];
+    setRecallContinuationFailureHook((category) => failures.push(category));
     const seen: string[] = [];
     const client = streamResponsesRecallAware(
       streamFrom([
@@ -443,6 +451,7 @@ describe("streamResponsesRecallAware", () => {
     expect(seen).toEqual([]);
     expect(out).toContain("response.failed");
     expect(out).toContain(PUBLIC_RECALL_ERROR);
+    expect(failures).toEqual(["parallel_recall"]);
   });
 
   test("rejects repeated call IDs before recall execution", async () => {
@@ -667,6 +676,8 @@ describe("streamResponsesRecallAware", () => {
   });
 
   test("rejects malformed named Responses events in a continuation", async () => {
+    const failures: RecallContinuationFailureCategory[] = [];
+    setRecallContinuationFailureHook((category) => failures.push(category));
     const followUp = streamFrom([
       created("resp_bad_continuation", "gpt-5.6-terra"),
       "event: response.completed\ndata: {not-json}\n\n",
@@ -690,6 +701,7 @@ describe("streamResponsesRecallAware", () => {
     const out = await drain(client);
     expect(out).toContain(PUBLIC_RECALL_ERROR);
     expect(out).not.toContain("{not-json}");
+    expect(failures).toEqual(["follow_up_protocol"]);
   });
 
   test("retries a dropped recall continuation before exposing any output", async () => {
@@ -752,7 +764,87 @@ describe("streamResponsesRecallAware", () => {
     ).toHaveLength(1);
   });
 
+  test("classifies an exhausted dropped continuation as transport failure once", async () => {
+    const failures: RecallContinuationFailureCategory[] = [];
+    setRecallContinuationFailureHook((category) => failures.push(category));
+    const dropped = () =>
+      new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(
+              new TextEncoder().encode(
+                created("resp_dropped_twice", "gpt-5.6-terra"),
+              ),
+            );
+            controller.error(new Error("private socket reset"));
+          },
+        }),
+        { headers: { "content-type": "text/event-stream" } },
+      );
+    let followUps = 0;
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_transport_principal", "gpt-5.6-terra"),
+        recallCall(0, { query: "transport" }),
+        completed("resp_transport_principal"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => ({
+          anchorText: buildAnchor("transport"),
+          resultText: "results",
+        }),
+        runFollowUp: async () => {
+          followUps++;
+          return { reader: dropped().body!.getReader() };
+        },
+      },
+    );
+
+    const out = await drain(client);
+    expect(followUps).toBe(2);
+    expect(out).toContain(PUBLIC_RECALL_ERROR);
+    expect(out).not.toContain("private socket reset");
+    expect(failures).toEqual(["follow_up_transport"]);
+  });
+
+  test("classifies a completed continuation without output", async () => {
+    const failures: RecallContinuationFailureCategory[] = [];
+    setRecallContinuationFailureHook((category) => failures.push(category));
+    const followUp = streamFrom([
+      created("resp_empty_followup", "gpt-5.6-terra"),
+      sseEvent("response.completed", {
+        response: {
+          id: "resp_empty_followup",
+          model: "gpt-5.6-terra",
+          status: "completed",
+          output: [],
+        },
+      }),
+    ]);
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_empty_principal", "gpt-5.6-terra"),
+        recallCall(0, { query: "empty" }),
+        completed("resp_empty_principal"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => ({
+          anchorText: buildAnchor("empty"),
+          resultText: "results",
+        }),
+        runFollowUp: async () => ({ reader: followUp.body!.getReader() }),
+      },
+    );
+
+    expect(await drain(client)).toContain(PUBLIC_RECALL_ERROR);
+    expect(failures).toEqual(["follow_up_missing_output"]);
+  });
+
   test("counts failed continuation bytes against the request-wide stream limit", async () => {
+    const failures: RecallContinuationFailureCategory[] = [];
+    setRecallContinuationFailureHook((category) => failures.push(category));
     const principal = [
       created("resp_retry_limit_principal", "gpt-5.6-terra"),
       recallCall(0, { query: "retry byte budget" }),
@@ -795,9 +887,12 @@ describe("streamResponsesRecallAware", () => {
     expect(followUps).toBe(2);
     expect(out).toContain(PUBLIC_RECALL_ERROR);
     expect(out).not.toContain("recovered after budget");
+    expect(failures).toEqual(["resource_limit"]);
   });
 
   test("counts failed continuation frames against the request-wide frame limit", async () => {
+    const failures: RecallContinuationFailureCategory[] = [];
+    setRecallContinuationFailureHook((category) => failures.push(category));
     const droppedFollowUp = new Response(
       new ReadableStream<Uint8Array>({
         start(controller) {
@@ -845,6 +940,7 @@ describe("streamResponsesRecallAware", () => {
     expect(followUps).toBe(2);
     expect(out).toContain(PUBLIC_RECALL_ERROR);
     expect(out).not.toContain("recovered after frames");
+    expect(failures).toEqual(["resource_limit"]);
   });
 
   test("rejects one content index changing type", async () => {
@@ -4394,9 +4490,16 @@ describe("streamResponsesRecallAware", () => {
   });
 
   test("caps frames across the principal and chained continuations", async () => {
+    const failures: RecallContinuationFailureCategory[] = [];
+    setRecallContinuationFailureHook((category) => failures.push(category));
     const second = streamFrom([
       created("resp_frame_second", "gpt-5.6-terra"),
-      recallCall(0, { query: "detail" }),
+      recallCall(
+        0,
+        { query: "detail" },
+        "fc_frame_second",
+        "call_frame_second",
+      ),
       completed("resp_frame_second"),
     ]);
     let recalls = 0;
@@ -4421,11 +4524,19 @@ describe("streamResponsesRecallAware", () => {
     );
     expect(await drain(client)).toContain(PUBLIC_RECALL_ERROR);
     expect(recalls).toBe(1);
+    expect(failures).toEqual(["resource_limit"]);
   });
 
   test("caps hidden recall bytes across chained continuations", async () => {
+    const failures: RecallContinuationFailureCategory[] = [];
+    setRecallContinuationFailureHook((category) => failures.push(category));
     const firstRecall = recallCall(0, { query: "architecture" });
-    const secondRecall = recallCall(0, { query: "detail" });
+    const secondRecall = recallCall(
+      0,
+      { query: "detail" },
+      "fc_bytes_second",
+      "call_bytes_second",
+    );
     const second = streamFrom([
       created("resp_bytes_second", "gpt-5.6-terra"),
       secondRecall,
@@ -4455,6 +4566,7 @@ describe("streamResponsesRecallAware", () => {
     );
     expect(await drain(client)).toContain(PUBLIC_RECALL_ERROR);
     expect(recalls).toBe(1);
+    expect(failures).toEqual(["resource_limit"]);
   });
 
   test("stops reading upstream while the client applies backpressure", async () => {
@@ -4516,6 +4628,8 @@ describe("streamResponsesRecallAware", () => {
   });
 
   test("caps raw stream bytes across a continuation", async () => {
+    const failures: RecallContinuationFailureCategory[] = [];
+    setRecallContinuationFailureHook((category) => failures.push(category));
     const principal = [
       created("resp_stream_chain", "gpt-5.6-terra"),
       recallCall(0, { query: "architecture" }),
@@ -4542,9 +4656,12 @@ describe("streamResponsesRecallAware", () => {
       runFollowUp: async () => ({ reader: followUp.body!.getReader() }),
     });
     expect(await drain(client)).toContain(PUBLIC_RECALL_ERROR);
+    expect(failures).toEqual(["resource_limit"]);
   });
 
   test("caps retained indexed state across a continuation", async () => {
+    const failures: RecallContinuationFailureCategory[] = [];
+    setRecallContinuationFailureHook((category) => failures.push(category));
     const principal = [
       created("resp_retained_chain", "gpt-5.6-terra"),
       recallCall(0, { query: "architecture" }),
@@ -4574,6 +4691,7 @@ describe("streamResponsesRecallAware", () => {
       runFollowUp: async () => ({ reader: followUp.body!.getReader() }),
     });
     expect(await drain(client)).toContain(PUBLIC_RECALL_ERROR);
+    expect(failures).toEqual(["resource_limit"]);
   });
 
   test("shifts refusal event coordinates in a continuation", async () => {
@@ -5189,6 +5307,8 @@ describe("streamResponsesRecallAware", () => {
   });
 
   test("rolls back persistence without contradicting an already delivered terminal", async () => {
+    const failures: RecallContinuationFailureCategory[] = [];
+    setRecallContinuationFailureHook((category) => failures.push(category));
     let completedCalls = 0;
     let committed = 0;
     let rolledBack = 0;
@@ -5228,6 +5348,78 @@ describe("streamResponsesRecallAware", () => {
     expect(committed).toBe(0);
     expect(rolledBack).toBe(1);
     expect(completedCalls).toBe(1);
+    expect(failures).toEqual(["delivery"]);
+  });
+
+  test("does not relabel malformed incomplete continuation as nested recall", async () => {
+    const failures: RecallContinuationFailureCategory[] = [];
+    setRecallContinuationFailureHook((category) => failures.push(category));
+    const followUp = streamFrom([
+      created("resp_malformed_incomplete", "gpt-5.6-terra"),
+      recallCall(0, { query: "detail" }, "fc_nested", "call_nested"),
+      sseEvent("response.incomplete", {
+        response: {
+          id: "resp_wrong_identity",
+          model: "gpt-5.6-terra",
+          status: "incomplete",
+          output: [],
+        },
+      }),
+    ]);
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_malformed_principal", "gpt-5.6-terra"),
+        recallCall(0, { query: "architecture" }),
+        completed("resp_malformed_principal"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async ({ query }) => ({
+          anchorText: buildAnchor(query),
+          resultText: "results",
+        }),
+        runFollowUp: async () => ({ reader: followUp.body!.getReader() }),
+      },
+    );
+
+    expect(await drain(client)).toContain(PUBLIC_RECALL_ERROR);
+    expect(failures).toEqual(["follow_up_protocol"]);
+  });
+
+  test("does not relabel malformed continuation after unfinished recall arguments", async () => {
+    const failures: RecallContinuationFailureCategory[] = [];
+    setRecallContinuationFailureHook((category) => failures.push(category));
+    const followUp = streamFrom([
+      created("resp_malformed_unfinished", "gpt-5.6-terra"),
+      sseEvent("response.output_item.added", {
+        output_index: 0,
+        item: {
+          type: "function_call",
+          id: "fc_malformed_unfinished",
+          call_id: "call_malformed_unfinished",
+          name: "recall",
+        },
+      }),
+      "event: response.output_item.done\ndata: {not json\n\n",
+    ]);
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_malformed_unfinished_principal", "gpt-5.6-terra"),
+        recallCall(0, { query: "architecture" }),
+        completed("resp_malformed_unfinished_principal"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async ({ query }) => ({
+          anchorText: buildAnchor(query),
+          resultText: "results",
+        }),
+        runFollowUp: async () => ({ reader: followUp.body!.getReader() }),
+      },
+    );
+
+    expect(await drain(client)).toContain(PUBLIC_RECALL_ERROR);
+    expect(failures).toEqual(["follow_up_protocol"]);
   });
 
   test("never commits when an abort-ignoring recall callback resolves late", async () => {
@@ -5390,6 +5582,8 @@ describe("streamResponsesRecallAware", () => {
   });
 
   test("does not retry when cancellation races a dropped continuation", async () => {
+    const failures: RecallContinuationFailureCategory[] = [];
+    setRecallContinuationFailureHook((category) => failures.push(category));
     const foreground = new AbortController();
     const followUpStarted = Promise.withResolvers<void>();
     const droppedStarted = Promise.withResolvers<void>();
@@ -5439,6 +5633,7 @@ describe("streamResponsesRecallAware", () => {
     expect(followUps).toBe(1);
     expect(cancelCalls).toBe(1);
     expect(droppedFollowUp.body?.locked).toBe(false);
+    expect(failures).toEqual([]);
   });
 
   test("cancellation never waits for non-settling follow-up setup", async () => {
@@ -5552,6 +5747,8 @@ describe("streamResponsesRecallAware", () => {
   });
 
   test("rejects a chained recall whose arguments never complete", async () => {
+    const failures: RecallContinuationFailureCategory[] = [];
+    setRecallContinuationFailureHook((category) => failures.push(category));
     const malformed = streamFrom([
       created("resp_malformed", "gpt-5.6-terra"),
       sseEvent("response.output_item.added", {
@@ -5563,15 +5760,32 @@ describe("streamResponsesRecallAware", () => {
           name: "recall",
         },
       }),
-      completed("resp_malformed"),
+      incomplete("resp_malformed"),
     ]);
     const client = streamResponsesRecallAware(
       streamFrom([
         created("resp_first", "gpt-5.6-terra"),
         recallCall(0, { query: "architecture" }),
-        completed("resp_first"),
+        sseEvent("response.completed", {
+          response: {
+            id: "resp_first",
+            model: "gpt-5.6-terra",
+            status: "completed",
+            output: [
+              {
+                type: "function_call",
+                id: "fc_0",
+                call_id: "call_0",
+                name: "recall",
+                arguments: JSON.stringify({ query: "architecture" }),
+                status: "completed",
+              },
+            ],
+          },
+        }),
       ]),
       {
+        validation: "public",
         onComplete: () => {},
         onRecall: async ({ query }) => ({
           anchorText: buildAnchor(query),
@@ -5585,6 +5799,7 @@ describe("streamResponsesRecallAware", () => {
     expect(out).toContain(PUBLIC_RECALL_ERROR);
     expect(out).not.toContain("call_malformed");
     expect(out).not.toContain("response.completed");
+    expect(failures).toEqual(["follow_up_incomplete_arguments"]);
   });
 
   test("rejects malformed completed recall arguments before execution", async () => {
@@ -5932,6 +6147,8 @@ describe("streamResponsesRecallAware", () => {
   });
 
   test("recall-only: fails the response when the continuation fails", async () => {
+    const failures: RecallContinuationFailureCategory[] = [];
+    setRecallContinuationFailureHook((category) => failures.push(category));
     const client = streamResponsesRecallAware(
       streamFrom([
         created("resp_failure", "gpt-5.6-terra"),
@@ -5957,9 +6174,39 @@ describe("streamResponsesRecallAware", () => {
     expect(out).not.toContain("lore-recall");
     expect(out).not.toContain("Searching");
     expect(out).not.toContain("response.completed");
+    expect(failures).toEqual(["follow_up_setup"]);
+  });
+
+  test("classifies recall execution failure without exposing callback details", async () => {
+    const failures: RecallContinuationFailureCategory[] = [];
+    setRecallContinuationFailureHook((category) => failures.push(category));
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_recall_execution_failure", "gpt-5.6-terra"),
+        recallCall(0, { query: "private query" }),
+        completed("resp_recall_execution_failure"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => {
+          throw new Error("private callback failure");
+        },
+        runFollowUp: async () => {
+          throw new Error("should not run");
+        },
+      },
+    );
+
+    const out = await drain(client);
+    expect(out).toContain(PUBLIC_RECALL_ERROR);
+    expect(out).not.toContain("private callback failure");
+    expect(out).not.toContain("private query");
+    expect(failures).toEqual(["recall_execution"]);
   });
 
   test("recall-only: never converts a failed continuation into completed", async () => {
+    const failures: RecallContinuationFailureCategory[] = [];
+    setRecallContinuationFailureHook((category) => failures.push(category));
     const failedFollowUp = streamFrom([
       created("resp_followup_failure", "gpt-5.6-terra"),
       textItem(0, "partial answer"),
@@ -6008,6 +6255,37 @@ describe("streamResponsesRecallAware", () => {
     });
     expect(successful).toBe(false);
     expect(out).not.toContain("response.completed");
+    expect(failures).toEqual(["follow_up_failed"]);
+  });
+
+  test("recall continuation diagnostics never alter the fixed public failure", async () => {
+    setRecallContinuationFailureHook(() => {
+      throw new Error("private telemetry failure");
+    });
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_diagnostic_failure", "gpt-5.6-terra"),
+        recallCall(0, { query: "private query" }),
+        completed("resp_diagnostic_failure"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => ({
+          anchorText: buildAnchor("private query"),
+          resultText: "private result",
+        }),
+        runFollowUp: async () => {
+          throw new Error("private provider failure");
+        },
+      },
+    );
+
+    const out = await drain(client);
+    expect(out).toContain(PUBLIC_RECALL_ERROR);
+    expect(out).not.toContain("private telemetry failure");
+    expect(out).not.toContain("private provider failure");
+    expect(out).not.toContain("private query");
+    expect(out).not.toContain("private result");
   });
 
   test.each(["failed", "cancelled"])(
@@ -6155,6 +6433,8 @@ describe("streamResponsesRecallAware", () => {
   });
 
   test("never executes a chained recall from an incomplete continuation", async () => {
+    const failures: RecallContinuationFailureCategory[] = [];
+    setRecallContinuationFailureHook((category) => failures.push(category));
     const followUp = streamFrom([
       created("resp_incomplete_recall", "gpt-5.6-terra"),
       recallCall(0, { query: "detail" }),
@@ -6181,6 +6461,57 @@ describe("streamResponsesRecallAware", () => {
     );
     expect(await drain(client)).toContain(PUBLIC_RECALL_ERROR);
     expect(recalls).toBe(1);
+    expect(failures).toEqual(["follow_up_protocol"]);
+  });
+
+  test("classifies a completed chained recall from a valid incomplete continuation", async () => {
+    const failures: RecallContinuationFailureCategory[] = [];
+    setRecallContinuationFailureHook((category) => failures.push(category));
+    const args = JSON.stringify({ query: "detail" });
+    const followUp = streamFrom([
+      created("resp_valid_incomplete_recall", "gpt-5.6-terra"),
+      recallCall(0, { query: "detail" }, "fc_nested", "call_nested"),
+      sseEvent("response.incomplete", {
+        response: {
+          id: "resp_valid_incomplete_recall",
+          model: "gpt-5.6-terra",
+          status: "incomplete",
+          output: [
+            {
+              type: "function_call",
+              id: "fc_nested",
+              call_id: "call_nested",
+              name: "recall",
+              arguments: args,
+              status: "completed",
+            },
+          ],
+        },
+      }),
+    ]);
+    let recalls = 0;
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_valid_incomplete_principal", "gpt-5.6-terra"),
+        recallCall(0, { query: "architecture" }),
+        completed("resp_valid_incomplete_principal"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async ({ query }) => {
+          recalls++;
+          return {
+            anchorText: buildAnchor(query),
+            resultText: "results",
+          };
+        },
+        runFollowUp: async () => ({ reader: followUp.body!.getReader() }),
+      },
+    );
+
+    expect(await drain(client)).toContain(PUBLIC_RECALL_ERROR);
+    expect(recalls).toBe(1);
+    expect(failures).toEqual(["nested_recall_incomplete"]);
   });
 
   test("maps response.done with incomplete status to response.incomplete", async () => {

--- a/packages/gateway/test/sentry-recall-continuation-envelope.test.ts
+++ b/packages/gateway/test/sentry-recall-continuation-envelope.test.ts
@@ -1,0 +1,77 @@
+import * as Sentry from "@sentry/bun";
+import { afterEach, describe, expect, it } from "vitest";
+import { buildSentryOptions } from "../instrument";
+import {
+  reportRecallContinuationFailure,
+  setRecallContinuationFailureHook,
+} from "../src/recall-continuation-failure";
+import { setupRecallContinuationFailureCapture } from "../src/sentry";
+
+describe("recall-continuation Sentry envelope", () => {
+  afterEach(() => {
+    setRecallContinuationFailureHook(undefined);
+  });
+
+  it("exports no inherited request or trace state through the real SDK", async () => {
+    const previousBun = Reflect.get(globalThis, "Bun");
+    Reflect.set(globalThis, "Bun", { version: "1.3.0", revision: "test" });
+    const sent: unknown[] = [];
+    const options = buildSentryOptions(() => ({
+      send(envelope) {
+        sent.push(envelope);
+        return Promise.resolve({ statusCode: 200 });
+      },
+      flush: () => Promise.resolve(true),
+    }));
+    if (!options.transport) throw new Error("test transport is required");
+    const client = new Sentry.BunClient({
+      ...options,
+      integrations: [],
+      transport: options.transport,
+      stackParser: Sentry.defaultStackParser,
+    });
+    client.init();
+    const current = new Sentry.Scope();
+    const isolation = new Sentry.Scope();
+    current.setClient(client);
+    current.setSDKProcessingMetadata({
+      normalizedRequest: {
+        method: "POST",
+        url: "https://private.invalid/private-metadata-path",
+      },
+    });
+    current.setContext("trace", { trace_id: "private-trace" });
+    isolation.setContext("request", {
+      method: "POST",
+      url: "https://private.invalid/private-path",
+    });
+
+    try {
+      await Sentry.withIsolationScope(isolation, () =>
+        Sentry.withScope(current, () =>
+          Sentry.startSpan(
+            { name: "private-model-transaction", op: "private-operation" },
+            async () => {
+              setupRecallContinuationFailureCapture();
+              reportRecallContinuationFailure("follow_up_failed");
+              await client.flush(5_000);
+            },
+          ),
+        ),
+      );
+
+      const recallEnvelope = sent.find((envelope) =>
+        JSON.stringify(envelope).includes("Recall continuation failed"),
+      );
+      const serialized = JSON.stringify(recallEnvelope);
+      expect(serialized).toContain("Recall continuation failed");
+      expect(serialized).not.toContain("private");
+      expect(serialized).not.toContain('"trace"');
+      expect(serialized).not.toContain('"request"');
+    } finally {
+      await client.close(5_000);
+      if (previousBun === undefined) Reflect.deleteProperty(globalThis, "Bun");
+      else Reflect.set(globalThis, "Bun", previousBun);
+    }
+  });
+});

--- a/packages/gateway/test/sentry-recall-continuation-failure.test.ts
+++ b/packages/gateway/test/sentry-recall-continuation-failure.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const scopeMocks = vi.hoisted(() => ({
+  current: { kind: "current", setClient: vi.fn() },
+  isolation: { kind: "isolation" },
+  index: 0,
+  client: { kind: "client" },
+}));
+
+vi.mock("@sentry/bun", () => ({
+  isInitialized: vi.fn(() => true),
+  getClient: vi.fn(() => scopeMocks.client),
+  captureEvent: vi.fn(() => "event-id"),
+  Scope: vi.fn(
+    class Scope {
+      constructor() {
+        return [scopeMocks.current, scopeMocks.isolation][
+          scopeMocks.index++
+        ] as unknown as this;
+      }
+    },
+  ),
+}));
+
+import * as Sentry from "@sentry/bun";
+import {
+  reportRecallContinuationFailure,
+  type RecallContinuationFailureCategory,
+  setRecallContinuationFailureHook,
+} from "../src/recall-continuation-failure";
+import { setupRecallContinuationFailureCapture } from "../src/sentry";
+
+describe("setupRecallContinuationFailureCapture", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    scopeMocks.index = 0;
+    scopeMocks.current.setClient.mockClear();
+    vi.mocked(Sentry.isInitialized).mockReturnValue(true);
+    setRecallContinuationFailureHook(undefined);
+  });
+
+  afterEach(() => {
+    setRecallContinuationFailureHook(undefined);
+  });
+
+  it("captures one fixed event containing only the allowlisted category", () => {
+    setupRecallContinuationFailureCapture();
+    reportRecallContinuationFailure("follow_up_failed");
+
+    expect(Sentry.captureEvent).toHaveBeenCalledWith({
+      level: "warning",
+      message: "Recall continuation failed",
+      fingerprint: ["recall-continuation-failure", "follow_up_failed"],
+      contexts: {
+        recall_continuation_failure: {
+          category: "follow_up_failed",
+        },
+      },
+      sdkProcessingMetadata: {
+        capturedSpanScope: scopeMocks.current,
+        capturedSpanIsolationScope: scopeMocks.isolation,
+      },
+    });
+    expect(scopeMocks.current.setClient).toHaveBeenCalledWith(
+      scopeMocks.client,
+    );
+  });
+
+  it("does nothing when Sentry is not initialized", () => {
+    vi.mocked(Sentry.isInitialized).mockReturnValue(false);
+    setupRecallContinuationFailureCapture();
+    reportRecallContinuationFailure("follow_up_setup");
+
+    expect(Sentry.captureEvent).not.toHaveBeenCalled();
+  });
+
+  it("contains Sentry failures", () => {
+    vi.mocked(Sentry.captureEvent).mockImplementation(() => {
+      throw new Error("private sentry failure");
+    });
+    setupRecallContinuationFailureCapture();
+
+    expect(() =>
+      reportRecallContinuationFailure("follow_up_protocol"),
+    ).not.toThrow();
+  });
+
+  it("drops categories outside the runtime allowlist", () => {
+    setupRecallContinuationFailureCapture();
+    reportRecallContinuationFailure(
+      "private provider detail" as RecallContinuationFailureCategory,
+    );
+
+    expect(Sentry.captureEvent).not.toHaveBeenCalled();
+  });
+});

--- a/packages/gateway/test/telemetry-privacy.test.ts
+++ b/packages/gateway/test/telemetry-privacy.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
+import type { Event } from "@sentry/bun";
 import { buildSentryOptions } from "../instrument";
 import {
   SENTRY_DATA_COLLECTION,
+  isolateRecallContinuationEvent,
   scrubTelemetryEvent,
   scrubTelemetryEnvelope,
   scrubTelemetryText,
@@ -143,6 +145,62 @@ describe("telemetry privacy boundary", () => {
       expect(serialized).not.toContain(marker);
     expect(serialized).not.toContain('"type":"log"');
     expect(serialized).toContain("Application error");
+  });
+
+  it("reduces recall-continuation events to the fixed allowlist", () => {
+    const input: Event = {
+      event_id: "event-id",
+      timestamp: 1,
+      platform: "javascript",
+      level: "warning",
+      message: "Recall continuation failed",
+      fingerprint: ["private-fingerprint"],
+      user: { id: SECRETS[0] },
+      tags: { model: SECRETS[1] },
+      transaction: SECRETS[2],
+      request: { url: `https://example.invalid/?secret=${SECRETS[3]}` },
+      contexts: {
+        trace: { trace_id: SECRETS[4], span_id: SECRETS[5] },
+        recall_continuation_failure: { category: "follow_up_protocol" },
+      },
+      extra: { diagnostic: SECRETS[6] },
+      breadcrumbs: [{ message: SECRETS[7] }],
+      sdkProcessingMetadata: { private: SECRETS[8] },
+    };
+    const event = isolateRecallContinuationEvent(input);
+
+    expect(event).toEqual({
+      event_id: "event-id",
+      timestamp: 1,
+      platform: "javascript",
+      level: "warning",
+      message: "Recall continuation failed",
+      fingerprint: ["recall-continuation-failure", "follow_up_protocol"],
+      contexts: {
+        recall_continuation_failure: { category: "follow_up_protocol" },
+      },
+    });
+    expectNoSecrets(event);
+    expect(scrubTelemetryEvent(input)).toEqual(event);
+
+    const options = buildSentryOptions();
+    expect(
+      options.beforeSend?.(
+        input as Parameters<NonNullable<typeof options.beforeSend>>[0],
+        {},
+      ),
+    ).toEqual(event);
+  });
+
+  it("drops invalid recall categories at the isolated boundary", () => {
+    expect(
+      isolateRecallContinuationEvent({
+        message: "Recall continuation failed",
+        contexts: {
+          recall_continuation_failure: { category: SECRETS[0] },
+        },
+      }),
+    ).toBeNull();
   });
 
   it("scrubs request data, breadcrumbs, contexts, and span attributes", () => {


### PR DESCRIPTION
## Summary
Classifies Responses recall-continuation failures without changing their fixed public failure or cancellation behavior.

## Changes
- Adds a closed set of structured continuation-failure categories with exactly-once reporting.
- Classifies transport, protocol, resource-limit, lifecycle, callback, and delivery failures at their decision boundaries.
- Captures a fixed category-only Sentry event through detached scopes and final envelope reconstruction.
- Adds adversarial stream, cancellation, resource-limit, malformed-terminal, and real-SDK privacy regressions.

Closes #1682