### PR TITLE
fix(gateway): stop misclassifying forced-attribution classifier calls as coding turns

### DIFF
--- a/packages/gateway/src/side-channel.ts
+++ b/packages/gateway/src/side-channel.ts
@@ -5,10 +5,12 @@
  * turns: the auto-mode permission classifier (one call per tool action),
  * conversation title/topic generation, and subagent naming/summary. These are
  * built with `skipSystemPromptPrefix: true`, so they carry NEITHER the coding
- * system prompt (no "Working directory:" line, no CLAUDE.md content) NOR the
- * anchored OAuth billing header — yet they still carry the SAME
- * `x-claude-code-session-id` header as the live coding conversation (Claude
- * Code attaches it to every request).
+ * system prompt (no "Working directory:" line, no CLAUDE.md content) NOR —
+ * since Claude Code 2.1.258, where the classifier request is built with
+ * `forceAttributionHeader: true` — is the anchored OAuth billing header a
+ * reliable discriminator: the classifier now DOES carry it at `system[0]`.
+ * All of these calls still carry the SAME `x-claude-code-session-id` header as
+ * the live coding conversation (Claude Code attaches it to every request).
  *
  * Running these through Lore's context pipeline is harmful:
  *   - LTM system blocks + the distilled conversation prefix get injected, and
@@ -25,7 +27,6 @@
  * any Lore processing (`handlePassthrough`), never touching session state or
  * memory.
  */
-import { hasBillingHeader } from "./cch";
 import { inferProjectPathDetailed } from "./config";
 import { isClaudeCodeClient } from "./session";
 import type { GatewayRequest } from "./translate/types";
@@ -46,21 +47,27 @@ const CLAUDE_CODE_CWD_MARKER_RE = /(?:^|\n)[ \t]*Working directory:[ \t]*\S/i;
  * side-channel call.
  *
  * Detected by any signal:
- *   1. the anchored OAuth billing header (present whenever
- *      `_CLAUDE_CODE_ASSUME_FIRST_PARTY_BASE_URL=1`, which both `lore run` and
- *      `lore setup` set — the standard Lore configuration); or
- *   2. a `Working directory:` marker line — Claude Code always embeds it in its
+ *   1. a `Working directory:` marker line — Claude Code always embeds it in its
  *      coding system prompt (including for subagent turns), for any OS; or
- *   3. an AUTHORITATIVE workspace inference (a `cwd` field or a
- *      CLAUDE/AGENTS/.lore.md path), a broader heuristic than signal 2.
+ *   2. an AUTHORITATIVE workspace inference (a `cwd` field or a
+ *      CLAUDE/AGENTS/.lore.md path), a broader heuristic than signal 1.
  *
- * The signals are OR-combined so a real turn is recognized even in a manual
- * setup that omits the first-party env var (no billing header), on any platform
- * (signal 2 does not require a POSIX-style path). A side-channel call carries
+ * The signals are OR-combined so a real turn is recognized on any platform
+ * (signal 1 does not require a POSIX-style path). A side-channel call carries
  * none of these.
+ *
+ * NOTE: the anchored OAuth billing header is deliberately NOT a signal here.
+ * Since Claude Code 2.1.258 the auto-mode permission classifier is built with
+ * `forceAttributionHeader: true`, so it carries the billing header at
+ * `system[0]` even though it is a `skipSystemPromptPrefix` side-channel call
+ * (it never embeds the coding prompt, so signals 1 and 2 are still absent).
+ * Treating the header as sufficient would demote the classifier out of the
+ * bypass and corrupt its verdict. A real coding turn always carries the
+ * `Working directory:` marker regardless, so dropping the header signal never
+ * mis-classifies a real turn — it only ever widens the bypass to
+ * side-channels that now carry `forceAttributionHeader`, which is correct.
  */
 export function hasClaudeCodeCodingPrompt(system: string): boolean {
-  if (hasBillingHeader(system)) return true;
   if (CLAUDE_CODE_CWD_MARKER_RE.test(system)) return true;
   return inferProjectPathDetailed(system)?.authoritative === true;
 }
