### PR TITLE
fix(perf): reuse exact provenance token counts across restarts

### DIFF
--- a/packages/core/src/data.ts
+++ b/packages/core/src/data.ts
@@ -654,6 +654,10 @@ export function clearProject(projectPath: string): ClearResult {
   // Delete in dependency order
   database.exec("BEGIN IMMEDIATE");
   try {
+    // Preparation may publish derived counts before any temporal row exists.
+    database
+      .query("DELETE FROM semantic_token_cache WHERE project_id = ?")
+      .run(pid);
     database
       .query("DELETE FROM session_prompt_deltas WHERE project_id = ?")
       .run(pid);

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -2058,6 +2058,18 @@ export const MIGRATIONS: readonly string[] = Object.freeze([
   CREATE INDEX IF NOT EXISTS idx_temporal_embedding_queue_enqueued
     ON temporal_embedding_queue(enqueued_at, message_id);
   `,
+  `
+  -- Version 86: bounded local derived token counts; no transcript or vectors.
+  CREATE TABLE IF NOT EXISTS semantic_token_cache (
+    project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    session_id TEXT NOT NULL REFERENCES session_state(session_id) ON DELETE CASCADE,
+    payload TEXT NOT NULL CHECK(length(payload) <= 1000000),
+    updated_at INTEGER NOT NULL,
+    PRIMARY KEY (project_id, session_id)
+  );
+  CREATE INDEX IF NOT EXISTS idx_semantic_token_cache_updated
+    ON semantic_token_cache(updated_at);
+  `,
 ]);
 
 // Index of the migration whose work is performed by a column-presence-aware JS
@@ -2927,6 +2939,10 @@ export function dbPath(): string {
 }
 
 let instance: Database | undefined;
+/** Read-only identity check for deferred derived-cache writes; never opens a DB. */
+export function isCurrentDatabase(connection: Database): boolean {
+  return instance === connection;
+}
 /** Actual file backing `instance`; absent for private in-memory databases. */
 let instanceFilePath: string | undefined;
 
@@ -4113,6 +4129,17 @@ function recoverMissingObjects(database: Database) {
     CREATE INDEX IF NOT EXISTS idx_temporal_embedding_queue_enqueued
       ON temporal_embedding_queue(enqueued_at, message_id);
   `);
+  database.exec(`
+    CREATE TABLE IF NOT EXISTS semantic_token_cache (
+      project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+      session_id TEXT NOT NULL REFERENCES session_state(session_id) ON DELETE CASCADE,
+      payload TEXT NOT NULL CHECK(length(payload) <= 1000000),
+      updated_at INTEGER NOT NULL,
+      PRIMARY KEY (project_id, session_id)
+    );
+    CREATE INDEX IF NOT EXISTS idx_semantic_token_cache_updated
+      ON semantic_token_cache(updated_at);
+  `);
   // Version 54: knowledge_session_injections.verdict (outcome impact, #497).
   // The verdict-keyed index MUST be created here, AFTER the column is ensured —
   // never in the big exec above, which runs before this ALTER and would throw
@@ -4234,6 +4261,7 @@ export const PROJECT_MERGE_TABLES = Object.freeze([
   "project_id_aliases",
   "project_path_aliases",
   "session_prompt_deltas",
+  "semantic_token_cache", // Disposable; source-project deletion cascades it away.
   "session_rollup",
   "temporal_messages",
   "temporal_vec",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -343,6 +343,7 @@ export {
 } from "./vec-latency";
 export { distillLimiter, curatorLimiter } from "./session-limiter";
 export { estimateTokens, encodingForModel } from "./tokenize";
+export { SemanticTokenCache } from "./semantic-token-cache";
 export {
   installFetchInterceptor,
   shouldIntercept,

--- a/packages/core/src/semantic-token-cache.ts
+++ b/packages/core/src/semantic-token-cache.ts
@@ -1,0 +1,178 @@
+import { createHash } from "node:crypto";
+import { db, isCurrentDatabase, projectId, withSavepoint } from "./db";
+import { currentTenantId } from "./tenant";
+import { estimateTokens, TOKEN_ESTIMATE_CACHE_VERSION } from "./tokenize";
+
+const VERSION = `${TOKEN_ESTIMATE_CACHE_VERSION}:hidden-input-v1`;
+export const SEMANTIC_TOKEN_CACHE_MAX_ENTRIES = 8192;
+export const SEMANTIC_TOKEN_CACHE_MAX_SESSIONS = 64;
+const MAX_PAYLOAD = 1_000_000;
+const digest = (text: string) =>
+  createHash("sha256").update(text).digest("hex");
+
+/**
+ * Exact, disposable derived counts. This is NOT an ingestion frontier: saving
+ * it cannot claim that a source message or response has been persisted.
+ * Only hashes and integers survive the request. Current wire content always
+ * remains authoritative; all bytes are checked, including encrypted data.
+ */
+export class SemanticTokenCache {
+  readonly stats = {
+    hits: 0,
+    misses: 0,
+    bpe_bytes: 0,
+    bpe_ms: 0,
+    unavailable: 0,
+  };
+  private readonly entries = new Map<string, number>();
+  private readonly used = new Map<string, number>();
+  private readonly tenant = currentTenantId();
+  private pid?: string;
+  private readonly connection: ReturnType<typeof db> | undefined;
+  private revision?: { changes: number; data_version: number };
+
+  constructor(
+    private readonly scope: {
+      projectPath: string;
+      sessionID: string;
+      noStore: boolean;
+    },
+  ) {
+    if (scope.noStore) return;
+    try {
+      this.connection = db();
+      this.pid = projectId(scope.projectPath);
+      if (!this.pid) return;
+      this.revision = this.connection
+        .query(
+          "SELECT total_changes() AS changes, data_version FROM pragma_data_version",
+        )
+        .get() as { changes: number; data_version: number };
+      const row = this.connection
+        .query(
+          "SELECT payload FROM semantic_token_cache WHERE project_id = ? AND session_id = ? AND length(payload) <= ?",
+        )
+        .get(this.pid, scope.sessionID, MAX_PAYLOAD) as {
+        payload: string;
+      } | null;
+      if (!row) return;
+      const decoded: unknown = JSON.parse(row.payload);
+      if (
+        !Array.isArray(decoded) ||
+        decoded.length !== 3 ||
+        decoded[0] !== VERSION ||
+        !Array.isArray(decoded[1]) ||
+        decoded[1].length > SEMANTIC_TOKEN_CACHE_MAX_ENTRIES
+      )
+        return;
+      const data: unknown[] = decoded[1];
+      if (decoded[2] !== digest(JSON.stringify(data))) return;
+      for (const entry of data) {
+        if (
+          !Array.isArray(entry) ||
+          entry.length !== 2 ||
+          typeof entry[0] !== "string" ||
+          !/^[a-f0-9]{64}$/.test(entry[0]) ||
+          !Number.isSafeInteger(entry[1]) ||
+          entry[1] < 0
+        ) {
+          this.entries.clear();
+          return;
+        }
+        this.entries.set(entry[0], entry[1]);
+      }
+    } catch {
+      // Cache damage or unavailable storage must never fail a foreground turn.
+      this.entries.clear();
+      this.stats.unavailable++;
+    }
+  }
+
+  count(visibleJson: string, provenanceJson: string): number {
+    // Length framing prevents (a, bc) colliding with (ab, c). Existing source
+    // IDs intentionally omit some fields and are unsuitable for cache keys.
+    const key = createHash("sha256")
+      .update(`${visibleJson.length}:`)
+      .update(visibleJson)
+      .update(provenanceJson)
+      .digest("hex");
+    let value = this.used.get(key) ?? this.entries.get(key);
+    if (value === undefined) {
+      this.stats.misses++;
+      this.stats.bpe_bytes +=
+        Buffer.byteLength(visibleJson) + Buffer.byteLength(provenanceJson);
+      const started = performance.now();
+      value = Math.max(
+        0,
+        estimateTokens(provenanceJson) - estimateTokens(visibleJson),
+      );
+      this.stats.bpe_ms += performance.now() - started;
+    } else this.stats.hits++;
+    this.used.delete(key);
+    this.used.set(key, value);
+    if (this.used.size > SEMANTIC_TOKEN_CACHE_MAX_ENTRIES)
+      this.used.delete(this.used.keys().next().value!);
+    return value;
+  }
+
+  persist(): void {
+    if (
+      this.scope.noStore ||
+      !this.connection ||
+      !this.pid ||
+      !this.revision ||
+      !this.used.size
+    )
+      return;
+    try {
+      // Do not publish into a replacement connection/generation or owner.
+      if (
+        !isCurrentDatabase(this.connection) ||
+        currentTenantId() !== this.tenant
+      )
+        return;
+      const data = [...this.used];
+      const payload = JSON.stringify([
+        VERSION,
+        data,
+        digest(JSON.stringify(data)),
+      ]);
+      if (payload.length > MAX_PAYLOAD) return;
+      const { timeout } = this.connection
+        .query("PRAGMA busy_timeout")
+        .get() as { timeout: number };
+      this.connection.exec("PRAGMA busy_timeout = 0");
+      try {
+        withSavepoint("semantic_token_cache", () => {
+          // The INSERT acquires the writer lock before checking local writes and
+          // external commits. Even deletion followed by same-ID recreation makes
+          // this request obsolete; dropping disposable counts is always safe.
+          const result =
+            this.connection!.query(`INSERT INTO semantic_token_cache (project_id, session_id, payload, updated_at)
+          SELECT p.id, s.session_id, ?, ? FROM projects p, session_state s
+          WHERE p.id = ? AND p.tenant_id = ? AND s.session_id = ?
+            AND total_changes() = ? AND (SELECT data_version FROM pragma_data_version) = ?
+          ON CONFLICT(project_id, session_id) DO UPDATE SET payload = excluded.payload, updated_at = excluded.updated_at`).run(
+              payload,
+              Date.now(),
+              this.pid!,
+              this.tenant,
+              this.scope.sessionID,
+              this.revision!.changes,
+              this.revision!.data_version,
+            );
+          if (!result.changes) return;
+          // Globally bounded disposable cache. Eviction only incurs recomputation.
+          this.connection!.query(`DELETE FROM semantic_token_cache WHERE rowid IN
+          (SELECT rowid FROM semantic_token_cache ORDER BY updated_at DESC, rowid DESC LIMIT -1 OFFSET ?)`).run(
+            SEMANTIC_TOKEN_CACHE_MAX_SESSIONS,
+          );
+        });
+      } finally {
+        this.connection.exec(`PRAGMA busy_timeout = ${timeout}`);
+      }
+    } catch {
+      this.stats.unavailable++;
+    }
+  }
+}

--- a/packages/core/src/tokenize.ts
+++ b/packages/core/src/tokenize.ts
@@ -27,6 +27,10 @@ import * as claude_encoding from "ai-tokenizer/encoding/claude";
 
 export type EncodingName = "cl100k_base" | "o200k_base" | "claude";
 
+// Durable derived counts must miss after an encoding/tokenizer-policy change.
+// The contract test checks this against the installed tokenizer version.
+export const TOKEN_ESTIMATE_CACHE_VERSION = "ai-tokenizer@1.0.6:cl100k_base:v1";
+
 const cache = new Map<EncodingName, Tokenizer>();
 cache.set("cl100k_base", new Tokenizer(cl100k_base_encoding));
 

--- a/packages/core/test/semantic-token-cache.test.ts
+++ b/packages/core/test/semantic-token-cache.test.ts
@@ -1,0 +1,346 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import {
+  close,
+  db,
+  ensureProject,
+  saveSessionTracking,
+  MIGRATIONS,
+  isCurrentDatabase,
+  mergeProjectInternal,
+} from "../src/db";
+import { withTenant } from "../src/tenant";
+import { clearProject, deleteSession } from "../src/data";
+import {
+  SemanticTokenCache,
+  SEMANTIC_TOKEN_CACHE_MAX_ENTRIES,
+  SEMANTIC_TOKEN_CACHE_MAX_SESSIONS,
+} from "../src/semantic-token-cache";
+import * as tokenize from "../src/tokenize";
+
+const scope = {
+  projectPath: "/test/token-cache",
+  sessionID: "token-session",
+  noStore: false,
+};
+const visible = '[{"type":"text","text":"public projection"}]';
+const provenance =
+  '[{"type":"opaque","raw":{"encrypted_content":"synthetic private reasoning AABCD123456789"}}]';
+function parent(s = scope) {
+  ensureProject(s.projectPath);
+  saveSessionTracking(s.sessionID, {});
+}
+function fill(s = scope) {
+  const cache = new SemanticTokenCache(s);
+  cache.count(visible, provenance);
+  cache.persist();
+  return cache;
+}
+function payload() {
+  return (
+    db().query("SELECT payload FROM semantic_token_cache").get() as {
+      payload: string;
+    }
+  ).payload;
+}
+beforeEach(() => {
+  db().exec("DELETE FROM semantic_token_cache");
+  parent();
+});
+afterEach(() => vi.restoreAllMocks());
+
+describe("exact derived provenance counts", () => {
+  it("pins the persistent algorithm key to the installed tokenizer", () => {
+    const entry = createRequire(import.meta.url).resolve("ai-tokenizer");
+    const pkg = JSON.parse(
+      readFileSync(join(dirname(dirname(entry)), "package.json"), "utf8"),
+    );
+    expect(tokenize.TOKEN_ESTIMATE_CACHE_VERSION).toContain(
+      `ai-tokenizer@${pkg.version}:cl100k_base:`,
+    );
+  });
+
+  it("survives a database close/reopen without retaining source content", () => {
+    const first = fill();
+    const saved = payload();
+    expect(saved).not.toContain("public projection");
+    expect(saved).not.toContain("private reasoning");
+    close();
+    const count = vi.spyOn(tokenize, "estimateTokens");
+    const next = new SemanticTokenCache(scope);
+    expect(next.count(visible, provenance)).toBeGreaterThanOrEqual(0);
+    expect(count).not.toHaveBeenCalled();
+    expect(first.stats.misses).toBe(1);
+    expect(next.stats.hits).toBe(1);
+  });
+
+  it.each([
+    [visible, provenance, visible + " ", provenance],
+    [visible, provenance, visible, provenance + " "],
+    [
+      '[{"type":"thinking","signature":"a"}]',
+      provenance,
+      '[{"type":"thinking","signature":"b"}]',
+      provenance,
+    ],
+    [
+      '[{"type":"tool_result","isError":false}]',
+      provenance,
+      '[{"type":"tool_result","isError":true}]',
+      provenance,
+    ],
+    [
+      visible,
+      JSON.stringify([{ raw: { data: "x".repeat(128) + "old tail" } }]),
+      visible,
+      JSON.stringify([{ raw: { data: "x".repeat(128) + "new tail" } }]),
+    ],
+    [visible, provenance, visible, provenance.replace("AABCD", "ZZBCD")],
+  ])("recomputes on every full-content difference (%#)", (oldV, oldP, v, p) => {
+    const first = new SemanticTokenCache(scope);
+    first.count(oldV, oldP);
+    first.persist();
+    const estimate = vi.spyOn(tokenize, "estimateTokens");
+    const cache = new SemanticTokenCache(scope);
+    const result = cache.count(v, p);
+    expect(estimate).toHaveBeenCalledTimes(2);
+    expect(result).toBe(
+      Math.max(0, tokenize.estimateTokens(p) - tokenize.estimateTokens(v)),
+    );
+    expect(cache.stats.misses).toBe(1);
+  });
+
+  it("uses framed input pairs and retains exact zero counts", () => {
+    const cache = new SemanticTokenCache(scope);
+    const count = vi.spyOn(tokenize, "estimateTokens");
+    expect(cache.count("abcd", "")).toBe(0);
+    cache.count("ab", "cd");
+    expect(cache.stats.misses).toBe(2);
+    count.mockClear();
+    expect(cache.count("abcd", "")).toBe(0);
+    expect(count).not.toHaveBeenCalled();
+  });
+
+  it("isolates the same session and source bytes across tenants and projects", () => {
+    fill();
+    const other = { ...scope, projectPath: "/test/other-token-project" };
+    parent(other);
+    expect(fill(other).stats.misses).toBe(1);
+    withTenant("other-tenant", () => {
+      parent();
+      expect(fill().stats.misses).toBe(1);
+    });
+    expect(
+      new SemanticTokenCache(scope).count(visible, provenance),
+    ).toBeGreaterThanOrEqual(0);
+    expect(
+      (
+        db().query("SELECT COUNT(*) AS n FROM semantic_token_cache").get() as {
+          n: number;
+        }
+      ).n,
+    ).toBe(3);
+  });
+
+  it("never reads or writes a durable cache in no-store mode", () => {
+    fill();
+    const before = db().query("SELECT total_changes() AS n").get();
+    const cache = fill({ ...scope, noStore: true });
+    expect(cache.stats.misses).toBe(1);
+    expect(db().query("SELECT total_changes() AS n").get()).toEqual(before);
+  });
+
+  it.each(["json", "checksum", "version", "entry", "oversize"])(
+    "treats %s corruption as a miss",
+    (kind) => {
+      fill();
+      const envelope = JSON.parse(payload());
+      if (kind === "checksum") envelope[1][0][1] += 1;
+      if (kind === "version") envelope[0] = "future-tokenizer";
+      if (kind === "entry") {
+        envelope[1][0][1] = -1;
+        envelope[2] = createHash("sha256")
+          .update(JSON.stringify(envelope[1]))
+          .digest("hex");
+      }
+      if (kind === "oversize")
+        envelope[1] = Array.from(
+          { length: SEMANTIC_TOKEN_CACHE_MAX_ENTRIES + 1 },
+          () => ["a", 0],
+        );
+      db()
+        .query("UPDATE semantic_token_cache SET payload = ?")
+        .run(kind === "json" ? "{" : JSON.stringify(envelope));
+      expect(fill().stats.misses).toBe(1);
+    },
+  );
+
+  it("bounds per-request and persisted entries, retaining recent inputs", () => {
+    const count = vi.spyOn(tokenize, "estimateTokens").mockReturnValue(1);
+    const cache = new SemanticTokenCache(scope);
+    for (let i = 0; i < SEMANTIC_TOKEN_CACHE_MAX_ENTRIES + 3; i++)
+      cache.count("", String(i));
+    cache.persist();
+    expect(JSON.parse(payload())[1]).toHaveLength(
+      SEMANTIC_TOKEN_CACHE_MAX_ENTRIES,
+    );
+    const next = new SemanticTokenCache(scope);
+    count.mockClear();
+    next.count("", String(SEMANTIC_TOKEN_CACHE_MAX_ENTRIES + 2));
+    expect(count).not.toHaveBeenCalled();
+    next.count("", "0");
+    expect(count).toHaveBeenCalledTimes(2);
+  });
+
+  it("bounds persisted session caches", () => {
+    for (let i = 0; i < SEMANTIC_TOKEN_CACHE_MAX_SESSIONS + 2; i++) {
+      const s = { ...scope, sessionID: `bounded-${i}` };
+      parent(s);
+      fill(s);
+    }
+    expect(
+      db().query("SELECT COUNT(*) AS n FROM semantic_token_cache").get(),
+    ).toEqual({ n: SEMANTIC_TOKEN_CACHE_MAX_SESSIONS });
+  });
+
+  it("does not resurrect deleted projects or sessions from a pending write", () => {
+    const pending = new SemanticTokenCache(scope);
+    pending.count(visible, provenance);
+    deleteSession(scope.projectPath, scope.sessionID);
+    pending.persist();
+    expect(
+      db().query("SELECT COUNT(*) AS n FROM semantic_token_cache").get(),
+    ).toEqual({ n: 0 });
+    expect(
+      db()
+        .query("SELECT session_id FROM session_state WHERE session_id = ?")
+        .get(scope.sessionID),
+    ).toBeNull();
+  });
+
+  it("does not reopen a closed database for a delayed write", () => {
+    const connection = db();
+    const pending = new SemanticTokenCache(scope);
+    pending.count(visible, provenance);
+    close();
+    pending.persist();
+    expect(isCurrentDatabase(connection)).toBe(false);
+    expect(
+      db().query("SELECT COUNT(*) AS n FROM semantic_token_cache").get(),
+    ).toEqual({ n: 0 });
+  });
+
+  it("clears pre-response derived data and rejects an outstanding publication", () => {
+    fill();
+    const pending = new SemanticTokenCache(scope);
+    pending.count(visible, provenance);
+    expect(
+      db().query("SELECT COUNT(*) AS n FROM temporal_messages").get(),
+    ).toEqual({ n: 0 });
+    clearProject(scope.projectPath);
+    expect(
+      db().query("SELECT COUNT(*) AS n FROM semantic_token_cache").get(),
+    ).toEqual({ n: 0 });
+    pending.persist();
+    expect(
+      db().query("SELECT COUNT(*) AS n FROM semantic_token_cache").get(),
+    ).toEqual({ n: 0 });
+  });
+
+  it.each([false, true])(
+    "rejects publication after session recreation (external=%s)",
+    (external) => {
+      const pending = new SemanticTokenCache(scope);
+      pending.count(visible, provenance);
+      if (external) {
+        const other = new DatabaseSync(process.env.LORE_DB_PATH!);
+        try {
+          other.exec("BEGIN IMMEDIATE");
+          other
+            .prepare("DELETE FROM session_state WHERE session_id = ?")
+            .run(scope.sessionID);
+          other
+            .prepare(
+              "INSERT INTO session_state (session_id, updated_at) VALUES (?, ?)",
+            )
+            .run(scope.sessionID, Date.now());
+          other.exec("COMMIT");
+        } finally {
+          other.close();
+        }
+      } else {
+        deleteSession(scope.projectPath, scope.sessionID);
+        parent();
+      }
+      pending.persist();
+      expect(
+        db().query("SELECT COUNT(*) AS n FROM semantic_token_cache").get(),
+      ).toEqual({ n: 0 });
+    },
+  );
+
+  it("skips a competing writer promptly and restores the caller's busy timeout", () => {
+    fill();
+    const before = payload();
+    const pending = new SemanticTokenCache(scope);
+    pending.count(visible, provenance + " ");
+    const other = new DatabaseSync(process.env.LORE_DB_PATH!);
+    db().exec("PRAGMA busy_timeout = 1375");
+    try {
+      other.exec("BEGIN IMMEDIATE");
+      const started = performance.now();
+      pending.persist();
+      expect(performance.now() - started).toBeLessThan(500);
+      expect(db().query("PRAGMA busy_timeout").get()).toEqual({
+        timeout: 1375,
+      });
+      expect(pending.stats.unavailable).toBe(1);
+      expect(payload()).toBe(before);
+    } finally {
+      other.exec("ROLLBACK");
+      other.close();
+      db().exec("PRAGMA busy_timeout = 5000");
+    }
+  });
+
+  it("rolls back derived-cache publication with the caller's transaction", () => {
+    db().exec("SAVEPOINT test_cache_rollback");
+    fill();
+    db().exec("ROLLBACK TO test_cache_rollback; RELEASE test_cache_rollback");
+    expect(fill().stats.misses).toBe(1);
+  });
+
+  it("does not reuse a merged project's derived cache under another owner", () => {
+    const source = ensureProject(scope.projectPath);
+    const target = ensureProject("/test/merged-token-project");
+    fill();
+    mergeProjectInternal(source, target);
+    expect(
+      db()
+        .query(
+          "SELECT project_id FROM semantic_token_cache WHERE project_id = ?",
+        )
+        .get(source),
+    ).toBeNull();
+  });
+
+  it("migrates v85 and repairs a missing derived table without touching source data", () => {
+    db().exec(
+      "DROP TABLE semantic_token_cache; UPDATE schema_version SET version = 85",
+    );
+    close();
+    expect(db().query("SELECT version FROM schema_version").get()).toEqual({
+      version: MIGRATIONS.length,
+    });
+    fill();
+    db().exec("DROP TABLE semantic_token_cache");
+    close();
+    expect(
+      db().query("SELECT COUNT(*) AS n FROM semantic_token_cache").get(),
+    ).toEqual({ n: 0 });
+  });
+});

--- a/packages/core/test/semantic-token-cache.test.ts
+++ b/packages/core/test/semantic-token-cache.test.ts
@@ -100,6 +100,16 @@ describe("exact derived provenance counts", () => {
       JSON.stringify([{ raw: { data: "x".repeat(128) + "new tail" } }]),
     ],
     [visible, provenance, visible, provenance.replace("AABCD", "ZZBCD")],
+    [
+      JSON.stringify([
+        { type: "opaque", raw: { data: "x".repeat(128) + "old tail" } },
+      ]),
+      provenance,
+      JSON.stringify([
+        { type: "opaque", raw: { data: "x".repeat(128) + "new tail" } },
+      ]),
+      provenance,
+    ],
   ])("recomputes on every full-content difference (%#)", (oldV, oldP, v, p) => {
     const first = new SemanticTokenCache(scope);
     first.count(oldV, oldP);

--- a/packages/core/test/sync-registry-contract.test.ts
+++ b/packages/core/test/sync-registry-contract.test.ts
@@ -338,6 +338,14 @@ describe("SYNCED_TABLES local-only secondary UNIQUE → convergence handling (#1
 });
 
 describe("server-internal tables are intentionally NOT synced", () => {
+  test("derived provenance counts never enter any sync tier", () => {
+    for (const tier of ["basic", "pro", "max"] as const)
+      expect(
+        SYNCED_TABLES[tier].find(
+          (metadata) => metadata.table === "semantic_token_cache",
+        ),
+      ).toBeUndefined();
+  });
   test("the temporal embedding queue is absent from every tier's registry", () => {
     for (const tier of ["basic", "pro", "max"] as const)
       expect(

--- a/packages/gateway/src/semantic-preparation.ts
+++ b/packages/gateway/src/semantic-preparation.ts
@@ -3,6 +3,7 @@ import {
   isToolPart,
   log,
   temporal,
+  SemanticTokenCache,
   type LoreMessageWithParts,
 } from "@loreai/core";
 import { gatewayMessagesToLore, resolveToolResults } from "./temporal-adapter";
@@ -98,7 +99,14 @@ export class PreparationTiming {
       wallMs: performance.now() - this.started,
       cpuMs: (delta.user + delta.system) / 1000,
     });
-    log.info("semantic-preparation", { ...this.counts, stages: this.stages });
+    log.info(
+      "semantic-preparation",
+      JSON.stringify({
+        ...this.counts,
+        stages: this.stages,
+        observations: this.observations,
+      }),
+    );
   }
 }
 
@@ -141,6 +149,7 @@ export async function prepareSemanticMessages(input: {
   const started = performance.now();
   const cpu = process.cpuUsage();
   const memory = process.memoryUsage();
+  const tokenCache = new SemanticTokenCache(input);
   // An immediate queued before synchronous preparation observes its event-loop
   // delay. Await it before the next stage so LTM work cannot pollute the sample.
   // The callback retains just a timestamp, never the transcript.
@@ -148,7 +157,13 @@ export async function prepareSemanticMessages(input: {
     setImmediate(() => resolve(performance.now() - started)),
   );
   const loreMessages = timing.measure("conversion", () =>
-    gatewayMessagesToLore(input.messages, input.sessionID),
+    gatewayMessagesToLore(
+      input.messages,
+      input.sessionID,
+      0,
+      0,
+      (visible, provenance) => tokenCache.count(visible, provenance),
+    ),
   );
   const temporalInput = timing.measure("temporal_input", () =>
     captureTurnTemporalInput(loreMessages),
@@ -191,6 +206,8 @@ export async function prepareSemanticMessages(input: {
   timing.measure("resolve_tools", () =>
     resolveToolResults(loreMessages, (m) => ids.get(m.info.id) ?? m.info.id),
   );
+  // Publish before yielding; cache writes never wait for another writer.
+  tokenCache.persist();
   const delta = process.cpuUsage(cpu);
   timing.record("semantic_total", {
     wallMs: performance.now() - started,
@@ -203,5 +220,7 @@ export async function prepareSemanticMessages(input: {
     timing.metric(name, count);
   timing.metric("stored_id_resolutions", candidates.length);
   timing.metric("event_loop_delay_ms", await loopDelay);
+  for (const [name, value] of Object.entries(tokenCache.stats))
+    timing.metric(`provenance_tokens_${name}`, value);
   return { loreMessages, temporalInput, provenanceByMessageId };
 }

--- a/packages/gateway/src/temporal-adapter.ts
+++ b/packages/gateway/src/temporal-adapter.ts
@@ -227,6 +227,7 @@ export function gatewayMessagesToLore(
   sessionID: string,
   startIndex = 0,
   legacyStartIndex = 0,
+  hiddenTokenCount?: (visibleJson: string, provenanceJson: string) => number,
 ): LoreMessageWithParts[] {
   const out: LoreMessageWithParts[] = [];
   const now = Date.now();
@@ -248,11 +249,15 @@ export function gatewayMessagesToLore(
       contentBlockToPart(block, sessionID, id, pi),
     );
     const hiddenInputTokens = m.provenanceContent
-      ? Math.max(
-          0,
-          coreEstimateTokens(JSON.stringify(m.provenanceContent)) -
-            coreEstimateTokens(JSON.stringify(m.content)),
-        )
+      ? (
+          hiddenTokenCount ??
+          ((visibleJson, provenanceJson) =>
+            Math.max(
+              0,
+              coreEstimateTokens(provenanceJson) -
+                coreEstimateTokens(visibleJson),
+            ))
+        )(JSON.stringify(m.content), JSON.stringify(m.provenanceContent))
       : 0;
 
     if (m.role === "user") {

--- a/packages/gateway/test/fixtures/semantic-history.ts
+++ b/packages/gateway/test/fixtures/semantic-history.ts
@@ -1,7 +1,7 @@
 import { parseOpenAICodexRequest } from "../../src/translate/openai-responses";
 
 /** Synthetic Responses/Codex transcript: no real prompts, paths or credentials. */
-export function semanticHistory(messageCount = 5580) {
+export function semanticHistory(messageCount = 5580, reasoningBytes = 0) {
   if (messageCount < 2 || messageCount % 2)
     throw new Error("Use an even message count >= 2");
   const input: Record<string, unknown>[] = [
@@ -20,7 +20,9 @@ export function semanticHistory(messageCount = 5580) {
     input.push({
       type: "reasoning",
       id: `reason-${turn}`,
-      encrypted_content: "synthetic-encrypted-state-".repeat(12),
+      encrypted_content: reasoningBytes
+        ? syntheticReasoning(turn + 1, reasoningBytes)
+        : "synthetic-encrypted-state-".repeat(12),
       summary: [],
     });
     for (let call = 0; call < 2; call++)
@@ -47,4 +49,17 @@ export function semanticHistory(messageCount = 5580) {
     { model: "synthetic-model", stream: true, input, tools: [] },
     {},
   );
+}
+
+/** Deterministic high-entropy fixture data; no real encrypted/user content. */
+function syntheticReasoning(seed: number, bytes: number): string {
+  const data = Buffer.alloc(bytes);
+  let state = seed;
+  for (let i = 0; i < bytes; i++) {
+    state ^= state << 13;
+    state ^= state >>> 17;
+    state ^= state << 5;
+    data[i] = state & 255;
+  }
+  return data.toString("base64");
 }

--- a/packages/gateway/test/semantic-preparation.test.ts
+++ b/packages/gateway/test/semantic-preparation.test.ts
@@ -1,5 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { db, ensureProject, isToolPart, log, temporal } from "@loreai/core";
+import {
+  db,
+  ensureProject,
+  isToolPart,
+  log,
+  temporal,
+  saveSessionTracking,
+} from "@loreai/core";
+import * as tokenize from "../../core/src/tokenize";
 import * as Sentry from "@sentry/bun";
 import * as adapter from "../src/temporal-adapter";
 import {
@@ -26,9 +34,12 @@ vi.mock("@sentry/bun", async (importOriginal) => {
 const projectPath = "/test/semantic-preparation";
 const sessionID = "semantic-session";
 const sink = { info() {}, warn() {}, error() {}, captureException() {} };
-beforeEach(() => db().exec("DELETE FROM temporal_messages"));
+beforeEach(() =>
+  db().exec("DELETE FROM temporal_messages; DELETE FROM semantic_token_cache"),
+);
 afterEach(() => {
   vi.restoreAllMocks();
+  vi.useRealTimers();
   log.registerSink(sink);
 });
 const storage = {
@@ -70,6 +81,130 @@ function seed(request: ReturnType<typeof semanticHistory>, restored = false) {
 }
 
 describe("semantic preparation", () => {
+  it("does not retokenize unchanged provenance on a subsequent request", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-09-07T18:14:04Z"));
+    const request = semanticHistory(6);
+    ensureProject(projectPath);
+    saveSessionTracking(sessionID, {});
+    const count = vi.spyOn(tokenize, "estimateTokens");
+    const first = await prepareSemanticMessages({
+      messages: request.messages,
+      projectPath,
+      sessionID,
+      noStore: false,
+      timing: new PreparationTiming(request),
+    });
+    expect(count.mock.calls.length).toBeGreaterThan(0);
+    count.mockClear();
+    vi.setSystemTime(new Date("2026-09-07T18:15:04Z"));
+    const next = await prepareSemanticMessages({
+      messages: structuredClone(request.messages),
+      projectPath,
+      sessionID,
+      noStore: false,
+      timing: new PreparationTiming(request),
+    });
+    expect(count).not.toHaveBeenCalled();
+    expect(
+      next.loreMessages[0].info.time.created -
+        first.loreMessages[0].info.time.created,
+    ).toBe(60_000);
+    expect(next.loreMessages.map((m) => m.hiddenInputTokens)).toEqual(
+      first.loreMessages.map((m) => m.hiddenInputTokens),
+    );
+    expect(
+      loreMessagesToGateway(
+        next.loreMessages,
+        next.provenanceByMessageId,
+        true,
+      ),
+    ).toEqual(
+      loreMessagesToGateway(
+        first.loreMessages,
+        first.provenanceByMessageId,
+        true,
+      ),
+    );
+  });
+
+  it.each(["edit", "rewind"])(
+    "preserves authoritative source after a warm historical %s",
+    async (mode) => {
+      const request = semanticHistory(6);
+      ensureProject(projectPath);
+      saveSessionTracking(sessionID, {});
+      const prepare = (noStore: boolean) =>
+        prepareSemanticMessages({
+          messages: request.messages,
+          projectPath,
+          sessionID,
+          noStore,
+          timing: new PreparationTiming(request),
+        });
+      await prepare(false);
+      if (mode === "edit") {
+        // Change hidden historical bytes while leaving the visible projection,
+        // source positions, and final message unchanged.
+        const historical = request.messages.find((m) =>
+          JSON.stringify(m.provenanceContent)?.includes(
+            "synthetic-encrypted-state-",
+          ),
+        )!;
+        historical.provenanceContent = JSON.parse(
+          JSON.stringify(historical.provenanceContent).replace(
+            "synthetic-encrypted-state-",
+            "different-encrypted-state-",
+          ),
+        );
+      } else request.messages.splice(2, 2);
+      const count = vi.spyOn(tokenize, "estimateTokens");
+      const warm = await prepare(false);
+      expect(count.mock.calls.length).toBe(mode === "edit" ? 2 : 0);
+      const cold = await prepare(true);
+      expect(warm.loreMessages.map((m) => m.hiddenInputTokens)).toEqual(
+        cold.loreMessages.map((m) => m.hiddenInputTokens),
+      );
+      expect(warm.temporalInput.assistantIndex).toBe(request.messages.length);
+      expect(warm.loreMessages.map((m) => m.info.id)).toEqual(
+        cold.loreMessages.map((m) => m.info.id),
+      );
+      expect(
+        loreMessagesToGateway(
+          warm.loreMessages,
+          warm.provenanceByMessageId,
+          true,
+        ),
+      ).toEqual(
+        loreMessagesToGateway(
+          cold.loreMessages,
+          cold.provenanceByMessageId,
+          true,
+        ),
+      );
+    },
+  );
+
+  it("preserves numeric stage timings through the real log sink", () => {
+    const lines: string[] = [];
+    log.registerSink({ ...sink, info: (message) => lines.push(message) });
+    const timing = new PreparationTiming(semanticHistory(2));
+    timing.counts.messages = 5741;
+    timing.record("conversion", { wallMs: 83199, cpuMs: 83000 });
+    timing.upstreamStart();
+    const line = lines.find((message) =>
+      message.startsWith("semantic-preparation "),
+    )!;
+    expect(line).not.toContain("[object Object]");
+    const payload = JSON.parse(line.slice("semantic-preparation ".length));
+    expect(payload.messages).toBe(5741);
+    expect(payload.stages.conversion).toEqual({ wallMs: 83199, cpuMs: 83000 });
+    expect(payload.stages.turn_to_upstream.wallMs).toEqual(expect.any(Number));
+    expect(payload.stages.turn_to_upstream.cpuMs).toEqual(expect.any(Number));
+    expect(line).not.toContain(projectPath);
+    expect(line).not.toContain(sessionID);
+  });
+
   it("preserves wire/provenance and recall IDs on a resumed 5,580-message Codex transcript", async () => {
     const request = semanticHistory();
     expect(request.messages).toHaveLength(5580);

--- a/packages/gateway/test/semantic-token-benchmark.test.ts
+++ b/packages/gateway/test/semantic-token-benchmark.test.ts
@@ -1,0 +1,74 @@
+import { it, expect } from "vitest";
+import { close, db, ensureProject, saveSessionTracking } from "@loreai/core";
+import { createHash } from "node:crypto";
+import {
+  PreparationTiming,
+  prepareSemanticMessages,
+} from "../src/semantic-preparation";
+import { loreMessagesToGateway } from "../src/pipeline";
+import { semanticHistory } from "./fixtures/semantic-history";
+
+it.skipIf(process.env.LORE_TOKEN_BENCHMARK !== "1")(
+  "measures realistic encrypted provenance across cold, warm, and reopened requests",
+  async () => {
+    const scope = {
+      projectPath: "/test/semantic-token-benchmark",
+      sessionID: "benchmark-session",
+    };
+    ensureProject(scope.projectPath);
+    saveSessionTracking(scope.sessionID, {});
+    const request = semanticHistory(5580, 4096);
+    let baseline: string | undefined;
+    for (const mode of [
+      "uncached",
+      "populate",
+      "warm",
+      "restart",
+      "append",
+    ] as const) {
+      if (mode === "restart") close();
+      const input = mode === "append" ? semanticHistory(5582, 4096) : request;
+      const timing = new PreparationTiming(input);
+      const started = performance.now();
+      const prepared = await prepareSemanticMessages({
+        ...scope,
+        messages: input.messages,
+        noStore: mode === "uncached",
+        timing,
+      });
+      timing.upstreamStart();
+      const elapsed = performance.now() - started;
+      const wire = loreMessagesToGateway(
+        prepared.loreMessages,
+        prepared.provenanceByMessageId,
+        true,
+      );
+      const hash = createHash("sha256")
+        .update(JSON.stringify(wire))
+        .digest("hex");
+      if (mode === "uncached") baseline = hash;
+      else if (mode !== "append") expect(hash).toBe(baseline);
+      if (mode === "warm" || mode === "restart")
+        expect(timing.observations.provenance_tokens_misses).toBe(0);
+      if (mode === "append")
+        expect(timing.observations.provenance_tokens_misses).toBe(1);
+      process.stdout.write(
+        JSON.stringify({
+          mode,
+          sourceMessages: input.messages.length,
+          elapsed,
+          stages: timing.stages,
+          observations: timing.observations,
+          wireHash: hash,
+          cacheBytes: (
+            db()
+              .query(
+                "SELECT COALESCE(SUM(length(payload)), 0) AS n FROM semantic_token_cache",
+              )
+              .get() as { n: number }
+          ).n,
+        }) + "\n",
+      );
+    }
+  },
+);

--- a/packages/gateway/test/store-turn-temporal.test.ts
+++ b/packages/gateway/test/store-turn-temporal.test.ts
@@ -397,7 +397,7 @@ describe("storeTurnTemporal (#1084)", () => {
       `);
       close();
       expect(db().query("SELECT version FROM schema_version").get()).toEqual({
-        version: 85,
+        version: 86,
       });
 
       const noStoreLore = gatewayMessagesToLore(conversation, sessionID);

--- a/quality/benchmarks/semantic-token-cache-1710.json
+++ b/quality/benchmarks/semantic-token-cache-1710.json
@@ -1,0 +1,554 @@
+{
+  "date": "2026-09-07",
+  "base": "4f92eaafab5c463127f3de8e9f42d8f47f2bcd9f",
+  "node": "v24.19.0",
+  "platform": "Linux x86_64",
+  "fixture": {
+    "messages": 5580,
+    "reasoningBytesPerTurn": 4096,
+    "generator": "deterministic xorshift bytes encoded as base64; no user data"
+  },
+  "measurement": "semantic preparation only; excludes HTTP parsing, LTM, gradient, and upstream inference",
+  "runs": [
+    {
+      "revision": "initial cache implementation, before review lifecycle and writer-contention fixes",
+      "samples": [
+        {
+          "mode": "uncached",
+          "sourceMessages": 5580,
+          "elapsed": 107020.64080000001,
+          "stages": {
+            "conversion": {
+              "wallMs": 106966.754575,
+              "cpuMs": 107931.664
+            },
+            "temporal_input": {
+              "wallMs": 0.5055730000021867,
+              "cpuMs": 0.493
+            },
+            "provenance": {
+              "wallMs": 9.962981999997282,
+              "cpuMs": 10.279
+            },
+            "stored_ids": {
+              "wallMs": 15.924683000004734,
+              "cpuMs": 21.491
+            },
+            "resolve_tools": {
+              "wallMs": 21.561642999993637,
+              "cpuMs": 28.355
+            },
+            "semantic_total": {
+              "wallMs": 107019.522852,
+              "cpuMs": 107997.807
+            },
+            "turn_to_upstream": {
+              "wallMs": 107020.275659,
+              "cpuMs": 107998.554
+            }
+          },
+          "observations": {
+            "rss_delta_bytes": 484425728,
+            "heap_delta_bytes": 370607032,
+            "messages": 5580,
+            "parts": 11158,
+            "toolUses": 5578,
+            "toolResults": 5578,
+            "placeholders": 2789,
+            "stored_id_resolutions": 2789,
+            "event_loop_delay_ms": 107019.865309,
+            "provenance_tokens_hits": 0,
+            "provenance_tokens_misses": 2790,
+            "provenance_tokens_bpe_bytes": 16622651,
+            "provenance_tokens_bpe_ms": 106301.23342200003,
+            "provenance_tokens_unavailable": 0
+          },
+          "wireHash": "91503580e05b00105aac0f54416cc6f5838a79b856e2758e369e966203fa80e0",
+          "cacheBytes": 0
+        },
+        {
+          "mode": "populate",
+          "sourceMessages": 5580,
+          "elapsed": 113887.357613,
+          "stages": {
+            "conversion": {
+              "wallMs": 113838.092506,
+              "cpuMs": 114759.914
+            },
+            "temporal_input": {
+              "wallMs": 0.19759800002793781,
+              "cpuMs": 0.194
+            },
+            "provenance": {
+              "wallMs": 4.600118000002112,
+              "cpuMs": 6.907
+            },
+            "stored_ids": {
+              "wallMs": 15.025763999990886,
+              "cpuMs": 26.175
+            },
+            "resolve_tools": {
+              "wallMs": 15.384636000002502,
+              "cpuMs": 27.108
+            },
+            "semantic_total": {
+              "wallMs": 113877.137297,
+              "cpuMs": 114825.782
+            },
+            "turn_to_upstream": {
+              "wallMs": 113887.12986,
+              "cpuMs": 114852.194
+            }
+          },
+          "observations": {
+            "rss_delta_bytes": 166203392,
+            "heap_delta_bytes": -225397488,
+            "messages": 5580,
+            "parts": 11158,
+            "toolUses": 5578,
+            "toolResults": 5578,
+            "placeholders": 2789,
+            "stored_id_resolutions": 2789,
+            "event_loop_delay_ms": 113884.348068,
+            "provenance_tokens_hits": 0,
+            "provenance_tokens_misses": 2790,
+            "provenance_tokens_bpe_bytes": 16622651,
+            "provenance_tokens_bpe_ms": 113189.47147499917,
+            "provenance_tokens_unavailable": 0
+          },
+          "wireHash": "91503580e05b00105aac0f54416cc6f5838a79b856e2758e369e966203fa80e0",
+          "cacheBytes": 206580
+        },
+        {
+          "mode": "warm",
+          "sourceMessages": 5580,
+          "elapsed": 138.33430099999532,
+          "stages": {
+            "conversion": {
+              "wallMs": 114.20632900000783,
+              "cpuMs": 130.787
+            },
+            "temporal_input": {
+              "wallMs": 0.16839400000753812,
+              "cpuMs": 0.167
+            },
+            "provenance": {
+              "wallMs": 1.2675039999885485,
+              "cpuMs": 1.265
+            },
+            "stored_ids": {
+              "wallMs": 10.55257800000254,
+              "cpuMs": 12.047
+            },
+            "resolve_tools": {
+              "wallMs": 6.33209299997543,
+              "cpuMs": 8.356
+            },
+            "semantic_total": {
+              "wallMs": 136.4960940000019,
+              "cpuMs": 156.812
+            },
+            "turn_to_upstream": {
+              "wallMs": 138.1992559999926,
+              "cpuMs": 158.503
+            }
+          },
+          "observations": {
+            "rss_delta_bytes": -29777920,
+            "heap_delta_bytes": -11688632,
+            "messages": 5580,
+            "parts": 11158,
+            "toolUses": 5578,
+            "toolResults": 5578,
+            "placeholders": 2789,
+            "stored_id_resolutions": 2789,
+            "event_loop_delay_ms": 136.7814139999973,
+            "provenance_tokens_hits": 2790,
+            "provenance_tokens_misses": 0,
+            "provenance_tokens_bpe_bytes": 0,
+            "provenance_tokens_bpe_ms": 0,
+            "provenance_tokens_unavailable": 0
+          },
+          "wireHash": "91503580e05b00105aac0f54416cc6f5838a79b856e2758e369e966203fa80e0",
+          "cacheBytes": 206580
+        },
+        {
+          "mode": "restart",
+          "sourceMessages": 5580,
+          "elapsed": 140.31494100001873,
+          "stages": {
+            "conversion": {
+              "wallMs": 110.23203700000886,
+              "cpuMs": 128.438
+            },
+            "temporal_input": {
+              "wallMs": 0.1840479999955278,
+              "cpuMs": 0.182
+            },
+            "provenance": {
+              "wallMs": 1.0757250000024214,
+              "cpuMs": 1.072
+            },
+            "stored_ids": {
+              "wallMs": 10.622392999997828,
+              "cpuMs": 11.336
+            },
+            "resolve_tools": {
+              "wallMs": 7.22754600000917,
+              "cpuMs": 10.31
+            },
+            "semantic_total": {
+              "wallMs": 138.24336299998686,
+              "cpuMs": 160.845
+            },
+            "turn_to_upstream": {
+              "wallMs": 140.14912100002402,
+              "cpuMs": 165.764
+            }
+          },
+          "observations": {
+            "rss_delta_bytes": -30519296,
+            "heap_delta_bytes": -11067272,
+            "messages": 5580,
+            "parts": 11158,
+            "toolUses": 5578,
+            "toolResults": 5578,
+            "placeholders": 2789,
+            "stored_id_resolutions": 2789,
+            "event_loop_delay_ms": 138.43130699999165,
+            "provenance_tokens_hits": 2790,
+            "provenance_tokens_misses": 0,
+            "provenance_tokens_bpe_bytes": 0,
+            "provenance_tokens_bpe_ms": 0,
+            "provenance_tokens_unavailable": 0
+          },
+          "wireHash": "91503580e05b00105aac0f54416cc6f5838a79b856e2758e369e966203fa80e0",
+          "cacheBytes": 206580
+        },
+        {
+          "mode": "append",
+          "sourceMessages": 5582,
+          "elapsed": 179.76237499999115,
+          "stages": {
+            "conversion": {
+              "wallMs": 153.81767099999706,
+              "cpuMs": 201.434
+            },
+            "temporal_input": {
+              "wallMs": 0.20699199999216944,
+              "cpuMs": 0.205
+            },
+            "provenance": {
+              "wallMs": 1.345441999990726,
+              "cpuMs": 1.34
+            },
+            "stored_ids": {
+              "wallMs": 10.878199999977369,
+              "cpuMs": 11.61
+            },
+            "resolve_tools": {
+              "wallMs": 7.2574510000122245,
+              "cpuMs": 8.861
+            },
+            "semantic_total": {
+              "wallMs": 177.62028999999166,
+              "cpuMs": 232.739
+            },
+            "turn_to_upstream": {
+              "wallMs": 179.62391600001138,
+              "cpuMs": 234.832
+            }
+          },
+          "observations": {
+            "rss_delta_bytes": -30203904,
+            "heap_delta_bytes": -30225632,
+            "messages": 5582,
+            "parts": 11162,
+            "toolUses": 5580,
+            "toolResults": 5580,
+            "placeholders": 2790,
+            "stored_id_resolutions": 2790,
+            "event_loop_delay_ms": 177.78749299998162,
+            "provenance_tokens_hits": 2790,
+            "provenance_tokens_misses": 1,
+            "provenance_tokens_bpe_bytes": 5961,
+            "provenance_tokens_bpe_ms": 29.89780599999358,
+            "provenance_tokens_unavailable": 0
+          },
+          "wireHash": "9f73f6e130fc1ff1a03876cdd031e4a13e446548265b5325653a9916dca44038",
+          "cacheBytes": 206654
+        }
+      ]
+    },
+    {
+      "revision": "final implementation with lifecycle revision guard and nonblocking publication",
+      "samples": [
+        {
+          "mode": "uncached",
+          "sourceMessages": 5580,
+          "elapsed": 102376.303265,
+          "stages": {
+            "conversion": {
+              "wallMs": 102322.880866,
+              "cpuMs": 103191.184
+            },
+            "temporal_input": {
+              "wallMs": 0.48459200000797864,
+              "cpuMs": 0.475
+            },
+            "provenance": {
+              "wallMs": 9.409908000001451,
+              "cpuMs": 12.127
+            },
+            "stored_ids": {
+              "wallMs": 18.64923799999815,
+              "cpuMs": 23.085
+            },
+            "resolve_tools": {
+              "wallMs": 18.929161000007298,
+              "cpuMs": 30.244
+            },
+            "semantic_total": {
+              "wallMs": 102375.20769,
+              "cpuMs": 103263.464
+            },
+            "turn_to_upstream": {
+              "wallMs": 102375.85695,
+              "cpuMs": 103264.11
+            }
+          },
+          "observations": {
+            "rss_delta_bytes": 462491648,
+            "heap_delta_bytes": 374747272,
+            "messages": 5580,
+            "parts": 11158,
+            "toolUses": 5578,
+            "toolResults": 5578,
+            "placeholders": 2789,
+            "stored_id_resolutions": 2789,
+            "event_loop_delay_ms": 102375.497818,
+            "provenance_tokens_hits": 0,
+            "provenance_tokens_misses": 2790,
+            "provenance_tokens_bpe_bytes": 16622651,
+            "provenance_tokens_bpe_ms": 101740.42861799999,
+            "provenance_tokens_unavailable": 0
+          },
+          "wireHash": "0345e85a096fe777f52a59653615d46de9371565062167d4f366196d65d201a4",
+          "cacheBytes": 0
+        },
+        {
+          "mode": "populate",
+          "sourceMessages": 5580,
+          "elapsed": 110825.34807100001,
+          "stages": {
+            "conversion": {
+              "wallMs": 110770.029453,
+              "cpuMs": 111688.283
+            },
+            "temporal_input": {
+              "wallMs": 0.2018450000032317,
+              "cpuMs": 0.199
+            },
+            "provenance": {
+              "wallMs": 9.167671000002883,
+              "cpuMs": 11.475
+            },
+            "stored_ids": {
+              "wallMs": 13.850076000002446,
+              "cpuMs": 26.196
+            },
+            "resolve_tools": {
+              "wallMs": 22.062489000003552,
+              "cpuMs": 40.494
+            },
+            "semantic_total": {
+              "wallMs": 110822.90885499999,
+              "cpuMs": 111777.854
+            },
+            "turn_to_upstream": {
+              "wallMs": 110825.14616599999,
+              "cpuMs": 111784.116
+            }
+          },
+          "observations": {
+            "rss_delta_bytes": 180051968,
+            "heap_delta_bytes": -260207976,
+            "messages": 5580,
+            "parts": 11158,
+            "toolUses": 5578,
+            "toolResults": 5578,
+            "placeholders": 2789,
+            "stored_id_resolutions": 2789,
+            "event_loop_delay_ms": 110825.02397099999,
+            "provenance_tokens_hits": 0,
+            "provenance_tokens_misses": 2790,
+            "provenance_tokens_bpe_bytes": 16622651,
+            "provenance_tokens_bpe_ms": 110171.25515900075,
+            "provenance_tokens_unavailable": 0
+          },
+          "wireHash": "0345e85a096fe777f52a59653615d46de9371565062167d4f366196d65d201a4",
+          "cacheBytes": 206580
+        },
+        {
+          "mode": "warm",
+          "sourceMessages": 5580,
+          "elapsed": 149.7586429999792,
+          "stages": {
+            "conversion": {
+              "wallMs": 104.23775400000159,
+              "cpuMs": 123.588
+            },
+            "temporal_input": {
+              "wallMs": 0.1852200000139419,
+              "cpuMs": 0.183
+            },
+            "provenance": {
+              "wallMs": 1.509691000013845,
+              "cpuMs": 1.504
+            },
+            "stored_ids": {
+              "wallMs": 11.227985000004992,
+              "cpuMs": 12.93
+            },
+            "resolve_tools": {
+              "wallMs": 14.98043399999733,
+              "cpuMs": 17.782
+            },
+            "semantic_total": {
+              "wallMs": 138.72648499999195,
+              "cpuMs": 163.154
+            },
+            "turn_to_upstream": {
+              "wallMs": 149.55467500002123,
+              "cpuMs": 189.045
+            }
+          },
+          "observations": {
+            "rss_delta_bytes": -29806592,
+            "heap_delta_bytes": -10376888,
+            "messages": 5580,
+            "parts": 11158,
+            "toolUses": 5578,
+            "toolResults": 5578,
+            "placeholders": 2789,
+            "stored_id_resolutions": 2789,
+            "event_loop_delay_ms": 149.4413539999805,
+            "provenance_tokens_hits": 2790,
+            "provenance_tokens_misses": 0,
+            "provenance_tokens_bpe_bytes": 0,
+            "provenance_tokens_bpe_ms": 0,
+            "provenance_tokens_unavailable": 0
+          },
+          "wireHash": "0345e85a096fe777f52a59653615d46de9371565062167d4f366196d65d201a4",
+          "cacheBytes": 206580
+        },
+        {
+          "mode": "restart",
+          "sourceMessages": 5580,
+          "elapsed": 147.45949000000837,
+          "stages": {
+            "conversion": {
+              "wallMs": 110.45873400001437,
+              "cpuMs": 122.257
+            },
+            "temporal_input": {
+              "wallMs": 0.25909199999296106,
+              "cpuMs": 0.257
+            },
+            "provenance": {
+              "wallMs": 1.1463020000082906,
+              "cpuMs": 1.142
+            },
+            "stored_ids": {
+              "wallMs": 11.860600000014529,
+              "cpuMs": 14.508
+            },
+            "resolve_tools": {
+              "wallMs": 10.960370999993756,
+              "cpuMs": 14.397
+            },
+            "semantic_total": {
+              "wallMs": 147.07588000001851,
+              "cpuMs": 172.342
+            },
+            "turn_to_upstream": {
+              "wallMs": 147.28693899998325,
+              "cpuMs": 172.544
+            }
+          },
+          "observations": {
+            "rss_delta_bytes": -28766208,
+            "heap_delta_bytes": -9234272,
+            "messages": 5580,
+            "parts": 11158,
+            "toolUses": 5578,
+            "toolResults": 5578,
+            "placeholders": 2789,
+            "stored_id_resolutions": 2789,
+            "event_loop_delay_ms": 147.2213000000047,
+            "provenance_tokens_hits": 2790,
+            "provenance_tokens_misses": 0,
+            "provenance_tokens_bpe_bytes": 0,
+            "provenance_tokens_bpe_ms": 0,
+            "provenance_tokens_unavailable": 0
+          },
+          "wireHash": "0345e85a096fe777f52a59653615d46de9371565062167d4f366196d65d201a4",
+          "cacheBytes": 206580
+        },
+        {
+          "mode": "append",
+          "sourceMessages": 5582,
+          "elapsed": 196.15915099999984,
+          "stages": {
+            "conversion": {
+              "wallMs": 168.01691000000574,
+              "cpuMs": 224.898
+            },
+            "temporal_input": {
+              "wallMs": 0.17245000001275912,
+              "cpuMs": 0.171
+            },
+            "provenance": {
+              "wallMs": 1.3623490000027232,
+              "cpuMs": 1.358
+            },
+            "stored_ids": {
+              "wallMs": 10.912727999995695,
+              "cpuMs": 11.628
+            },
+            "resolve_tools": {
+              "wallMs": 8.483658000011928,
+              "cpuMs": 10.923
+            },
+            "semantic_total": {
+              "wallMs": 195.7826809999824,
+              "cpuMs": 260.357
+            },
+            "turn_to_upstream": {
+              "wallMs": 196.0247279999894,
+              "cpuMs": 260.586
+            }
+          },
+          "observations": {
+            "rss_delta_bytes": -29089792,
+            "heap_delta_bytes": -27858824,
+            "messages": 5582,
+            "parts": 11162,
+            "toolUses": 5580,
+            "toolResults": 5580,
+            "placeholders": 2790,
+            "stored_id_resolutions": 2790,
+            "event_loop_delay_ms": 195.92179199997918,
+            "provenance_tokens_hits": 2790,
+            "provenance_tokens_misses": 1,
+            "provenance_tokens_bpe_bytes": 5961,
+            "provenance_tokens_bpe_ms": 35.489090999995824,
+            "provenance_tokens_unavailable": 0
+          },
+          "wireHash": "f7238cb81fa37f608253c667b1fad620aca9c5e3c7e289bed0d52ffe05e615c0",
+          "cacheBytes": 206654
+        }
+      ]
+    }
+  ]
+}

--- a/quality/benchmarks/semantic-token-cache-1710.md
+++ b/quality/benchmarks/semantic-token-cache-1710.md
@@ -1,0 +1,103 @@
+# Exact provenance token counts on long resumed sessions
+
+Measured 2026-09-07 on Linux x64, Node 24, from base
+`4f92eaafab5c463127f3de8e9f42d8f47f2bcd9f`. Raw observations are in
+[`semantic-token-cache-1710.json`](semantic-token-cache-1710.json).
+
+## Problem and scope
+
+The reported successive warm turns spent 83.2 and 83.7 seconds before the
+`ltm-budget` log, despite only three additional normalized messages. The
+earlier #1712 benchmark used repetitive synthetic ciphertext. Increasing the
+fixture to distinct high-entropy reasoning exposes a much larger cost:
+`gatewayMessagesToLore` tokenizes both full provenance and visible JSON for
+every historical provenance-bearing message to compute `hiddenInputTokens`.
+This is exact BPE work on encrypted data, repeated before LTM on every turn.
+
+The fix reuses that exact scalar only when both full serialized inputs and
+the tokenizer algorithm version match. It preserves the complete authoritative
+message graph, tool pairing, wire provenance, source IDs, and fresh timestamps.
+No source position or ingestion boundary is inferred from the cache.
+
+This addresses the measured bottleneck within #1710; it does **not** complete
+the larger durable source-frontier/active-window design. Full source hashing,
+conversion, and gradient processing remain. Budget expansion, global dedup,
+and tool boundaries need explicit source fallback before truncating the graph
+can preserve current behavior. #1710 stays open. #1716 recall-depth completion
+is separate.
+
+## Reproduction
+
+```sh
+LORE_TOKEN_BENCHMARK=1 pnpm exec vitest run packages/gateway/test/semantic-token-benchmark.test.ts
+```
+
+The synthetic Responses fixture has 5,580 normalized messages, 2,789 tool-result
+messages, two tool calls per turn, and 4,096 deterministic random bytes encoded
+as base64 per reasoning item. It uses no user transcript, network, or model.
+The five modes run serially in one process: no durable cache, first population,
+same request again, database close/reopen, and append one assistant/tool-result
+pair. Database reopen validates durable reuse; it is not a separate-process
+startup measurement. The first four produce the same SHA-256 of serialized
+upstream wire messages. Appending adds exactly one uncached provenance pair.
+
+The initial run measured 107.0 seconds without durable reuse and 113.9 seconds
+for first population. Warm preparation took 138 ms; after database reopen it
+took 140 ms. Appending two messages took 180 ms with 2,790 hits and one miss.
+The cache payload was 206,580 bytes. BPE accounted for 106.3 seconds of the
+uncached run and zero on unchanged warm/reopened requests.
+
+The final implementation, including lifecycle checks and nonblocking writes,
+was measured again without other CPU-heavy validation running:
+
+| Mode | Preparation | BPE | Hits / misses |
+| --- | ---: | ---: | ---: |
+| No durable cache | 102,376 ms | 101,740 ms | 0 / 2,790 |
+| First population | 110,825 ms | 110,171 ms | 0 / 2,790 |
+| Unchanged warm turn | 150 ms | 0 ms | 2,790 / 0 |
+| Database close/reopen | 148 ms | 0 ms | 2,790 / 0 |
+| Append two source messages | 196 ms | 35 ms | 2,790 / 1 |
+
+These are individual synthetic observations, not a production latency promise
+or a statistical latency distribution. Timings include semantic conversion,
+snapshot/provenance handling, batched ID lookup and tool resolution; they
+exclude HTTP parsing, LTM retrieval, gradient processing, and model inference.
+The first use, eviction, changed content, or disabled persistence can still pay
+the full tokenization cost. The live logs identify a matching phase but do not
+prove this is their only remaining bottleneck.
+
+## Persistence and validation
+
+Schema v86 adds a local-only derived table scoped by tenant-resolved project
+and session. It stores full-input SHA-256 keys and integer counts, with a
+versioned/checksummed envelope. Limits are 8,192 entries per session, 1 MB per
+payload and 64 retained session rows. Cache loss, invalid metadata, or a
+version mismatch causes recomputation. No-store mode bypasses durable reads
+and writes. Project clear removes even pre-response cache data; project merge
+discards the source cache, and project/session deletion cascades it away.
+
+Publication checks the same database connection, tenant, parent rows, local
+write count and external commit version under the INSERT's writer lock.
+Intervening writes conservatively discard the pending publication, including
+delete/recreate. It runs before yielding, uses a zero busy timeout, restores
+the caller's timeout, and never waits for background writers. Cache publication
+does not mark source messages ingested or advance distillation boundaries.
+
+Regressions cover actual unchanged/edited/rewound requests, persistence across
+reopen, changed hidden bytes/signature/error/opaque tail, fresh timestamps,
+tenant isolation, no-store, bounds, corruption, rollback, merge, deletion,
+same-ID recreation from either connection, and v85 migration/table recovery.
+The log-sink and repeated-tokenization tests failed before their fixes;
+review-found lifecycle and contention regressions also failed before repair.
+
+## Diagnostics (#1715)
+
+`semantic-preparation` now explicitly serializes its numeric payload so the
+real log sink preserves stage timings instead of printing `[object Object]`.
+It includes wall/CPU stage values and numeric observations for cache hits,
+misses, tokenized bytes, BPE milliseconds, and cache errors. These also emit as
+`lore.preparation.provenance_tokens_*` distributions. Dimensions remain fixed;
+no source text, ciphertext, paths, credentials, or session IDs are logged.
+Cache publication is included in `semantic_total`; `turn_to_upstream` also
+includes later preparation stages. Process-wide CPU and event-loop samples
+can include unrelated work.


### PR DESCRIPTION
Long resumed Codex histories repeatedly tokenize encrypted provenance before LTM, matching the phase where the supplied logs stall for 83 seconds on successive turns. The earlier fixture's repetitive ciphertext substantially understated this cost.

This change stores exact hidden-input token counts keyed by the complete serialized visible/provenance pair and a tokenizer version. Warm requests and database restarts reuse those counts while retaining the authoritative full message graph, original wire provenance, tool pairing, source IDs, and fresh timestamps.

The schema-v86 cache is local-only, tenant/project/session scoped, bounded, and disposable. No-store bypasses durable reads/writes. Corrupt entries recompute. Clear/delete/recreate, rollback, and merge preserve deletion semantics. Publication cannot wait on background writers or restore metadata after intervening database writes.

It also fixes the real log sink printing `semantic-preparation [object Object]`: numeric stage timings and cache diagnostics are explicitly serialized.

### Evidence

Committed benchmark: [report](https://github.com/BYK/loreai/blob/04290883fa8992fb6bd365ca43990ca88b894830/quality/benchmarks/semantic-token-cache-1710.md), [raw observations](https://github.com/BYK/loreai/blob/04290883fa8992fb6bd365ca43990ca88b894830/quality/benchmarks/semantic-token-cache-1710.json).

Final synthetic 5,580-message high-entropy fixture:

- Without durable reuse: **102.4 seconds**, including 101.7 seconds of BPE.
- First population: **110.8 seconds**.
- Same request warm: **150 ms**, zero BPE misses.
- Database close/reopen: **148 ms**, zero BPE misses.
- Append two source messages: **196 ms**, exactly one new provenance count.
- Equivalent requests produce identical serialized wire hashes; retained payload is about 207 KB.

These measure semantic preparation, excluding HTTP parsing, LTM, gradient processing, and inference. First use, eviction, invalidation, or no-store can still pay the full tokenization cost.

### Validation

Regression tests were proven failing before the logging/reuse fixes and the review-found lifecycle/contention repairs. Focused tests cover restart, historical edits/rewinds, byte-complete keys, timestamps, no-store, tenant isolation, corruption, bounds, migration/recovery, deletion/recreation from both connections, and locked writers.

Independent correctness and security reviews are complete with no unresolved findings. All ten targeted mutants are killed. Typecheck, lint, formatting and bundle pass; all ten sync-property runs pass. Security focused validation passed 129 tests; the final test-only addition passes all 28 core cache tests.

The full suite on identical production source finished with **9,554 passed, 7 failed, 229 skipped** (exit 1). All seven match documented base/environment failures: raw-window e2e (1), compact-endpoint budget assertions (2), installer process/ps checks (3), optional GPU assets (1). There are no newly introduced failures. The final delta adds one regression parameter; lint/format and its focused tests were revalidated.

The literal pnpm-test pretest hits the known tsx IPC restriction here. Validation used the equivalent explicit Node/tsx bundle command and complete Vitest suite. Seer passed on final head `04290883fa8992fb6bd365ca43990ca88b894830` with no issues (reference 16546882). Hosted semantic lint, documentation checks and Postgres sync integration also pass. The hosted test job and its downstream build/smoke gates remain pending; no failed gate is bypassed.

Fixes #1715.
Related to #1710, which remains open: this removes the measured BPE bottleneck but does not yet implement the source frontier or bounded active model window. #1716 recall-budget recovery remains a separate follow-up.