### PR TITLE
fix(ci): prepare semantic lint enforcement

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -12,6 +12,9 @@ paths:
   .github/workflows/semantic-linter.yml:
     ignore:
       - 'unknown permission scope "copilot-requests"'
+  .github/workflows/semantic-linter-cache.yml:
+    ignore:
+      - 'unknown permission scope "copilot-requests"'
   .github/workflows/eval.yml:
     ignore:
       - 'unknown permission scope "copilot-requests"'

--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -172,6 +172,11 @@ runs:
         [ -n "$LORE_IC_MODEL" ] && args+=(--model "$LORE_IC_MODEL")
         [ -n "$LORE_IC_EFFORT" ] && args+=(--effort "$LORE_IC_EFFORT")
         args+=(--import-lore-md)
+        # A trusted cache-primer must import even when .lore.md is the only
+        # changed file (which produces no code hunks).
+        if [ "$LORE_CACHE_MODE" = "save" ]; then
+          args+=(--prime-lore-db)
+        fi
         if [ "$LORE_IC_GATE" = "true" ]; then
           args+=(--gate)
         fi
@@ -210,10 +215,25 @@ runs:
         stop "$LORE_COPILOT_PROXY_PID"
 
     - name: Save derived invariant DB
+      id: cache-db
       if: >-
         always() && inputs.cache-mode == 'save' &&
         steps.cache.outputs.cache-hit != 'true' &&
         steps.check.outputs.exit_code == '0'
+      shell: bash
+      env:
+        LORE_DB_PATH: ${{ steps.key.outputs.db }}
+      run: |
+        set -euo pipefail
+        test -s "$LORE_DB_PATH"
+        echo "ready=true" >> "$GITHUB_OUTPUT"
+
+    - name: Save verified invariant DB cache
+      if: >-
+        always() && inputs.cache-mode == 'save' &&
+        steps.cache.outputs.cache-hit != 'true' &&
+        steps.check.outputs.exit_code == '0' &&
+        steps.cache-db.outputs.ready == 'true'
       uses: actions/cache/save@v5
       with:
         path: ${{ runner.temp }}/lore-ci

--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -38,6 +38,12 @@ inputs:
     description: "Set true to fail on blocking findings and health failures."
     required: false
     default: "false"
+  cache-mode:
+    description: >-
+      Derived invariant-DB cache policy: restore (safe for PRs), save (trusted
+      default-branch priming only), or off.
+    required: false
+    default: "restore"
   deadline-seconds:
     description: "Overall semantic lint deadline, in seconds."
     required: false
@@ -56,6 +62,7 @@ runs:
         LORE_IC_MODEL: ${{ inputs.model }}
         LORE_WORKER_API_KEY: ${{ inputs.worker-api-key }}
         LORE_GITHUB_TOKEN: ${{ inputs.github-token }}
+        LORE_CACHE_MODE: ${{ inputs.cache-mode }}
       run: |
         set -euo pipefail
         if [ -n "$LORE_GITHUB_TOKEN" ] && [ -n "$LORE_WORKER_API_KEY" ]; then
@@ -64,6 +71,10 @@ runs:
         fi
         if [ -n "$LORE_GITHUB_TOKEN" ] && [[ ! "$LORE_IC_MODEL" =~ ^github-copilot/gpt-5\.6-[A-Za-z0-9._-]+$ ]]; then
           echo "github-token requires a Responses-compatible github-copilot/gpt-5.6-* model" >&2
+          exit 1
+        fi
+        if [[ ! "$LORE_CACHE_MODE" =~ ^(restore|save|off)$ ]]; then
+          echo "cache-mode must be restore, save, or off" >&2
           exit 1
         fi
 
@@ -105,7 +116,8 @@ runs:
 
     - name: Restore derived invariant DB
       id: cache
-      uses: actions/cache@v5
+      if: inputs.cache-mode != 'off'
+      uses: actions/cache/restore@v5
       with:
         path: ${{ runner.temp }}/lore-ci
         key: ${{ steps.key.outputs.key }}
@@ -196,3 +208,13 @@ runs:
       run: >-
         node "${{ github.action_path }}/copilot-proxy.mjs"
         stop "$LORE_COPILOT_PROXY_PID"
+
+    - name: Save derived invariant DB
+      if: >-
+        always() && inputs.cache-mode == 'save' &&
+        steps.cache.outputs.cache-hit != 'true' &&
+        steps.check.outputs.exit_code == '0'
+      uses: actions/cache/save@v5
+      with:
+        path: ${{ runner.temp }}/lore-ci
+        key: ${{ steps.key.outputs.key }}

