### PR TITLE
fix(gateway): stop Claude Code sub-agent turns from misrouting to com…

### DIFF
--- a/packages/core/src/credential-headers.ts
+++ b/packages/core/src/credential-headers.ts
@@ -3,8 +3,29 @@
 /** Internal gateway access credential. Never forward, learn, persist, or log. */
 export const GATEWAY_AUTH_HEADER = "x-lore-gateway-token";
 
+/**
+ * Claude Code sub-agent (Task/Agent tool) correlation headers.
+ *
+ * A sub-agent request carries its own `x-claude-code-agent-id` (a fresh id per
+ * sub-agent invocation) AND the parent's `x-claude-code-session-id`. The main
+ * agent emits only the session-id (`x-claude-code-agent-id` is absent).
+ * `x-claude-code-parent-agent-id` carries the parent *agent* id (not the parent
+ * session id) and is never emitted by the main agent, so it never appears in
+ * the header session index.
+ */
+export const CLAUDE_CODE_AGENT_ID_HEADER = "x-claude-code-agent-id";
+export const CLAUDE_CODE_PARENT_AGENT_ID_HEADER =
+  "x-claude-code-parent-agent-id";
+
 export const KNOWN_SESSION_HEADERS = [
   "x-lore-session-id",
+  // Claude Code sub-agents emit their own id AND the parent's
+  // `x-claude-code-session-id`. The agent-id must win priority over the shared
+  // session-id so a sub-agent gets its own session rather than merging into the
+  // parent (whose message history then makes the sub-agent's short first request
+  // look like a structural compaction — see pipeline.ts). Main-agent requests
+  // carry only the session-id, so they are unaffected.
+  CLAUDE_CODE_AGENT_ID_HEADER,
   "x-claude-code-session-id",
   "x-session-id",
   "x-session-affinity",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -206,6 +206,8 @@ export {
 export {
   GATEWAY_AUTH_HEADER,
   KNOWN_SESSION_HEADERS,
+  CLAUDE_CODE_AGENT_ID_HEADER,
+  CLAUDE_CODE_PARENT_AGENT_ID_HEADER,
   isCredentialHeaderName,
   redactCredentialHeaderAssignments,
 } from "./credential-headers";

--- a/packages/gateway/src/credential-headers.ts
+++ b/packages/gateway/src/credential-headers.ts
@@ -1,6 +1,8 @@
 export {
   GATEWAY_AUTH_HEADER,
   KNOWN_SESSION_HEADERS,
+  CLAUDE_CODE_AGENT_ID_HEADER,
+  CLAUDE_CODE_PARENT_AGENT_ID_HEADER,
   isCredentialHeaderName,
   redactCredentialHeaderAssignments,
 } from "@loreai/core";

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -15639,19 +15639,21 @@ async function handleConversationTurn(
       req.rawHeaders,
       config,
     );
+    // Resolve by the OpenCode parent-session-id, or — for Claude Code — by
+    // the parent's shared x-claude-code-session-id (the only stable link back
+    // to the parent session; x-claude-code-parent-agent-id identifies the
+    // parent *agent*, not its session). May be undefined for a malformed or
+    // adversarial sub-agent request that carries neither header.
+    const parentLookupValue = parentClientId ?? sharedSessionId;
     const shouldResolveParent =
       credentialFingerprint !== null &&
       (!sessionState.isSubagent || !sessionState.parentSessionId) &&
-      (isClaudeSubagent || !!parentClientId);
+      (isClaudeSubagent || !!parentClientId) &&
+      !!parentLookupValue;
     if (shouldResolveParent) {
       if (!sessionState.isSubagent) {
         sessionState.isSubagent = true;
       }
-      // Resolve by the OpenCode parent-session-id, or — for Claude Code — by
-      // the parent's shared x-claude-code-session-id (the only stable link back
-      // to the parent session; x-claude-code-parent-agent-id identifies the
-      // parent *agent*, not its session).
-      const parentLookupValue = parentClientId ?? sharedSessionId;
       // Search the full headerSessionIndex — covers Tier 1 (known) and Tier 2 (learned) headers.
       let resolvedParent: string | undefined;
       for (const [key, loreId] of headerSessionIndex) {

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -142,6 +142,7 @@ import {
   MESSAGE_COUNT_PROXIMITY_THRESHOLD,
   KNOWN_SESSION_HEADERS,
   extractKnownSessionHeader,
+  isClaudeCodeSubagent,
   learnHeaders,
   observeHeaderValues,
   isCredentialHeaderName,
@@ -5625,7 +5626,8 @@ async function adoptByFingerprint(input: {
     assertCurrentPipelineGeneration(req.signal, requestGeneration);
   }
 
-  const reqIsSubagent = !!headers["x-parent-session-id"];
+  const reqIsSubagent =
+    !!headers["x-parent-session-id"] || isClaudeCodeSubagent(headers);
   const candidates = findSessionStatesByFingerprint(fingerprint, {
     credentialFingerprint,
   }).map((candidate) => ({ ...candidate, credentialBound: true }));
@@ -15618,33 +15620,45 @@ async function handleConversationTurn(
   );
   assertCurrentPipelineGeneration(req.signal, requestGeneration);
 
-  // Mark sub-agent sessions (x-parent-session-id present).
-  // These get their own session but are flagged for cache warming exemption.
-  // Resolve the client-side parent ID to a Lore internal session ID via the
-  // headerSessionIndex (searches all indexed headers, including Tier 2 learned).
-  // Tier 3 (fingerprint-only) parents have no index entry — resolution will fail
-  // and a warning is logged.
+  // Mark sub-agent sessions (x-parent-session-id OR x-claude-code-agent-id
+  // present). These get their own session but are flagged for cache warming
+  // exemption. Resolve the client-side parent ID to a Lore internal session ID
+  // via the headerSessionIndex (searches all indexed headers, including Tier 2
+  // learned). Tier 3 (fingerprint-only) parents have no index entry — resolution
+  // will fail and a warning is logged.
+  //
+  // Claude Code sub-agents do NOT carry x-parent-session-id (that header is
+  // OpenCode-only); they carry x-claude-code-agent-id. Their parent session is
+  // the one that shares the x-claude-code-session-id with this request, so we
+  // resolve it through the index by that shared session-id value.
   {
+    const isClaudeSubagent = isClaudeCodeSubagent(req.rawHeaders);
     const parentClientId = req.rawHeaders["x-parent-session-id"];
+    const sharedSessionId = req.rawHeaders["x-claude-code-session-id"];
     const credentialFingerprint = requestCredentialFingerprint(
       req.rawHeaders,
       config,
     );
-    if (
-      parentClientId &&
+    const shouldResolveParent =
       credentialFingerprint !== null &&
-      (!sessionState.isSubagent || !sessionState.parentSessionId)
-    ) {
+      (!sessionState.isSubagent || !sessionState.parentSessionId) &&
+      (isClaudeSubagent || !!parentClientId);
+    if (shouldResolveParent) {
       if (!sessionState.isSubagent) {
         sessionState.isSubagent = true;
       }
+      // Resolve by the OpenCode parent-session-id, or — for Claude Code — by
+      // the parent's shared x-claude-code-session-id (the only stable link back
+      // to the parent session; x-claude-code-parent-agent-id identifies the
+      // parent *agent*, not its session).
+      const parentLookupValue = parentClientId ?? sharedSessionId;
       // Search the full headerSessionIndex — covers Tier 1 (known) and Tier 2 (learned) headers.
       let resolvedParent: string | undefined;
       for (const [key, loreId] of headerSessionIndex) {
         const parsed = parseSessionIndexKey(key);
         if (
           parsed?.credentialFingerprint === credentialFingerprint &&
-          parsed.headerValue === parentClientId
+          parsed.headerValue === parentLookupValue
         ) {
           resolvedParent = loreId;
           break;
@@ -15663,11 +15677,11 @@ async function handleConversationTurn(
         // Dedup the log: a child agent with an unresolvable parent fires this
         // branch on every turn. Without dedup, a single parent-less agent
         // produces 50+ identical log lines per session.
-        const pendingKey = `${sessionID}:${parentClientId}`;
+        const pendingKey = `${sessionID}:${parentLookupValue}`;
         if (!subagentParentPendingLogged.has(pendingKey)) {
           subagentParentPendingLogged.add(pendingKey);
           log.info(
-            `session ${sessionID.slice(0, 16)}: subagent parent resolution pending for client ID ${parentClientId.slice(0, 16)}`,
+            `session ${sessionID.slice(0, 16)}: subagent parent resolution pending for client ID ${parentLookupValue.slice(0, 16)}`,
           );
         }
         saveSessionTracking(sessionID, { isSubagent: true });
@@ -19084,9 +19098,22 @@ async function handleRequestInner(
 
     // --- Case 1: Compaction request → intercept ---
     // Structural detection (session-aware) first, pattern matching as fallback.
-    // Sub-agents now get their own sessions (separate x-session-affinity), so
-    // priorState is the sub-agent's own state — structural detection is safe.
-    const structuralCompaction = isStructuralCompaction(req, priorState);
+    // Sub-agents now get their own sessions (separate x-session-affinity /
+    // x-claude-code-agent-id), so priorState is the sub-agent's own state —
+    // structural detection is safe.
+    //
+    // IMPORTANT: a Claude Code sub-agent still shares the parent's
+    // `x-claude-code-session-id`. Before x-claude-code-agent-id was added to the
+    // known-header priority (see credential-headers.ts), `activeSessionForKnownHeader`
+    // resolved it to the PARENT session, whose large message count made the
+    // sub-agent's short first request (1 user message + tool-schema attachments)
+    // look like a structural compaction. The gateway then intercepted it and
+    // returned the offline "# Session Summary" block as the sub-agent's
+    // task_result. Guarding structural detection on the sub-agent signal closes
+    // that hole regardless of which header resolved the session.
+    const isClaudeSubagent = isClaudeCodeSubagent(req.rawHeaders);
+    const structuralCompaction =
+      !isClaudeSubagent && isStructuralCompaction(req, priorState);
     const patternDetection = structuralCompaction
       ? undefined
       : detectCompactionRequest(req);

--- a/packages/gateway/src/session.ts
+++ b/packages/gateway/src/session.ts
@@ -29,11 +29,16 @@
  */
 
 import {
+  CLAUDE_CODE_AGENT_ID_HEADER,
   isCredentialHeaderName,
   KNOWN_SESSION_HEADERS,
 } from "./credential-headers";
 
-export { isCredentialHeaderName, KNOWN_SESSION_HEADERS };
+export {
+  isCredentialHeaderName,
+  KNOWN_SESSION_HEADERS,
+  CLAUDE_CODE_AGENT_ID_HEADER,
+};
 
 // ---------------------------------------------------------------------------
 // Base62 encoding
@@ -289,6 +294,24 @@ const ROTATION_ELIGIBLE_HEADERS: ReadonlySet<string> = new Set([
  */
 export function isRotationEligible(headerName: string): boolean {
   return ROTATION_ELIGIBLE_HEADERS.has(headerName);
+}
+
+/**
+ * True when the request is a Claude Code sub-agent turn — i.e. it carries a
+ * non-empty `x-claude-code-agent-id` header.
+ *
+ * Claude Code (2.1.258+) emits `x-claude-code-agent-id` only for Task/Agent
+ * sub-agents; the main conversation loop emits `x-claude-code-session-id`
+ * with NO agent-id. This is the only reliable Claude Code sub-agent signal:
+ * the `x-claude-code-parent-agent-id` header is correlated with agent lineage,
+ * not the shared session, and the `x-parent-session-id` header that the
+ * OpenCode plugin injects is never emitted by Claude Code.
+ */
+export function isClaudeCodeSubagent(
+  rawHeaders: Record<string, string>,
+): boolean {
+  const value = rawHeaders[CLAUDE_CODE_AGENT_ID_HEADER];
+  return typeof value === "string" && value.length > 0;
 }
 
 /**

--- a/packages/gateway/src/translate/types.ts
+++ b/packages/gateway/src/translate/types.ts
@@ -14,6 +14,8 @@
 import { asString } from "@loreai/core";
 import {
   GATEWAY_AUTH_HEADER,
+  CLAUDE_CODE_AGENT_ID_HEADER,
+  CLAUDE_CODE_PARENT_AGENT_ID_HEADER,
   isCredentialHeaderName,
   KNOWN_SESSION_HEADERS,
 } from "../credential-headers";
@@ -591,13 +593,15 @@ export type SessionState = {
   // --- Sub-agent detection ---
 
   /** True when a request in this session carried an `x-parent-session-id`
-   *  header, indicating it belongs to an ephemeral sub-agent (e.g. OpenCode
-   *  explore). Sub-agent sessions are exempt from cache warming — they are
-   *  too short-lived (1-3 turns) for warming to be profitable. */
+   *  header (OpenCode) or an `x-claude-code-agent-id` header (Claude Code),
+   *  indicating it belongs to an ephemeral sub-agent. Sub-agent sessions are
+   *  exempt from cache warming — they are too short-lived (1-3 turns) for
+   *  warming to be profitable. */
   isSubagent?: boolean;
 
   /** Lore internal session ID of the parent session (resolved from the
-   *  `x-parent-session-id` header value via the headerSessionIndex).
+   *  `x-parent-session-id` header value — or, for Claude Code, the shared
+   *  `x-claude-code-session-id` — via the headerSessionIndex).
    *  NULL/undefined for root (non-sub-agent) sessions. */
   parentSessionId?: string;
 
@@ -796,6 +800,8 @@ const GATEWAY_MANAGED_HEADERS = new Set([
   "anthropic-version",
   // Session identification — consumed by gateway, not meaningful to upstream
   "x-parent-session-id",
+  CLAUDE_CODE_AGENT_ID_HEADER,
+  CLAUDE_CODE_PARENT_AGENT_ID_HEADER,
   ...KNOWN_SESSION_HEADERS,
   // Auth — handled separately by each builder (extractAuth + authHeaders)
   "x-api-key",

--- a/packages/gateway/test/session.test.ts
+++ b/packages/gateway/test/session.test.ts
@@ -7,6 +7,7 @@ import {
   scanForMarker,
   fingerprintMessages,
   extractKnownSessionHeader,
+  isClaudeCodeSubagent,
   findRotationPredecessor,
   isRotationEligible,
   KNOWN_SESSION_HEADERS,
@@ -449,6 +450,21 @@ describe("extractKnownSessionHeader", () => {
     });
   });
 
+  test("prefers x-claude-code-agent-id over the shared x-claude-code-session-id", () => {
+    // A Claude Code sub-agent carries BOTH its own agent-id and the parent's
+    // session-id. The agent-id must win so the sub-agent gets its own session
+    // (regression: otherwise the sub-agent merges into the parent and its short
+    // first request is misdetected as a structural compaction).
+    const result = extractKnownSessionHeader({
+      "x-claude-code-agent-id": "agent-abc",
+      "x-claude-code-session-id": "parent-session-uuid",
+    });
+    expect(result).toEqual({
+      sessionId: "agent-abc",
+      headerName: "x-claude-code-agent-id",
+    });
+  });
+
   test("prefers x-session-id over x-session-affinity", () => {
     const result = extractKnownSessionHeader({
       "x-session-id": "standard-id",
@@ -484,6 +500,34 @@ describe("extractKnownSessionHeader", () => {
 // ===========================================================================
 // Tier 2: Header learning helpers
 // ===========================================================================
+
+describe("isClaudeCodeSubagent", () => {
+  test("true when x-claude-code-agent-id present", () => {
+    expect(
+      isClaudeCodeSubagent({
+        "x-claude-code-agent-id": "agent-abc",
+        "x-claude-code-session-id": "parent-session-uuid",
+      }),
+    ).toBe(true);
+  });
+
+  test("false for the main agent (session-id only, no agent-id)", () => {
+    expect(
+      isClaudeCodeSubagent({ "x-claude-code-session-id": "main-session-uuid" }),
+    ).toBe(false);
+  });
+
+  test("false for empty agent-id value", () => {
+    expect(isClaudeCodeSubagent({ "x-claude-code-agent-id": "" })).toBe(false);
+  });
+
+  test("false when no Claude Code headers present", () => {
+    expect(isClaudeCodeSubagent({})).toBe(false);
+    expect(
+      isClaudeCodeSubagent({ "x-parent-session-id": "opencode-parent" }),
+    ).toBe(false);
+  });
+});
 
 describe("isSessionHeaderName", () => {
   test("matches session-related header names", () => {


### PR DESCRIPTION
Claude Code sub-agents (the Agent/Task tool) get their task_result replaced by a lore # Session Summary block instead of their actual output. Root cause: the gateway's sub-agent detection only recognized x-parent-session-id — a header OpenCode injects but Claude Code never sends.

### Problem
Claude Code ≥ 2.1.258 emits x-claude-code-agent-id + x-claude-code-parent-agent-id on sub-agent requests and reuses the parent's x-claude-code-session-id. The gateway has two independent bugs flowing from that:
1. Structural-compaction false positive. Because the sub-agent shares the parent's x-claude-code-session-id (a Tier-1 known header), the gateway resolved the sub-agent's request to the parent session. The parent's large message count (priorState.messageCount) versus the sub-agent's short first request (1 user message + tool-schema attachments, ~2 messages) tripped isStructuralCompaction (prior > 10 && curr ≤ 3 && curr < prior/2). The gateway intercepted it and returned assembleOfflineCompaction — a # Session Summary + Long-term-Knowledge dump — as the sub-agent's task_result.
2. Parent-session contamination. The sub-agent turn merged into the parent's session state (LTM/gradient/distillation on the wrong context), and isSubagent was never set, so the sub-agent wasn't exempted from cache warming / LTM budget sizing.
This is a regression of the class fixed in #236 (e9a85162, "prevent compaction summary leaking as subagent task_result"), whose guard was keyed on x-parent-session-id and subsequently removed in #335 (dc52b656) on the assumption that "sub-agents carry their own x-session-affinity" — true for OpenCode, never for Claude Code.

### Fix
- x-claude-code-agent-id joins KNOWN_SESSION_HEADERS above x-claude-code-session-id, so a Claude Code sub-agent keys its own Tier-1 session. Main-agent requests emit only the session-id, so they are unaffected.
- Structural-compaction detection is skipped for Claude Code sub-agents (isClaudeCodeSubagent() guard in the request dispatch). Pattern-detected compaction is still intercepted (unchanged; correct for both clients).
- isSubagent + parent resolution now fire for Claude Code, resolving the parent via the shared x-claude-code-session-id. OpenCode continues to resolve via x-parent-session-id (mirrors the approach in #1309).
- x-claude-code-agent-id / x-claude-code-parent-agent-id are added to the gateway-managed headers and no longer forwarded upstream.

### References
- #236 — fix: prevent compaction summary leaking as subagent task_result to parent session (the original fix this regresses)
- #335 — fix: stop merging sub-agent turns into parent session (removed the guard)
- #1300 / #1302 / #1309 — sub-agent detection, LTM budget sizing, and the OpenCode x-parent-session-id flagging

### Testing
- typecheck (core + gateway) clean; no new lint warnings.
- New tests: x-claude-code-agent-id header priority, isClaudeCodeSubagent detection, and OpenCode x-parent-session-id behavior preserved.
- 372 gateway tests + 43 opencode tests pass. (The worker-model/eviction suite failures in a full local run are a pre-existing LORE_WORKER_MODEL env leak, unrelated to this change.)