@@ -71,12 +78,11 @@ export function hasClaudeCodeCodingPrompt(system: string): boolean {
  *
  * Conservative by construction: it bypasses ONLY requests that (a) originate
  * from Claude Code (carry `x-claude-code-session-id`) AND (b) lack the coding
- * system prompt (no billing header, no `Working directory:` marker, no
- * authoritative workspace inference). A real coding turn carries the marker on
- * every platform, so it is never mis-classified as a side-channel. Conversely,
- * a side-channel that somehow embedded a coding-prompt signal would merely fall
- * through to the normal pipeline — a safe (memory-only) miss, never a broken
- * conversation.
+ * system prompt (no `Working directory:` marker, no authoritative workspace
+ * inference). A real coding turn carries the marker on every platform, so it is
+ * never mis-classified as a side-channel. Conversely, a side-channel that
+ * somehow embedded a coding-prompt signal would merely fall through to the
+ * normal pipeline — a safe (memory-only) miss, never a broken conversation.
  */
 export function isClaudeCodeSideChannel(req: GatewayRequest): boolean {
   if (!isClaudeCodeClient(req.rawHeaders)) return false;

--- a/packages/gateway/test/session-rotation-merge.test.ts
+++ b/packages/gateway/test/session-rotation-merge.test.ts
@@ -33,23 +33,31 @@ import { enableHostedMode, _resetHostedModeForTest } from "@loreai/core";
 
 // A faithful Claude Code coding turn carries the anchored OAuth billing header
 // at system[0] (Claude Code emits it whenever `_CLAUDE_CODE_ASSUME_FIRST_PARTY_
-// BASE_URL=1`, which `lore run`/`lore setup` always set). Without it — and
-// without a "Working directory:" line — a request bearing an
-// `x-claude-code-session-id` is indistinguishable from a Claude Code
-// side-channel call (auto-mode classifier / title gen), which the pipeline
-// now forwards upstream untouched (see side-channel.test.ts). These
+// BASE_URL=1`, which `lore run`/`lore setup` always set) AND a "Working
+// directory:" line. Since Claude Code 2.1.258 the auto-mode classifier is built
+// with `forceAttributionHeader: true`, so the billing header ALONE is no longer
+// a reliable coding-turn discriminator — the side-channel detector relies on
+// the `Working directory:` marker instead (see side-channel.test.ts). These
 // session-identification regression tests exercise REAL coding turns, so they
-// must present the coding-turn system prompt.
+// must present the coding-turn system prompt (billing header + cwd line). The
+// cwd line is passed per-request so it agrees with the `x-lore-project` header
+// under test.
 const CC_BILLING_HEADER =
   "x-anthropic-billing-header: cc_version=2.1.186; cc_entrypoint=cli; cch=a75d0;\n";
 const CC_CODING_SYSTEM = CC_BILLING_HEADER + DEFAULT_SYSTEM;
 
-function body(userMessage: string): Record<string, unknown> {
+function body(
+  userMessage: string,
+  workingDir?: string,
+): Record<string, unknown> {
+  const system = workingDir
+    ? `${CC_CODING_SYSTEM}\nWorking directory: ${workingDir}`
+    : CC_CODING_SYSTEM;
   return {
     model: DEFAULT_MODEL,
     max_tokens: 1024,
     stream: false,
-    system: CC_CODING_SYSTEM,
+    system,
     messages: [{ role: "user", content: userMessage }],
     tools: STANDARD_TOOLS,
   };
@@ -85,20 +93,28 @@ describe("Tier 1b session-merge regression (x-claude-code-session-id)", () => {
     });
 
     // First conversation: fresh claude-code session id + project /proj/alpha.
-    const r1 = await harness.chat(body("conversation one alpha"), "key-A", {
-      "x-claude-code-session-id": "11111111-1111-1111-1111-111111111111",
-      "x-lore-project": "/proj/alpha",
-    });
+    const r1 = await harness.chat(
+      body("conversation one alpha", "/proj/alpha"),
+      "key-A",
+      {
+        "x-claude-code-session-id": "11111111-1111-1111-1111-111111111111",
+        "x-lore-project": "/proj/alpha",
+      },
+    );
     expect(r1.status).toBe(200);
     await r1.text();
 
     // Second conversation: DIFFERENT claude-code session id + project /proj/beta.
     // Pre-fix, Tier 1b would "resume" the first session and rebind it to
     // /proj/beta. Post-fix, this MUST create a second, independent session.
-    const r2 = await harness.chat(body("conversation two beta"), "key-B", {
-      "x-claude-code-session-id": "22222222-2222-2222-2222-222222222222",
-      "x-lore-project": "/proj/beta",
-    });
+    const r2 = await harness.chat(
+      body("conversation two beta", "/proj/beta"),
+      "key-B",
+      {
+        "x-claude-code-session-id": "22222222-2222-2222-2222-222222222222",
+        "x-lore-project": "/proj/beta",
+      },
+    );
     expect(r2.status).toBe(200);
     await r2.text();
 
@@ -147,7 +163,7 @@ describe("Tier 1b session-merge regression (x-claude-code-session-id)", () => {
 
     const sameId = "33333333-3333-3333-3333-333333333333";
 
-    const r1 = await harness.chat(body("turn one"), "key-A", {
+    const r1 = await harness.chat(body("turn one", "/proj/gamma"), "key-A", {
       "x-claude-code-session-id": sameId,
       "x-lore-project": "/proj/gamma",
     });
@@ -156,16 +172,12 @@ describe("Tier 1b session-merge regression (x-claude-code-session-id)", () => {
 
     const r2 = await harness.chat(
       {
-        model: DEFAULT_MODEL,
-        max_tokens: 1024,
-        stream: false,
-        system: DEFAULT_SYSTEM,
+        ...body("turn two", "/proj/gamma"),
         messages: [
           { role: "user", content: "turn one" },
           { role: "assistant", content: "T1." },
           { role: "user", content: "turn two" },
         ],
-        tools: STANDARD_TOOLS,
       },
       "key-A",
       {
@@ -211,7 +223,7 @@ describe("Tier 1b session-merge regression (x-claude-code-session-id)", () => {
     const msgs = ["msg one", "msg two", "msg three"];
     for (let i = 0; i < ids.length; i++) {
       const [id, proj] = ids[i];
-      const r = await harness.chat(body(msgs[i]), `key-${i}`, {
+      const r = await harness.chat(body(msgs[i], proj), `key-${i}`, {
         "x-claude-code-session-id": id,
         "x-lore-project": proj,
       });

--- a/packages/gateway/test/side-channel.test.ts
+++ b/packages/gateway/test/side-channel.test.ts
@@ -72,9 +72,21 @@ const BILLING_PREFIX =
 // ---------------------------------------------------------------------------
 
 describe("hasClaudeCodeCodingPrompt", () => {
-  test("true when the billing header is present at system[0]", () => {
+  test("false when only the billing header is present (no coding-prompt marker)", () => {
+    // Regression: since Claude Code 2.1.258 the auto-mode classifier is built
+    // with `forceAttributionHeader: true`, so it carries the billing header at
+    // system[0] even though it is a skipSystemPromptPrefix side-channel call.
+    // The header alone must NOT count as a coding prompt.
     expect(
       hasClaudeCodeCodingPrompt(`${BILLING_PREFIX}You are Claude Code.`),
+    ).toBe(false);
+  });
+
+  test("true when the billing header accompanies a Working directory marker", () => {
+    expect(
+      hasClaudeCodeCodingPrompt(
+        `${BILLING_PREFIX}You are Claude Code.\nWorking directory: /home/user/project\n`,
+      ),
     ).toBe(true);
   });
 
@@ -134,6 +146,27 @@ describe("isClaudeCodeSideChannel", () => {
         makeRequest({
           rawHeaders: { ...CC_SESSION_HEADERS },
           system: CLASSIFIER_SYSTEM,
+          maxTokens: 8192,
+          messages: [
+            {
+              role: "user",
+              content: [{ type: "text", text: "action: rm -rf build" }],
+            },
+          ],
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  test("true: classifier prompt carrying a forced attribution (billing) header", () => {
+    // Regression: Claude Code 2.1.258 builds the classifier with
+    // `forceAttributionHeader: true`, anchoring the billing header at system[0]
+    // even though there is no coding prompt. It must STILL bypass the pipeline.
+    expect(
+      isClaudeCodeSideChannel(
+        makeRequest({
+          rawHeaders: { ...CC_SESSION_HEADERS },
+          system: `${BILLING_PREFIX}${CLASSIFIER_SYSTEM}`,
           maxTokens: 8192,
           messages: [
             {
@@ -228,6 +261,14 @@ function sideChannelBody(): Record<string, unknown> {
   };
 }
 
+/** A classifier-shaped body carrying the forced attribution (billing) header. */
+function forcedAttributionBody(): Record<string, unknown> {
+  return {
+    ...sideChannelBody(),
+    system: `${BILLING_PREFIX}${CLASSIFIER_SYSTEM}`,
+  };
+}
+
 async function assistantText(resp: Response): Promise<string> {
   const body = (await resp.json()) as {
     content: Array<{ type: string; text?: string }>;
@@ -273,6 +314,44 @@ describe("handleRequest — Claude Code side-channel routing", () => {
     expect(sentSystem).not.toContain("Long-term Knowledge");
 
     // Passthrough stores nothing in temporal memory.
+    const [{ n }] = harness.queryDB<{ n: number }>(
+      "SELECT COUNT(*) AS n FROM temporal_messages",
+    );
+    expect(n).toBe(0);
+  });
+
+  it("forwards a forced-attribution classifier (billing header) upstream verbatim", async () => {
+    // Regression: since Claude Code 2.1.258 the classifier carries the billing
+    // header at system[0] (forceAttributionHeader). It must STILL bypass the
+    // pipeline — no LTM injection, no compaction mis-route, nothing stored.
+    harness = await createHarness({
+      fixtures: [
+        makeFixtureEntry({
+          seq: 0,
+          requestMessages: [],
+          responseText: "<action>allow</action>",
+        }),
+      ],
+    });
+
+    const resp = await harness.chat(forcedAttributionBody(), "test-key", {
+      ...CC_SESSION_HEADERS,
+    });
+    expect(resp.status).toBe(200);
+    expect(await assistantText(resp)).toBe("<action>allow</action>");
+
+    // Passthrough forwards the ORIGINAL system prompt — no LTM injection.
+    const bodies = harness.upstreamBodies();
+    expect(bodies.length).toBe(1);
+    const sent = JSON.parse(bodies[0]) as { system?: unknown };
+    const sentSystem =
+      typeof sent.system === "string"
+        ? sent.system
+        : JSON.stringify(sent.system);
+    expect(sentSystem).toContain("x-anthropic-billing-header");
+    expect(sentSystem).toContain("<action> verdict");
+    expect(sentSystem).not.toContain("Long-term Knowledge");
+
     const [{ n }] = harness.queryDB<{ n: number }>(
       "SELECT COUNT(*) AS n FROM temporal_messages",
     );


### PR DESCRIPTION
## Problem

Running Claude Code through the Lore gateway breaks auto mode. Sessions report, verbatim:

- `[bug] Bash tool unusable for ~1 hour: safety classifier (claude-sonnet-5)`
- `[bug] Bash safety-classifier outage blocked all non-trivial commands for a full session`

Claude Code's auto-mode permission classifier (one call per tool action, model `claude-sonnet-5`) fails repeatedly, and after 3 consecutive bad verdicts Claude Code drops auto mode to fail-closed — every Bash action gets blocked or prompted.

## Root cause

PR #1161 introduced the side-channel filter in `packages/gateway/src/side-channel.ts`, which forwards Claude Code auxiliary calls (auto-mode classifier, title/topic generation, subagent naming) upstream untouched. It classifies a request as a *side-channel* when it is a Claude Code client **and** `hasClaudeCodeCodingPrompt()` returns `false`. That predicate used the anchored OAuth billing header as a **sufficient** signal:

```
hasClaudeCodeCodingPrompt(system)
  = hasBillingHeader(system)          // signal 1 (SUFFICIENT)
  || "Working directory:" marker      // signal 2
  || authoritative cwd/CLAUDE.md path // signal 3
```

At the time, classifier calls were built with `skipSystemPromptPrefix: true` and carried **no** billing header, so signal 1 never fired for them and they were correctly passed through.

**Claude Code 2.1.258 changed this.** The classifier request is now built with `forceAttributionHeader: true`, so it carries the anchored billing header at `system[0]` even though it is still a `skipSystemPromptPrefix` side-channel call (it never embeds the coding prompt).

With signal 1 firing, `isClaudeCodeSideChannel()` returns `false` for the classifier, so it falls into the full context pipeline — LTM injection, distilled-prefix injection, and structural-compaction mis-routing — which corrupts the verdict and triggers the fail-closed fallback.

## Solution

Demote the billing header from a *sufficient* signal to advisory in `hasClaudeCodeCodingPrompt()`. The discriminator now relies on:

1. the `Working directory:` marker line (present in every real coding turn, including subagents, on any OS), and
2. authoritative workspace inference (a `cwd` field or a CLAUDE/AGENTS/.lore.md path).

Neither of these is carried by a `skipSystemPromptPrefix` classifier call, so the classifier (and any other `forceAttributionHeader` side-channel) is again forwarded upstream untouched. A real coding turn always carries the marker, so it is never mis-classified — with or without the billing header.

The change is scoped to the side-channel discriminator only. `hasBillingHeader()` is untouched and continues to drive the re-sign gate, `captureBillingPrefix()`, and the OAuth worker-header logic.

## Changes

- `packages/gateway/src/side-channel.ts` — drop `hasBillingHeader(system)` from `hasClaudeCodeCodingPrompt()`; update docs.
- `packages/gateway/test/side-channel.test.ts` — regression tests: billing header alone no longer marks a coding prompt; a forced-attribution classifier still bypasses the pipeline; a real coding turn (billing header + `Working directory:`) is still not a side-channel.
- `packages/gateway/test/session-rotation-merge.test.ts` — update CC coding-turn fixtures to carry the `Working directory:` marker (they previously relied on the billing header alone).

## Related

- PR #1161 — the original side-channel fix; its "no billing header" assumption is what regressed in 2.1.258.
- Issue #807 — `cch: defensively handle billing headers that arrive without a cch segment` (adjacent: it made billing-header detection *more* permissive, compounding this mis-detection).