--- a/.github/actions/lint/report.mjs
+++ b/.github/actions/lint/report.mjs
@@ -552,7 +552,7 @@ if (report) {
     annotation(
       "notice",
       "Lore semantic lint",
-      `✓ no suspected invariant violations (${funnel})`,
+      `✓ no suspected invariant violations among selected candidates (${funnel})`,
     );
   } else if (report.status !== "complete") {
     annotation(
@@ -578,7 +578,7 @@ if (report) {
         : blocking
           ? `🚫 **${report.gate.blockingFindingIds.length} blocking finding(s)**.`
           : report.findings.length === 0
-            ? "✓ No suspected invariant violations."
+            ? "✓ No suspected invariant violations among selected candidates."
             : `⚠ **${report.findings.length} advisory finding(s)**.`;
     appendFileSync(
       summaryFile,

--- a/.github/workflows/semantic-linter-cache.yml
+++ b/.github/workflows/semantic-linter-cache.yml
@@ -1,0 +1,61 @@
+name: Semantic linter cache
+
+# PR runs restore this derived DB but never write it: pull_request_target's
+# token is intentionally constrained against cache writes. Prime on trusted
+# default-branch changes instead, where the cache can be safely shared with PRs.
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".lore.md"
+      - ".github/actions/lint/**"
+      - ".github/workflows/semantic-linter-cache.yml"
+      - "packages/core/src/agents-file.ts"
+      - "packages/core/src/invariant-check.ts"
+      - "packages/gateway/src/cli/invariant-check.ts"
+      - "pnpm-lock.yaml"
+  workflow_dispatch:
+
+permissions:
+  actions: write
+  contents: read
+  copilot-requests: write
+
+jobs:
+  prime:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 2
+      - name: Resolve a trusted priming range
+        id: range
+        env:
+          EVENT_BEFORE: ${{ github.event.before }}
+        run: |
+          set -euo pipefail
+          base="$EVENT_BEFORE"
+          if ! [[ "$base" =~ ^[0-9a-fA-F]{40}$ ]] || ! git cat-file -e "$base^{commit}" 2>/dev/null; then
+            base="$(git rev-parse HEAD^)"
+          fi
+          echo "base=$base" >> "$GITHUB_OUTPUT"
+          echo "head=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm --filter @loreai/gateway run bundle
+      - name: Prime Lore invariant DB cache
+        uses: ./.github/actions/lint
+        with:
+          base: ${{ steps.range.outputs.base }}
+          head: ${{ steps.range.outputs.head }}
+          lore-command: "node packages/gateway/dist/bin.cjs"
+          cache-mode: save
+          model: ${{ secrets.LORE_WORKER_API_KEY != '' && vars.LORE_INVARIANT_MODEL != '' && vars.LORE_INVARIANT_MODEL || 'github-copilot/gpt-5.6-luna' }}
+          worker-api-key: ${{ secrets.LORE_WORKER_API_KEY != '' && vars.LORE_INVARIANT_MODEL != '' && secrets.LORE_WORKER_API_KEY || '' }}
+          github-token: ${{ secrets.LORE_WORKER_API_KEY != '' && vars.LORE_INVARIANT_MODEL != '' && '' || github.token }}
+          deadline-seconds: "1200"
+          candidate-timeout-seconds: "90"

--- a/.github/workflows/semantic-linter.yml
+++ b/.github/workflows/semantic-linter.yml
@@ -17,7 +17,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  actions: write
+  actions: read
   contents: read
   pull-requests: read
   copilot-requests: write

--- a/.github/workflows/semantic-linter.yml
+++ b/.github/workflows/semantic-linter.yml
@@ -1,7 +1,9 @@
-name: Semantic linter (advisory)
+name: Semantic linter
 
-# Advisory-only: surfaces PR changes that contradict a documented invariant.
-# NEVER fails the build — reports findings as annotations + a job summary.
+# Starts advisory. Set the protected repository variable
+# LORE_SEMANTIC_LINT_GATE=true only after explicitly marking calibrated rules
+# in .lore.md; gate mode then fails closed on health failures and soft/strict
+# findings while leaving all unmarked knowledge advisory.
 
 on:
   # Run the base repository's trusted workflow definition. The job checks out
@@ -27,8 +29,9 @@ jobs:
     # ~10-15 min on a PR with many hunks and invariants. Keep enough headroom
     # for cold-start variation and bounded shutdown/report publication.
     timeout-minutes: 25
-    # Advisory: a failure here must never block a PR.
-    continue-on-error: true
+    # Keep this non-blocking until the repository explicitly promotes calibrated
+    # rules. The variable is read from the trusted base repository, never the PR.
+    continue-on-error: ${{ vars.LORE_SEMANTIC_LINT_GATE != 'true' }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -84,3 +87,4 @@ jobs:
           # bounded gateway shutdown.
           deadline-seconds: "1200"
           candidate-timeout-seconds: "90"
+          gate: ${{ vars.LORE_SEMANTIC_LINT_GATE == 'true' }}

--- a/packages/core/src/agents-file.ts
+++ b/packages/core/src/agents-file.ts
@@ -115,8 +115,38 @@ const LORE_FILE_HEADER =
 const UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
 
-/** Matches `<!-- lore:UUID -->` tracking markers. */
-const MARKER_RE = /^<!--\s*lore:([0-9a-f-]+)\s*-->$/;
+/** Matches `<!-- lore:UUID [enforce:soft|strict|off] -->` tracking markers. */
+const MARKER_RE =
+  /^<!--\s*lore:([0-9a-f-]+)(?:\s+enforce:(soft|strict|off))?\s*-->$/;
+
+export type LoreEnforcement = "soft" | "strict" | "off";
+
+function markerEnforcement(
+  metadata: ltm.KnowledgeMetadata | null,
+): LoreEnforcement | undefined {
+  switch (metadata?.enforce) {
+    case true:
+    case "strict":
+      return "strict";
+    case "soft":
+      return "soft";
+    case false:
+    case "off":
+      return "off";
+    default:
+      return undefined;
+  }
+}
+
+function withMarkerEnforcement(
+  metadata: ltm.KnowledgeMetadata | null,
+  enforce: LoreEnforcement | undefined,
+): ltm.KnowledgeMetadata | null {
+  const next = { ...metadata };
+  if (enforce === undefined) delete next.enforce;
+  else next.enforce = enforce;
+  return Object.keys(next).length > 0 ? next : null;
+}
 
 // ---------------------------------------------------------------------------
 // File cache (kv_meta) — skip redundant import/export work
@@ -178,6 +208,8 @@ export type ParsedFileEntry = {
   category: string;
   title: string;
   content: string;
+  /** Explicit semantic-lint enforcement opt-in carried by the marker. */
+  enforce?: LoreEnforcement;
 };
 
 // ---------------------------------------------------------------------------
@@ -286,6 +318,7 @@ export function parseEntriesFromSection(section: string): ParsedFileEntry[] {
   const entries: ParsedFileEntry[] = [];
   let currentCategory = "pattern";
   let pendingId: string | null = null;
+  let pendingEnforce: LoreEnforcement | undefined;
 
   for (const raw of lines) {
     const line = raw.trim();
@@ -295,14 +328,19 @@ export function parseEntriesFromSection(section: string): ParsedFileEntry[] {
     if (headingMatch) {
       currentCategory = headingMatch[1].toLowerCase();
       pendingId = null;
+      pendingEnforce = undefined;
       continue;
     }
 
-    // Marker line: <!-- lore:UUID -->
+    // Marker line: <!-- lore:UUID [enforce:soft|strict|off] -->
     const markerMatch = line.match(MARKER_RE);
     if (markerMatch) {
       const candidate = markerMatch[1];
       pendingId = UUID_RE.test(candidate) ? candidate : null;
+      pendingEnforce =
+        pendingId === null
+          ? undefined
+          : (markerMatch[2] as LoreEnforcement | undefined);
       continue;
     }
 
@@ -317,14 +355,17 @@ export function parseEntriesFromSection(section: string): ParsedFileEntry[] {
         category: currentCategory,
         title: unescapeMarkdown(bulletMatch[1].trim()),
         content: unescapeMarkdown(bulletMatch[2].trim()),
+        ...(pendingEnforce !== undefined ? { enforce: pendingEnforce } : {}),
       });
       pendingId = null; // consume the pending marker
+      pendingEnforce = undefined;
       continue;
     }
 
     // Any non-matching non-empty line resets the pending marker
     if (line !== "" && !line.startsWith("##") && !line.startsWith("<!--")) {
       pendingId = null;
+      pendingEnforce = undefined;
     }
   }
 
@@ -398,7 +439,10 @@ function buildSection(
 
     for (let i = 0; i < sorted.length; i++) {
       if (i > 0) out.push(""); // blank line between entries for git context
-      out.push(`<!-- lore:${sorted[i].logical_id} -->`);
+      const enforce = markerEnforcement(sorted[i].metadata);
+      out.push(
+        `<!-- lore:${sorted[i].logical_id}${enforce ? ` enforce:${enforce}` : ""} -->`,
+      );
       // Render the bullet using remark serializer for proper markdown escaping.
       // serialize(root(ul([liph(...)]))) produces "* **Title**: content\n".
       // Trim the trailing newline since we join with \n ourselves.
@@ -635,8 +679,19 @@ function _importEntries(entries: ParsedFileEntry[], projectPath: string): void {
         // Known entry — update only if content changed (manual edit in file). Pass
         // the resolved current row id (Seer #848): update() resolves it to the
         // logical_id and appends a new version.
-        if (existing.content !== entry.content) {
-          ltm.update(existing.id, { content: entry.content });
+        const metadata = withMarkerEnforcement(
+          existing.metadata,
+          entry.enforce,
+        );
+        if (
+          existing.content !== entry.content ||
+          JSON.stringify(existing.metadata) !== JSON.stringify(metadata)
+        ) {
+          ltm.update(existing.id, {
+            content: entry.content,
+            metadata,
+            replaceMetadata: true,
+          });
         }
       } else if (ltm.isTombstoned(entry.id)) {
       } else {
@@ -650,11 +705,22 @@ function _importEntries(entries: ParsedFileEntry[], projectPath: string): void {
         });
         if (fuzzyMatch) {
           // Title-similar entry exists locally — update it, discard foreign UUID
+          const current = ltm.get(fuzzyMatch.id);
+          const metadata = withMarkerEnforcement(
+            current?.metadata ?? null,
+            entry.enforce,
+          );
           if (
             fuzzyMatch.title !== entry.title ||
-            ltm.get(fuzzyMatch.id)?.content !== entry.content
+            current?.content !== entry.content ||
+            JSON.stringify(current?.metadata ?? null) !==
+              JSON.stringify(metadata)
           ) {
-            ltm.update(fuzzyMatch.id, { content: entry.content });
+            ltm.update(fuzzyMatch.id, {
+              content: entry.content,
+              metadata,
+              replaceMetadata: true,
+            });
           }
         } else {
           // No workerProviderID/workerModelID — these are user-authored
@@ -667,6 +733,9 @@ function _importEntries(entries: ParsedFileEntry[], projectPath: string): void {
             scope: "project",
             crossProject: false,
             id: entry.id,
+            ...(entry.enforce !== undefined
+              ? { metadata: { enforce: entry.enforce } }
+              : {}),
           });
         }
       }
@@ -687,6 +756,9 @@ function _importEntries(entries: ParsedFileEntry[], projectPath: string): void {
           content: entry.content,
           scope: "project",
           crossProject: false,
+          ...(entry.enforce !== undefined
+            ? { metadata: { enforce: entry.enforce } }
+            : {}),
         });
       }
     }

--- a/packages/core/src/invariant-check.ts
+++ b/packages/core/src/invariant-check.ts
@@ -728,8 +728,10 @@ export function clusterHunks(
  * the invariant most likely to be violated (highest relevance per hunk).
  *
  * Algorithm:
- *  1. For each cluster representative, rank its invariants by relevance:
- *     ref-hits first (exact evidence), then cosine ≥ floor, descending.
+ *  1. For each cluster representative, rank its invariants by enforcement and
+ *     relevance: explicit strict/soft rules first, then ref-hits (exact
+ *     evidence), then cosine ≥ floor, descending. This reserves the bounded
+ *     budget for the rules that may actually gate a PR.
  *     Keep the top {@link PER_HUNK_INVARIANTS} (plus ALL ref-hits, which are
  *     never dropped — exact evidence must always be judged).
  *  2. Round-robin across representatives so early budget exhaustion still
@@ -769,8 +771,20 @@ export function selectCandidates(
         });
       }
     }
-    // Rank: ref-hits first, then descending cosine.
+    // Rank: explicit gate rules first, then ref-hits, then descending cosine.
     admitted.sort((a, b) => {
+      const rank = (candidate: Candidate): number => {
+        switch (enforcementLevel(invariants[candidate.invariantIdx].entry)) {
+          case "strict":
+            return 2;
+          case "soft":
+            return 1;
+          default:
+            return 0;
+        }
+      };
+      const rankDiff = rank(b) - rank(a);
+      if (rankDiff !== 0) return rankDiff;
       if (a.refHit !== b.refHit) return a.refHit ? -1 : 1;
       return b.similarity - a.similarity;
     });

--- a/packages/core/src/ltm.ts
+++ b/packages/core/src/ltm.ts
@@ -88,7 +88,9 @@ function parseMetadata(raw: string | null): KnowledgeMetadata | null {
 
 /** Stringify a metadata object for INSERT/UPDATE. `undefined` and empty objects
  *  both serialize to NULL so the column stays clean for entries that never opt in. */
-function stringifyMetadata(m: KnowledgeMetadata | undefined): string | null {
+function stringifyMetadata(
+  m: KnowledgeMetadata | null | undefined,
+): string | null {
   if (m == null) return null;
   const json = JSON.stringify(m);
   return json === "{}" ? null : json;
@@ -440,13 +442,10 @@ export function appendVersion(
     category?: string;
     isDeleted?: boolean;
     /**
-     * #627 Phase 2: stamp the NEW version with fresh provenance (the commit the
-     * edit/delete happened at). When omitted — or empty (`{}` → NULL via
-     * stringifyMetadata) — the prior version's metadata is forward-copied via
-     * `COALESCE(?, metadata)`, so a caller with no session gitHead (CLI import,
-     * dashboard delete) never wipes a previously-recorded commit anchor.
+     * Per-version metadata. Omit the property to forward-copy the current
+     * value; pass `null` or `{}` to clear it deliberately.
      */
-    metadata?: KnowledgeMetadata;
+    metadata?: KnowledgeMetadata | null;
   } = {},
 ): string | null {
   const newId = uuidv7();
@@ -487,7 +486,7 @@ export function appendVersion(
            logical_id, version, is_deleted, is_current)
          SELECT
             ?, tenant_id, project_id, COALESCE(?, category), COALESCE(?, title), COALESCE(?, content),
-           source_session, cross_project, created_at, ?, COALESCE(?, metadata), ${embSel}created_by,
+           source_session, cross_project, created_at, ?, CASE WHEN ? THEN ? ELSE metadata END, ${embSel}created_by,
            updated_by, sensitivity, promotion_status, promoted_at,
            approval_status, approved_by, approved_at, source_user_id, source_entry_id,
            last_accessed_at, worker_provider_id, worker_model_id,
@@ -500,8 +499,11 @@ export function appendVersion(
         overrides.title ?? null,
         overrides.content ?? null,
         now,
-        // #627 Phase 2: a non-empty override stamps the new version; NULL (absent
-        // or `{}`) makes COALESCE forward-copy the prior version's metadata.
+        // A missing property forwards the prior version. An explicit empty/null
+        // value clears it, which lets `.lore.md` remove an `enforce:` marker.
+        Object.hasOwn(overrides, "metadata") && overrides.metadata !== undefined
+          ? 1
+          : 0,
         stringifyMetadata(overrides.metadata),
         overrides.isDeleted ? 1 : 0,
         cur.id,
@@ -760,7 +762,13 @@ export function update(
      * appends a new version — a metric/sensitivity-only update mutates no version
      * row (A2 rows are immutable), so the existing gitHead correctly stands.
      */
-    metadata?: KnowledgeMetadata;
+    metadata?: KnowledgeMetadata | null;
+    /**
+     * Replace metadata from a canonical file import, even when content is
+     * unchanged. Ordinary callers retain the historical no-version-bump
+     * behavior for metadata-only re-observation.
+     */
+    replaceMetadata?: boolean;
   },
 ) {
   // A2 (#823): content is IMMUTABLE per version. A content change appends a new
@@ -796,11 +804,26 @@ export function update(
   const contentChanged =
     input.content !== undefined && cur != null && cur.content !== input.content;
   const titleChanged = effectiveTitle !== undefined;
-  if (contentChanged || titleChanged) {
+  const metadataChanged =
+    input.replaceMetadata === true &&
+    Object.hasOwn(input, "metadata") &&
+    JSON.stringify(cur.metadata) !== JSON.stringify(input.metadata ?? null);
+  if (contentChanged || titleChanged || metadataChanged) {
+    // Before `replaceMetadata`, an empty metadata object has always meant
+    // "no fresh provenance" and therefore forward-copies the current value.
+    // File imports explicitly opt into replacement so removing `enforce:` can
+    // clear just that marker without disturbing generic callers.
+    const metadataOverride = input.replaceMetadata
+      ? Object.hasOwn(input, "metadata")
+        ? { metadata: input.metadata }
+        : {}
+      : input.metadata && Object.keys(input.metadata).length > 0
+        ? { metadata: input.metadata }
+        : {};
     appendVersion(logicalId, {
       ...(effectiveTitle !== undefined ? { title: effectiveTitle } : {}),
       ...(input.content !== undefined ? { content: input.content } : {}),
-      metadata: input.metadata,
+      ...metadataOverride,
     });
     appended = true;
   }
@@ -884,7 +907,10 @@ export function remove(id: string, metadata?: KnowledgeMetadata) {
   // `lore why`); absent → forward-copies the entry's last commit anchor.
   const logicalId = logicalIdOf(id);
   if (!getByLogical(logicalId)) return; // already deleted or unknown — no-op
-  appendVersion(logicalId, { isDeleted: true, metadata });
+  appendVersion(logicalId, {
+    isDeleted: true,
+    ...(metadata !== undefined ? { metadata } : {}),
+  });
   // The row is NOT physically deleted, so FK ON DELETE CASCADE no longer fires —
   // clean cross-references explicitly, all keyed on the logical_id.
   // Capture the entities that lose a ref BEFORE the delete so their sync_rank

--- a/packages/core/test/agents-file.test.ts
+++ b/packages/core/test/agents-file.test.ts
@@ -186,6 +186,22 @@ describe("parseEntriesFromSection", () => {
     });
   });
 
+  test("extracts an explicit semantic-lint enforcement marker", () => {
+    const entries = parseEntriesFromSection(`
+### Gotcha
+
+<!-- lore:019505a1-7c00-7000-8000-1a2b3c4d5e6f enforce:soft -->
+* **Driver boundary**: db.ts must be the only node:sqlite importer
+`);
+
+    expect(entries).toEqual([
+      expect.objectContaining({
+        id: "019505a1-7c00-7000-8000-1a2b3c4d5e6f",
+        enforce: "soft",
+      }),
+    ]);
+  });
+
   test("extracts hand-written entries without markers (no id)", () => {
     const section = `
 ## Long-term Knowledge
@@ -1208,6 +1224,23 @@ describe("exportLoreFile", () => {
     expect(content).toContain(`<!-- lore:${id} -->`);
   });
 
+  test("exports a semantic-lint enforcement marker from entry metadata", () => {
+    const id = ltm.create({
+      projectPath: PROJECT,
+      category: "gotcha",
+      title: "Driver boundary",
+      content: "db.ts must be the only node:sqlite importer",
+      scope: "project",
+      metadata: { enforce: "soft", gitHead: "deadbee" },
+    });
+
+    exportLoreFile(PROJECT);
+
+    expect(readFile(LORE_FILE_PATH)).toContain(
+      `<!-- lore:${id} enforce:soft -->`,
+    );
+  });
+
   test("writes only a header when there are no entries", () => {
     exportLoreFile(PROJECT);
 
@@ -1368,6 +1401,36 @@ describe("importLoreFile", () => {
 
     const entry = ltm.getByLogical(id); // import edit appended a new version
     expect(entry?.content).toContain("API keys");
+  });
+
+  test("imports and removes an enforcement marker without dropping other metadata", () => {
+    const id = ltm.create({
+      projectPath: PROJECT,
+      category: "gotcha",
+      title: "Driver boundary",
+      content: "db.ts must be the only node:sqlite importer",
+      scope: "project",
+      metadata: { gitHead: "deadbee" },
+    });
+    writeFile(
+      `<!-- Managed by lore -->\n\n## Long-term Knowledge\n\n### Gotcha\n\n<!-- lore:${id} enforce:strict -->\n* **Driver boundary**: db.ts must be the only node:sqlite importer\n`,
+      LORE_FILE_PATH,
+    );
+
+    importLoreFile(PROJECT);
+    expect(ltm.getByLogical(id)?.metadata).toEqual({
+      enforce: "strict",
+      gitHead: "deadbee",
+    });
+
+    writeFile(
+      readFile(LORE_FILE_PATH).replace(" enforce:strict", ""),
+      LORE_FILE_PATH,
+    );
+    clearLoreFileCache(PROJECT);
+    importLoreFile(PROJECT);
+
+    expect(ltm.getByLogical(id)?.metadata).toEqual({ gitHead: "deadbee" });
   });
 
   test("handles hand-written entries (no UUID markers) in .lore.md", () => {

--- a/packages/core/test/invariant-check.test.ts
+++ b/packages/core/test/invariant-check.test.ts
@@ -755,7 +755,11 @@ describe("clusterHunks", () => {
 });
 
 describe("selectCandidates", () => {
-  function inv(refFiles: string[], vec: Float32Array | null): InvariantVec {
+  function inv(
+    refFiles: string[],
+    vec: Float32Array | null,
+    enforce?: "soft" | "strict",
+  ): InvariantVec {
     return {
       entry: {
         id: "x",
@@ -763,6 +767,7 @@ describe("selectCandidates", () => {
         title: "t",
         content: "c",
         confidence: 0.9,
+        ...(enforce ? { metadata: { enforce } } : {}),
       } as never,
       vec,
       refFiles: new Set(refFiles),
@@ -818,6 +823,20 @@ describe("selectCandidates", () => {
       cap: 2,
     });
     expect(sel.length).toBeLessThanOrEqual(2);
+  });
+
+  it("prioritizes explicit gate rules when the candidate budget is tight", () => {
+    const hunkVecs = [v(1, 0, 0)];
+    const clusters = clusterHunks(hunkVecs, 0.92);
+    const invariants = [inv([], v(1, 0, 0)), inv([], v(0.75, 0.25, 0), "soft")];
+
+    const selected = selectCandidates(clusters, hunkVecs, invariants, hunks, {
+      floor: 0.72,
+      cap: 1,
+    });
+
+    expect(selected).toHaveLength(1);
+    expect(selected[0].invariantIdx).toBe(1);
   });
 });
 

--- a/packages/gateway/src/cli/commands/lint.ts
+++ b/packages/gateway/src/cli/commands/lint.ts
@@ -16,6 +16,7 @@ type LintFlags = {
   effort?: ReasoningEffort;
   gate: boolean;
   "import-lore-md": boolean;
+  "prime-lore-db": boolean;
   "report-file"?: string;
   "deadline-ms": number;
   "candidate-timeout-ms": number;
@@ -83,6 +84,11 @@ export const lintCommand = buildOutputCommand<SemanticLintReport, LintFlags>({
         brief: "Import repository lore before linting",
         default: false,
       },
+      "prime-lore-db": {
+        kind: "boolean",
+        brief: "Import and embed repository lore even when no code changed",
+        default: false,
+      },
       "report-file": {
         kind: "parsed",
         parse: String,
@@ -116,6 +122,7 @@ export const lintCommand = buildOutputCommand<SemanticLintReport, LintFlags>({
       effort: flags.effort,
       gate: flags.gate,
       importLoreMd: flags["import-lore-md"],
+      primeLoreDb: flags["prime-lore-db"],
       deadlineMs: flags["deadline-ms"],
       candidateTimeoutMs: flags["candidate-timeout-ms"],
       onDiagnostic: (message) =>

--- a/packages/gateway/src/cli/invariant-check.ts
+++ b/packages/gateway/src/cli/invariant-check.ts
@@ -31,6 +31,8 @@ export interface SemanticLintOptions {
   effort?: ReasoningEffort;
   gate: boolean;
   importLoreMd: boolean;
+  /** Import and embed .lore.md even when the diff contains no code hunks. */
+  primeLoreDb?: boolean;
   deadlineMs: number;
   candidateTimeoutMs: number;
   onDiagnostic?: (message: string) => void;
@@ -170,10 +172,12 @@ export async function runSemanticLint(
     }
 
     const invariantSource: LintPhaseHealth = { status: "healthy" };
-    if (diff.hunks.length === 0) {
+    if (diff.hunks.length === 0 && !options.primeLoreDb) {
       // No changed code can violate an invariant. Preserve core's zero-work
       // contract without starting the gateway, importing .lore.md, or requiring
-      // an embedding provider merely because the action requested import.
+      // an embedding provider merely because the action requested import. Cache
+      // priming opts in to the import path explicitly so a .lore.md-only commit
+      // can populate the derived DB.
       phase = "invariantVectors";
       const result = await invariantCheck.checkInvariants({
         projectPath,
@@ -412,6 +416,7 @@ export async function commandInvariantCheck(
     effort: effort ?? undefined,
     gate: values.gate === true,
     importLoreMd: values["import-lore-md"] === true,
+    primeLoreDb: values["prime-lore-db"] === true,
     deadlineMs: Number(values["deadline-ms"] ?? 1_200_000),
     candidateTimeoutMs: Number(values["candidate-timeout-ms"] ?? 90_000),
     onDiagnostic: (message) => console.error(`[lore] ${message}`),

--- a/packages/gateway/test/invariant-check-orchestration.test.ts
+++ b/packages/gateway/test/invariant-check-orchestration.test.ts
@@ -246,6 +246,125 @@ describe("runSemanticLint cancellation", () => {
     expect(ensureEmbeddingReady).not.toHaveBeenCalled();
   });
 
+  it("primes .lore.md for a zero-hunk range only when requested", async () => {
+    const events: string[] = [];
+    const range = { base: "base", head: "head", source: "test" };
+    const ensureEmbeddingReady = vi.fn(async () => events.push("ready"));
+    const importLoreFile = vi.fn(() => events.push("import"));
+    const settleDocumentEmbeds = vi.fn(async () => events.push("settle"));
+    const backfillEmbeddings = vi.fn(async () => {
+      events.push("backfill");
+      return 1;
+    });
+    const checkInvariants = vi.fn(async () => {
+      events.push("check");
+      return {
+        range,
+        status: "complete" as const,
+        health: {
+          diff: { status: "healthy" as const, hunks: 0 },
+          invariantVectors: {
+            status: "healthy" as const,
+            expected: 1,
+            available: 1,
+            missing: 0,
+          },
+          hunkVectors: {
+            status: "healthy" as const,
+            expected: 0,
+            available: 0,
+            missing: 0,
+          },
+          judge: {
+            status: "healthy" as const,
+            selected: 0,
+            resolved: 0,
+            unresolved: 0,
+            notAttempted: 0,
+          },
+        },
+        hunks: 0,
+        invariants: 1,
+        candidates: 0,
+        attempted: 0,
+        resolved: 0,
+        unresolved: 0,
+        notAttempted: 0,
+        semanticCalls: 0,
+        transportAttempts: 0,
+        candidateOutcomes: [],
+        findings: [],
+      };
+    });
+    vi.doMock("node:fs", () => ({ existsSync: () => true }));
+    vi.doMock("@loreai/core", () => ({
+      config: () => ({
+        model: undefined,
+        invariantCheck: { effort: "off" },
+      }),
+      embedding: {
+        ensureEmbeddingReady,
+        settleDocumentEmbeds,
+        backfillEmbeddings,
+      },
+      importLoreFile,
+      invariantCheck: {
+        resolveRange: () => range,
+        parseDiffResult: () => ({ kind: "success", hunks: [] }),
+        checkInvariants,
+        collectCommitMessages: () => [],
+        parseOverrides: () => [],
+        gateDecision: () => ({
+          mode: "advisory",
+          exitCode: 0,
+          blocking: [],
+          overridden: [],
+          advisory: [],
+        }),
+      },
+      parseReasoningEffort: vi.fn(),
+    }));
+    vi.doMock("../src/llm-adapter", () => ({
+      createGatewayLLMClient: vi.fn(() => ({})),
+      createGatewayInvariantJudge: vi.fn(() => ({})),
+    }));
+    vi.doMock("../src/cli/start", () => ({
+      startGateway: async () => {
+        events.push("gateway");
+        return {
+          owned: true,
+          config: {
+            workerApiKey: undefined,
+            upstreamAnthropic: "http://anthropic.test",
+            upstreamOpenAI: "http://openai.test",
+          },
+          shutdown: async () => events.push("cleanup"),
+        };
+      },
+    }));
+
+    const { runSemanticLint } = await import("../src/cli/invariant-check");
+    const report = await runSemanticLint({
+      project: ".",
+      gate: false,
+      importLoreMd: true,
+      primeLoreDb: true,
+      deadlineMs: 1_000,
+      candidateTimeoutMs: 100,
+    });
+
+    expect(report.status).toBe("complete");
+    expect(events).toEqual([
+      "gateway",
+      "ready",
+      "import",
+      "settle",
+      "backfill",
+      "check",
+      "cleanup",
+    ]);
+  });
+
   it("reports readiness failure before import and cleanup", async () => {
     const events: string[] = [];
     const range = { base: "base", head: "head", source: "test" };

--- a/packages/gateway/test/lint-action-report.test.ts
+++ b/packages/gateway/test/lint-action-report.test.ts
@@ -544,6 +544,9 @@ describe("semantic lint action reporter", () => {
     expect(action).toContain("actions/cache/restore@v5");
     expect(action).toContain("actions/cache/save@v5");
     expect(action).toContain("inputs.cache-mode == 'save'");
+    expect(action).toContain("--prime-lore-db");
+    expect(action).toContain('test -s "$LORE_DB_PATH"');
+    expect(action).toContain("steps.cache-db.outputs.ready == 'true'");
     expect(action).toContain("--report-file");
     expect(action).toContain("if: always()");
     expect(action).toContain(
@@ -1165,7 +1168,7 @@ describe("semantic lint action reporter", () => {
       "github-token: ${{ secrets.LORE_WORKER_API_KEY != '' && vars.LORE_INVARIANT_MODEL != '' && '' || github.token }}",
     );
     expect(workflow).toMatch(
-      /permissions:\n  actions: write\n  contents: read\n  pull-requests: read\n  copilot-requests: write\n\njobs:/,
+      /permissions:\n  actions: read\n  contents: read\n  pull-requests: read\n  copilot-requests: write\n\njobs:/,
     );
     expect(workflow).not.toMatch(/^\s+pull_request:\s*$/m);
 

--- a/packages/gateway/test/lint-action-report.test.ts
+++ b/packages/gateway/test/lint-action-report.test.ts
@@ -540,6 +540,10 @@ describe("semantic lint action reporter", () => {
     const action = readFileSync(join(actionDirectory, "action.yml"), "utf8");
     expect(action).toContain('default: "1200"');
     expect(action).toContain('default: "90"');
+    expect(action).toContain('default: "restore"');
+    expect(action).toContain("actions/cache/restore@v5");
+    expect(action).toContain("actions/cache/save@v5");
+    expect(action).toContain("inputs.cache-mode == 'save'");
     expect(action).toContain("--report-file");
     expect(action).toContain("if: always()");
     expect(action).toContain(
@@ -1144,7 +1148,12 @@ describe("semantic lint action reporter", () => {
     expect(workflow).toContain(
       "head: ${{ github.event.pull_request.head.sha }}",
     );
-    expect(workflow).toContain("continue-on-error: true");
+    expect(workflow).toContain(
+      "continue-on-error: ${{ vars.LORE_SEMANTIC_LINT_GATE != 'true' }}",
+    );
+    expect(workflow).toContain(
+      "gate: ${{ vars.LORE_SEMANTIC_LINT_GATE == 'true' }}",
+    );
     expect(workflow).toContain("pull_request_target:");
     expect(workflow).toContain(
       "model: ${{ secrets.LORE_WORKER_API_KEY != '' && vars.LORE_INVARIANT_MODEL != '' && vars.LORE_INVARIANT_MODEL || 'github-copilot/gpt-5.6-luna' }}",
@@ -1159,6 +1168,19 @@ describe("semantic lint action reporter", () => {
       /permissions:\n  actions: write\n  contents: read\n  pull-requests: read\n  copilot-requests: write\n\njobs:/,
     );
     expect(workflow).not.toMatch(/^\s+pull_request:\s*$/m);
+
+    const primeWorkflow = readFileSync(
+      resolve(actionDirectory, "../../workflows/semantic-linter-cache.yml"),
+      "utf8",
+    );
+    expect(primeWorkflow).toContain("push:");
+    expect(primeWorkflow).toContain("branches: [main]");
+    expect(primeWorkflow).toContain(
+      '".github/workflows/semantic-linter-cache.yml"',
+    );
+    expect(primeWorkflow).toContain("cache-mode: save");
+    expect(primeWorkflow).toContain("actions: write");
+    expect(primeWorkflow).toContain("copilot-requests: write");
   });
 
   test("published workflow guide preserves trusted credential/model pairing", () => {
@@ -1177,6 +1199,8 @@ describe("semantic lint action reporter", () => {
     expect(guide).toContain("github-token:");
     expect(guide).toContain("official Copilot SDK bridge");
     expect(guide).toContain("copilot-requests: write");
+    expect(guide).toContain("LORE_SEMANTIC_LINT_GATE");
+    expect(guide).toContain("enforce:soft");
     expect(guide).not.toMatch(/^\s+pull_request:\s*$/m);
   });
 });

--- a/packages/website/src/content/docs/docs/guides/semantic-linter.md
+++ b/packages/website/src/content/docs/docs/guides/semantic-linter.md
@@ -39,7 +39,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  actions: write
+  actions: read
   contents: read
   pull-requests: read
   copilot-requests: write
@@ -88,7 +88,7 @@ jobs:
 
 Open a PR and the check runs, posting any suspected contradictions as annotations plus a job summary. The reference workflow passes a 20-minute overall deadline and a 90-second per-candidate timeout, leaving five minutes for report publication and gateway shutdown.
 
-PR runs restore a derived invariant database but never write it. Copy the repository's `semantic-linter-cache.yml` too: it primes that cache on trusted `main` changes, avoiding forbidden cache-save attempts from `pull_request_target` runs.
+PR runs restore a derived invariant database but never write it. Copy the repository's `semantic-linter-cache.yml` too: it primes that cache on trusted `main` changes, including commits that change only `.lore.md`, avoiding forbidden cache-save attempts from `pull_request_target` runs.
 
 :::caution
 Use `pull_request_target` only with the trusted-base checkout pattern above. The workflow executes the base revision's code and fetches the PR head solely as immutable diff data, so the judge secret is never exposed to code supplied by the pull request.

--- a/packages/website/src/content/docs/docs/guides/semantic-linter.md
+++ b/packages/website/src/content/docs/docs/guides/semantic-linter.md
@@ -7,10 +7,10 @@ sidebar:
 
 Your team's decisions, patterns, and gotchas live in [`.lore.md`](/docs/team-memory/), a version-controlled record of how this codebase is supposed to work. The **semantic linter** reads that record and, on every pull request, flags changes that appear to contradict it.
 
-It is a judge, not a rule engine. Instead of matching regexes, it asks an LLM whether a specific diff hunk conflicts with a specific documented invariant, and surfaces the ones that do as GitHub annotations. It is **advisory by default: findings and health failures do not fail the build.** A human decides what to do with each finding. Gate mode fails closed when the run is inconclusive.
+It is a judge, not a rule engine. Instead of matching regexes, it asks an LLM whether a specific diff hunk conflicts with a specific documented invariant, and surfaces the ones that do as GitHub annotations. It is **advisory by default: findings and health failures do not fail the build.** A human decides what to do with each finding. A repository can deliberately promote calibrated rules to gate mode, which fails closed when the run is inconclusive.
 
 ```
-✓ no suspected invariant violations (45 hunks × 67 invariants → 20 candidates → 20 judge calls)
+✓ no suspected invariant violations among selected candidates (45 hunks × 67 invariants → 20 candidates → 20 judge calls)
 ```
 
 ## What it is good for
@@ -19,7 +19,7 @@ It is a judge, not a rule engine. Instead of matching regexes, it asks an LLM wh
 - Turning tribal knowledge in `.lore.md` into a check that runs whether or not the person who wrote the rule is reviewing.
 - Doing this cheaply. Most hunk/invariant pairs are eliminated before any model is called (see [How it works](#how-it-works)).
 
-It is **not** a replacement for tests, type checking, or a linter. It has no ground truth; it produces suspicions for humans, so it runs alongside your real gates and never blocks them.
+It is **not** a replacement for tests, type checking, or a linter. It has no ground truth; promote only narrowly scoped, calibrated rules and keep the rest advisory.
 
 ## Quick start (GitHub Actions)
 
@@ -28,7 +28,7 @@ The repository ships a reusable composite action and a reference workflow. It us
 Add `.github/workflows/semantic-linter.yml`:
 
 ```yaml
-name: Semantic linter (advisory)
+name: Semantic linter
 
 on:
   pull_request_target:
@@ -39,6 +39,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
+  actions: write
   contents: read
   pull-requests: read
   copilot-requests: write
@@ -47,7 +48,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     timeout-minutes: 25
-    continue-on-error: true # advisory: never block a PR
+    # Set this protected repository variable only after calibration.
+    continue-on-error: ${{ vars.LORE_SEMANTIC_LINT_GATE != 'true' }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -81,9 +83,12 @@ jobs:
           model: ${{ secrets.LORE_WORKER_API_KEY != '' && vars.LORE_INVARIANT_MODEL != '' && vars.LORE_INVARIANT_MODEL || 'github-copilot/gpt-5.6-luna' }}
           worker-api-key: ${{ secrets.LORE_WORKER_API_KEY != '' && vars.LORE_INVARIANT_MODEL != '' && secrets.LORE_WORKER_API_KEY || '' }}
           github-token: ${{ secrets.LORE_WORKER_API_KEY != '' && vars.LORE_INVARIANT_MODEL != '' && '' || github.token }}
+          gate: ${{ vars.LORE_SEMANTIC_LINT_GATE == 'true' }}
 ```
 
 Open a PR and the check runs, posting any suspected contradictions as annotations plus a job summary. The reference workflow passes a 20-minute overall deadline and a 90-second per-candidate timeout, leaving five minutes for report publication and gateway shutdown.
+
+PR runs restore a derived invariant database but never write it. Copy the repository's `semantic-linter-cache.yml` too: it primes that cache on trusted `main` changes, avoiding forbidden cache-save attempts from `pull_request_target` runs.
 
 :::caution
 Use `pull_request_target` only with the trusted-base checkout pattern above. The workflow executes the base revision's code and fetches the PR head solely as immutable diff data, so the judge secret is never exposed to code supplied by the pull request.
@@ -133,6 +138,8 @@ The check is a three-stage funnel designed so the expensive stage runs as rarely
 3. **LLM judge.** The surviving candidates (capped at 20 per run) are sent to the judge one pair at a time: *does this hunk contradict this invariant?* Only these calls cost tokens.
 
 The funnel line in the report (`N hunks × M invariants → C candidates → J judge calls`) shows how aggressively each stage narrowed the work.
+
+On a wide PR, the cap means a complete, clean report says none of the **selected** candidates looked contradictory; it is not proof that every possible hunk/invariant pair was examined. Split broad changes before relying on an enforced rule.
 
 ### Where the invariants come from
 
@@ -212,8 +219,20 @@ A graduated ladder is designed above advisory:
 - **soft**: an overridable gate. A finding blocks unless the PR author adds a `lore-override: <invariant> — <reason>` trailer to a commit in the range.
 - **strict**: a hard gate that cannot be overridden.
 
-An invariant only escalates past advisory when its author explicitly opts it in (an `enforce` marker), and enumeration invariants are always capped at advisory regardless. The `--gate` flag (and the action's `gate` input) is the switch that makes soft/strict findings blocking.
+An invariant only escalates past advisory when its author explicitly opts it in on its marker. Enumeration invariants are always capped at advisory regardless. The `--gate` flag (and the action's `gate` input) is the switch that makes soft/strict findings blocking.
 
-:::note
-The gate/override machinery exists in the judge, but there is not yet an authoring path to set the `enforce` opt-in through `.lore.md`, so the CI check currently gates on nothing: every finding is advisory in practice. Treat gate mode as forthcoming. Use the advisory tier today and let a team tune the false-positive rate before any gate is turned on.
-:::
+```markdown
+<!-- lore:019e18ec-e328-76c4-9c3c-09dbe8d51c6c enforce:soft -->
+* **SQLite driver boundary**: `node:sqlite` must only be imported by packages/core/src/db.ts.
+```
+
+Use `enforce:soft`, `enforce:strict`, or `enforce:off`; omit it for advisory. Lore preserves the marker on export and imports it into the entry metadata. `soft` can be overridden with a `lore-override: <invariant> — <reason>` commit trailer; `strict` cannot.
+
+### Promoting a rule to a gate
+
+1. Leave a new rule advisory and review its findings across several representative PRs, including refactors and test-only changes.
+2. Make the rule narrow, prescriptive, and anchored to a file path or symbol; never promote a broad architectural summary or an enumeration.
+3. Add `enforce:soft` first. After confirming that its findings are actionable, set the protected repository variable `LORE_SEMANTIC_LINT_GATE` to `true`.
+4. Use `strict` only for a small rule that has already demonstrated a negligible false-positive rate. A partial or failed run blocks in gate mode by design.
+
+The supplied workflow reads that variable from the trusted base repository. With the variable absent or anything other than `true`, it remains advisory; this makes rollout reversible without accepting a PR-controlled gate switch.


### PR DESCRIPTION
## Summary

- make PR semantic-lint cache restore-only and prime the derived DB on trusted `main` changes
- add `.lore.md` `enforce:soft|strict|off` marker round-tripping and a protected gate-promotion switch
- prioritize explicit gate rules under the judge cap and clarify selected-candidate coverage in CI/docs

## Validation

- `vitest run packages/core/test/agents-file.test.ts packages/core/test/ltm-metadata.test.ts packages/core/test/invariant-check.test.ts packages/gateway/test/lint-action-report.test.ts` (231 passing)
- `pnpm run typecheck`
- `pnpm run format:check`
- changed-source `oxlint --type-aware`
- YAML parse and `git diff --check`

## Full-suite note

The full suite was started after an equivalent no-IPC gateway bundle (the normal `tsx` pretest IPC socket is blocked by this sandbox). It exposed unrelated existing failures in `compact-endpoint-integration`, `install-script`, `cache-stability.e2e`, and `vendor-ort-native`; the run was stopped after those failures.