### PR TITLE
fix(gateway): bound recall recovery and diagnose repeated retrievals

### DIFF
--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -7073,6 +7073,7 @@ export function buildStreamingResponse(
                         getLLMClient(recallContext.config),
                         alreadyInLtmIds.size > 0 ? alreadyInLtmIds : undefined,
                         streamSignal,
+                        recallContext.noStore ? () => {} : undefined,
                       ),
                   ),
                 streamSignal,
@@ -18211,6 +18212,7 @@ async function handleConversationTurn(
       return finishForeground(
         translateAnthropicStreamToOpenAI(anthropicSSE, {
           signal: foregroundAbort.signal,
+          propagateErrors: true,
         }),
       );
     }

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -370,7 +370,7 @@ import {
   executeRecall,
   findRecallToolUse,
   hasRecallToolUse,
-  hasRecallContinuationOutput,
+  isUsableRecallContinuation,
   hasOtherToolUse,
   clientHasRecallTool,
   runRecallFollowUpStreaming,
@@ -7472,10 +7472,7 @@ export function buildStreamingResponse(
               if (recallDepth === MAX_RECALL_DEPTH) {
                 if (contAccum.hasRecall())
                   throw new RecallContinuationFailure("depth_exhausted");
-                if (
-                  continuationResp.stopReason === "max_tokens" ||
-                  !hasRecallContinuationOutput(continuationResp)
-                )
+                if (!isUsableRecallContinuation(continuationResp))
                   throw new RecallContinuationFailure("follow_up_failed");
               }
 
@@ -10714,7 +10711,7 @@ export function streamResponsesRecallAware(
                       if (
                         continuationFollowUpInput.finalRecallRound &&
                         contPending.length === 0 &&
-                        !hasRecallContinuationOutput(
+                        !isUsableRecallContinuation(
                           finalizeResponsesAcc(contState),
                         )
                       ) {
@@ -17639,8 +17636,7 @@ async function handleConversationTurn(
     if (hasRecallToolUse(currentResp)) return failRecall("depth_exhausted");
     if (
       recallDepth === MAX_RECALL_DEPTH &&
-      (currentResp.stopReason === "max_tokens" ||
-        !hasRecallContinuationOutput(currentResp))
+      !isUsableRecallContinuation(currentResp)
     )
       return failRecall("follow_up_failed");
     currentResp.usage = cumulativeUsage;

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -340,6 +340,7 @@ import {
   captureEmptyCompletion,
   type AnthropicUsage,
 } from "./sentry";
+import { createRecallDiagnostics } from "./recall-diagnostics";
 import {
   RecallContinuationFailure,
   reportRecallContinuationFailure,
@@ -369,6 +370,7 @@ import {
   executeRecall,
   findRecallToolUse,
   hasRecallToolUse,
+  hasRecallContinuationOutput,
   hasOtherToolUse,
   clientHasRecallTool,
   runRecallFollowUpStreaming,
@@ -6740,6 +6742,8 @@ export function buildStreamingResponse(
     upstreamRoute?: ResolvedRequestUpstreamRoute;
     /** Suppress recall-result retention for amnesia/no-store turns. */
     noStore?: boolean;
+    /** Account failed recall continuations without persisting a successful reply. */
+    onFailure?: (response: GatewayResponse) => void;
     /** True iff the inbound CLIENT speaks Anthropic SSE. Controls whether the
      *  recall marker is emitted as its own Anthropic SSE message envelope
      *  (split) or as an inline synthetic text content block (which the
@@ -6780,6 +6784,9 @@ export function buildStreamingResponse(
   maxReportedUsage: number = DEFAULT_MAX_REPORTED_USAGE,
   signal?: AbortSignal,
 ): Response {
+  const recallDiagnostics = createRecallDiagnostics(
+    recallContext !== undefined && !recallContext.noStore,
+  );
   const recallAccum = recallContext
     ? createRecallAwareAccumulator(RECALL_TOOL_NAME, {
         scaleClientUsage: true,
@@ -6891,6 +6898,7 @@ export function buildStreamingResponse(
         if (keepaliveTimer) clearTimeout(keepaliveTimer);
         keepaliveTimer = null;
       };
+      let recallFailureResponse: (() => GatewayResponse) | undefined;
       void (async () => {
         try {
           // Parse and forward upstream SSE events
@@ -7017,6 +7025,17 @@ export function buildStreamingResponse(
             let currentBlockOffset = warningOffset; // accumulates across iterations
             let currentModifiedReq = recallContext.modifiedReq;
             let recallDepth = 0;
+            let cumulativeUsage = { ...(currentResp.usage ?? ZERO_USAGE) };
+            let activeContinuation: RecallAwareAccumulator | undefined;
+            recallFailureResponse = () => ({
+              ...(activeContinuation ?? currentAccum).getResponse(),
+              usage: activeContinuation
+                ? mergeRecallUsage(
+                    cumulativeUsage,
+                    activeContinuation.getResponse().usage ?? ZERO_USAGE,
+                  )
+                : cumulativeUsage,
+            });
 
             // Snapshot IDs already in LTM context (system[1] catalog + durable
             // delta) so recall can hint "N of K results already in LTM" when the
@@ -7032,6 +7051,15 @@ export function buildStreamingResponse(
               const recallBlock = findRecallToolUse(currentResp);
               if (!recallBlock) break;
 
+              if (
+                currentResp.content.filter(
+                  (block) =>
+                    block.type === "tool_use" &&
+                    block.name === RECALL_TOOL_NAME,
+                ).length > 1
+              ) {
+                throw new RecallContinuationFailure("parallel_recall");
+              }
               recallDepth++;
               const { result, input } = await promiseAgainstAbort(
                 () =>
@@ -7050,6 +7078,7 @@ export function buildStreamingResponse(
                 streamSignal,
               );
 
+              recallDiagnostics.record(input, result);
               const scope = input.scope ?? "all";
 
               // Store recall result for marker round-trip expansion
@@ -7239,6 +7268,8 @@ export function buildStreamingResponse(
                   new Map([[recallBlock.id, markerText]]),
                 );
                 clearKeepalive();
+                markerResp.usage = cumulativeUsage;
+                recallDiagnostics.finish("completed");
                 onComplete(markerResp);
                 safeClose();
                 return;
@@ -7289,8 +7320,12 @@ export function buildStreamingResponse(
                   result,
                   recallBlock,
                   streamSignal,
+                  recallDepth === MAX_RECALL_DEPTH,
                 );
-              } catch {
+              } catch (error) {
+                if (streamSignal.aborted) throw error;
+                if (recallDepth === MAX_RECALL_DEPTH)
+                  throw new RecallContinuationFailure("follow_up_setup");
                 log.error(
                   `recall follow-up fetch failed (depth=${recallDepth}) for session ${recallContext.sessionState.sessionID.slice(0, 16)}`,
                 );
@@ -7307,12 +7342,16 @@ export function buildStreamingResponse(
                   new Map([[recallBlock.id, markerText]]),
                 );
                 clearKeepalive();
+                markerResp.usage = cumulativeUsage;
+                recallDiagnostics.finish("failed");
                 onComplete(markerResp);
                 safeClose();
                 return;
               }
 
               if (!streamingFollowUp.ok) {
+                if (recallDepth === MAX_RECALL_DEPTH)
+                  throw new RecallContinuationFailure("follow_up_failed");
                 log.error(
                   `recall follow-up upstream error: ${streamingFollowUp.status ?? "?"}`,
                   new Error(
@@ -7342,6 +7381,8 @@ export function buildStreamingResponse(
                   new Map([[recallBlock.id, markerText]]),
                 );
                 clearKeepalive();
+                markerResp.usage = cumulativeUsage;
+                recallDiagnostics.finish("failed");
                 onComplete(markerResp);
                 safeClose();
                 return;
@@ -7376,9 +7417,11 @@ export function buildStreamingResponse(
                 blockOffset: contBlockOffset,
                 suppressMessageStart: !recallContext.clientSpeaksAnthropic,
               });
+              activeContinuation = contAccum;
               const contReader = streamingFollowUp.reader;
               activeReader = contReader;
 
+              const finalTerminalEvents: string[] = [];
               const continuationValidator = new AnthropicSSEValidator();
               try {
                 for await (const {
@@ -7395,7 +7438,14 @@ export function buildStreamingResponse(
                   resetKeepalive(); // continuation stream alive — reset timer
                   continuationValidator.process(contEvent, contData);
                   const forwarded = contAccum.processEvent(contEvent, contData);
-                  if (forwarded) {
+                  if (
+                    forwarded &&
+                    recallDepth === MAX_RECALL_DEPTH &&
+                    (contEvent === "message_delta" ||
+                      contEvent === "message_stop")
+                  ) {
+                    finalTerminalEvents.push(forwarded);
+                  } else if (forwarded) {
                     // Forward non-recall, non-held-back events to client.
                     // message_delta usage scaling is handled by a separate pass
                     // below only for the final continuation's terminal events.
@@ -7413,6 +7463,21 @@ export function buildStreamingResponse(
                 `recall follow-up stream complete (depth=${recallDepth}): ` +
                   `session=${recallContext.sessionState.sessionID.slice(0, 16)}`,
               );
+              const continuationResp = contAccum.getResponse();
+              cumulativeUsage = mergeRecallUsage(
+                cumulativeUsage,
+                continuationResp.usage ?? ZERO_USAGE,
+              );
+              activeContinuation = undefined;
+              if (recallDepth === MAX_RECALL_DEPTH) {
+                if (contAccum.hasRecall())
+                  throw new RecallContinuationFailure("depth_exhausted");
+                if (
+                  continuationResp.stopReason === "max_tokens" ||
+                  !hasRecallContinuationOutput(continuationResp)
+                )
+                  throw new RecallContinuationFailure("follow_up_failed");
+              }
 
               // Check if continuation contained recall — if so, loop
               if (contAccum.hasRecall() && recallDepth < MAX_RECALL_DEPTH) {
@@ -7421,13 +7486,6 @@ export function buildStreamingResponse(
                 currentBlockOffset = contBlockOffset;
                 currentModifiedReq = followUp;
                 continue; // Loop: execute the new recall, emit marker, follow up
-              }
-
-              // No more recall (or depth exhausted) — forward terminal events, close
-              if (contAccum.hasRecall()) {
-                log.warn(
-                  `recall depth exhausted (${MAX_RECALL_DEPTH}) in streaming path`,
-                );
               }
 
               // For non-Anthropic clients: the original (preamble) envelope is
@@ -7446,18 +7504,20 @@ export function buildStreamingResponse(
               // refactor that re-enters the drill-down loop or replays the
               // accumulator). In the current control flow the heldBack is read
               // exactly once — this just makes the consume semantics explicit.
+              for (const terminal of finalTerminalEvents)
+                await safeEnqueue(encoder.encode(terminal));
               const heldBack = contAccum.takeHeldBackEvents();
               if (heldBack) {
                 // Scale usage in held-back message_delta for anti-compaction
                 await safeEnqueue(encoder.encode(heldBack));
               }
 
-              const markerResp = replaceRecallWithMarker(
-                contAccum.hasRecall() ? contAccum.getResponse() : currentResp,
-                new Map([[recallBlock.id, markerText]]),
-              );
+              continuationResp.usage = cumulativeUsage;
+              if (recallDepth === MAX_RECALL_DEPTH)
+                log.info("recall final continuation: completed");
               clearKeepalive();
-              onComplete(markerResp);
+              recallDiagnostics.finish("completed");
+              onComplete(continuationResp);
               safeClose();
               return;
             }
@@ -7469,6 +7529,16 @@ export function buildStreamingResponse(
           onComplete(response);
           safeClose();
         } catch (err) {
+          recallDiagnostics.finish(streamSignal.aborted ? "aborted" : "failed");
+          if (err instanceof RecallContinuationFailure)
+            reportRecallContinuationFailure(err.category);
+          if (recallFailureResponse) {
+            try {
+              recallContext?.onFailure?.(recallFailureResponse());
+            } catch {
+              log.error("recall failure accounting callback failed");
+            }
+          }
           streamSignal.removeEventListener("abort", onStreamAbort);
           clearKeepalive();
           clearRecallDeadline();
@@ -7504,6 +7574,7 @@ export function buildStreamingResponse(
       resumeDemand = undefined;
     },
     cancel() {
+      recallDiagnostics.finish("aborted");
       resumeDemand?.();
       resumeDemand = undefined;
       if (keepaliveTimer) clearTimeout(keepaliveTimer);
@@ -7567,6 +7638,7 @@ export function streamResponsesRecallAware(
     }) => void;
     sessionID?: string;
     maxRecallDepth?: number;
+    noStore?: boolean;
     maxDeferredBytes?: number;
     maxHiddenRecallBytes?: number;
     maxRetainedStateBytes?: number;
@@ -7602,6 +7674,8 @@ export function streamResponsesRecallAware(
     }>;
     /** Streaming follow-up stage: build + forward + assert-SSE + reader. */
     runFollowUp: (ctx: {
+      /** This is the one final continuation after the last allowed recall. */
+      finalRecallRound: boolean;
       anchorText: string;
       resultText: string;
       acc: GatewayResponse;
@@ -7615,6 +7689,7 @@ export function streamResponsesRecallAware(
     }>;
   },
 ): Response {
+  const recallDiagnostics = createRecallDiagnostics(!opts.noStore);
   const state = makeResponsesAccState();
   const syntheticIdentities = new Set<string>();
   const referenceIdentities = new Set<string>();
@@ -9256,6 +9331,7 @@ export function streamResponsesRecallAware(
   const finish = (resp: GatewayResponse, successful: boolean): boolean => {
     if (completionAttempted) return completed;
     completionAttempted = true;
+    recallDiagnostics.finish(successful ? "completed" : "failed");
     try {
       opts.onComplete(resp, successful);
       completed = true;
@@ -9304,6 +9380,7 @@ export function streamResponsesRecallAware(
       }
       throw signal.reason;
     }
+    recallDiagnostics.record(input, result.resultText);
     return result;
   };
   const settleFollowUp = async (
@@ -9548,6 +9625,7 @@ export function streamResponsesRecallAware(
   const cleanupAbort = (): void =>
     signal.removeEventListener("abort", onStreamAbort);
   const onStreamAbort = (): void => {
+    recallDiagnostics.finish("aborted");
     resumeDemand?.();
     resumeDemand = undefined;
     if (keepaliveTimer) clearTimeout(keepaliveTimer);
@@ -10057,6 +10135,7 @@ export function streamResponsesRecallAware(
                     continuationFailureCategory = "follow_up_setup";
                     signal.throwIfAborted();
                     let follow = await settleFollowUp({
+                      finalRecallRound: pendingRecalls.length >= maxRecallDepth,
                       anchorText: executed.anchorText,
                       resultText: executed.resultText,
                       acc: recallAcc,
@@ -10069,6 +10148,7 @@ export function streamResponsesRecallAware(
                     let continuationFollowUpInput: Parameters<
                       typeof opts.runFollowUp
                     >[0] = {
+                      finalRecallRound: pendingRecalls.length >= maxRecallDepth,
                       anchorText: executed.anchorText,
                       resultText: executed.resultText,
                       acc: recallAcc,
@@ -10505,6 +10585,7 @@ export function streamResponsesRecallAware(
                         }
                         if (
                           error instanceof SSEStreamTransportError &&
+                          !continuationFollowUpInput.finalRecallRound &&
                           recallContinuationTransportRetries <
                             maxRecallContinuationTransportRetries
                         ) {
@@ -10615,12 +10696,27 @@ export function streamResponsesRecallAware(
                         contState.usage,
                       );
                       mergeUsage(transactionProviderUsage, contState.usage);
-                      if (continuationFailed) {
+                      if (
+                        continuationFailed ||
+                        (continuationFollowUpInput.finalRecallRound &&
+                          contState.terminalEvent === "response.incomplete")
+                      ) {
                         throw new RecallContinuationFailure("follow_up_failed");
                       }
                       if (
                         !continuationCompleted ||
                         contState.rawItems.size === 0
+                      ) {
+                        throw new RecallContinuationFailure(
+                          "follow_up_missing_output",
+                        );
+                      }
+                      if (
+                        continuationFollowUpInput.finalRecallRound &&
+                        contPending.length === 0 &&
+                        !hasRecallContinuationOutput(
+                          finalizeResponsesAcc(contState),
+                        )
                       ) {
                         throw new RecallContinuationFailure(
                           "follow_up_missing_output",
@@ -10655,30 +10751,8 @@ export function streamResponsesRecallAware(
                       let nextAcc: GatewayResponse | undefined;
                       if (contPending.length === 1) {
                         if (recallDepth >= maxRecallDepth) {
-                          const exhaustedRecall = contPending[0];
-                          const shiftedRecallIndex = shiftedOutputIndex(
-                            exhaustedRecall.outputIndex,
-                            contIndex,
-                          );
-                          const marker = `Recall depth limit reached (${maxRecallDepth}).`;
-                          const syntheticId = `msg_${state.id || "lore"}_${shiftedRecallIndex}`;
-                          reserveSyntheticIdentity(syntheticId, [
-                            state,
-                            contState,
-                          ]);
-                          contState.items.set(exhaustedRecall.outputIndex, {
-                            type: "text",
-                            id: syntheticId,
-                            text: marker,
-                          });
-                          queueTransactional(
-                            encoder.encode(
-                              emitTextItem(
-                                shiftedRecallIndex,
-                                marker,
-                                syntheticId,
-                              ),
-                            ),
+                          throw new RecallContinuationFailure(
+                            "depth_exhausted",
                           );
                         } else {
                           recallDepth++;
@@ -10751,6 +10825,8 @@ export function streamResponsesRecallAware(
                         recallIndices.add(shiftedOutputIndex(index, contIndex));
                       }
                       mergeContinuation();
+                      if (continuationFollowUpInput.finalRecallRound)
+                        log.info("recall final continuation: completed");
                       if (!nextRecall || !nextExecuted || contOtherTool) {
                         state.stopReason = contState.stopReason;
                         state.terminalEvent = contState.terminalEvent;
@@ -10759,6 +10835,7 @@ export function streamResponsesRecallAware(
                       }
                       follow.commit?.();
                       continuationFollowUpInput = {
+                        finalRecallRound: recallDepth >= maxRecallDepth,
                         anchorText: nextExecuted.anchorText,
                         resultText: nextExecuted.resultText,
                         acc: nextAcc ?? finalizeResponsesAcc(contState),
@@ -11016,6 +11093,7 @@ export function streamResponsesRecallAware(
       resumeDemand = undefined;
     },
     cancel() {
+      recallDiagnostics.finish("aborted");
       resumeDemand?.();
       resumeDemand = undefined;
       cancelled = true;
@@ -17238,6 +17316,9 @@ async function handleConversationTurn(
   // Anthropic-format response, so the recall loop is protocol-agnostic here.
   // Without this, a `recall` tool_use injected by the gateway would leak to the
   // client (e.g. "Model tried to call unavailable tool 'recall'").
+  const bufferedRecallDiagnostics = createRecallDiagnostics(
+    !suppressTemporalStorage,
+  );
   const finalizeWithRecall = async (
     resp: GatewayResponse,
   ): Promise<Response> => {
@@ -17249,6 +17330,13 @@ async function handleConversationTurn(
     let currentModifiedReq = modifiedReq;
     const responsesVisibleContent: GatewayContentBlock[] = [];
     const cumulativeUsage = { ...(resp.usage ?? ZERO_USAGE) };
+    const failRecall = (
+      category: RecallContinuationFailureCategory,
+    ): Response => {
+      reportRecallContinuationFailure(category);
+      finishUnsuccessfulStreaming({ ...currentResp, usage: cumulativeUsage });
+      return errorResponse(502, "Recall continuation failed");
+    };
     // Whether this request opted into the 1M window (context-1m beta); gates the
     // client-usage cap so a 1M-capable model the client meters against 200K is
     // clamped below its ~167K auto-compact threshold (#910 regression).
@@ -17264,6 +17352,13 @@ async function handleConversationTurn(
     );
 
     while (hasRecallToolUse(currentResp) && recallDepth < MAX_RECALL_DEPTH) {
+      if (
+        currentResp.content.filter(
+          (block) =>
+            block.type === "tool_use" && block.name === RECALL_TOOL_NAME,
+        ).length > 1
+      )
+        return failRecall("parallel_recall");
       recallDepth++;
       const recallBlock = findRecallToolUse(currentResp);
       if (!recallBlock) break;
@@ -17280,6 +17375,7 @@ async function handleConversationTurn(
         foregroundAbort.signal,
       );
 
+      bufferedRecallDiagnostics.record(input, result);
       // Store recall result for marker round-trip expansion
       const scope = input.scope ?? "all";
       const anchorId = crypto.randomUUID();
@@ -17393,7 +17489,13 @@ async function handleConversationTurn(
             requestUpstreamRoute,
           ),
         parseJSON: (response, protocol, signal) =>
-          accumulateNonStreamResponse(response, protocol, false, signal),
+          accumulateNonStreamResponse(
+            response,
+            protocol,
+            false,
+            signal,
+            recallDepth === MAX_RECALL_DEPTH,
+          ),
         parseSSE: (response, signal) =>
           accumulateResponsesSSEStream(response, {
             signal,
@@ -17412,6 +17514,7 @@ async function handleConversationTurn(
               result,
               recallBlock,
               foregroundAbort.signal,
+              recallDepth === MAX_RECALL_DEPTH,
             )
           : await runRecallFollowUpJSON(
               jsonRecallCtx,
@@ -17420,6 +17523,7 @@ async function handleConversationTurn(
               result,
               recallBlock,
               foregroundAbort.signal,
+              recallDepth === MAX_RECALL_DEPTH,
             );
       } catch (fetchErr) {
         if (
@@ -17440,6 +17544,9 @@ async function handleConversationTurn(
         log.error(
           `recall follow-up fetch failed (non-stream, depth=${recallDepth}) for session ${sessionState.sessionID.slice(0, 16)}`,
         );
+        if (recallDepth === MAX_RECALL_DEPTH)
+          return failRecall("follow_up_failed");
+        bufferedRecallDiagnostics.finish("failed");
         // Fall back to response with marker (no continuation)
         markerResp.usage = cumulativeUsage;
         if (req.stream) {
@@ -17483,6 +17590,9 @@ async function handleConversationTurn(
           model: currentModifiedReq.model,
           sessionID: sessionState.sessionID,
         });
+        if (recallDepth === MAX_RECALL_DEPTH)
+          return failRecall("follow_up_failed");
+        bufferedRecallDiagnostics.finish("failed");
         // Fall back to response with marker (no continuation)
         markerResp.usage = cumulativeUsage;
         if (req.stream) {
@@ -17526,24 +17636,16 @@ async function handleConversationTurn(
       // Loop continues — hasRecallToolUse checked at top
     }
 
-    // Depth exhausted or no more recall — finalize
-    if (hasRecallToolUse(currentResp)) {
-      log.warn(
-        `recall depth exhausted (${MAX_RECALL_DEPTH}) — stripping remaining recall`,
-      );
-      currentResp = {
-        ...currentResp,
-        content: currentResp.content.map((block) =>
-          block.type === "tool_use" && block.name === RECALL_TOOL_NAME
-            ? {
-                type: "text" as const,
-                text: `Recall depth limit reached (${MAX_RECALL_DEPTH}).`,
-              }
-            : block,
-        ),
-      };
-    }
+    if (hasRecallToolUse(currentResp)) return failRecall("depth_exhausted");
+    if (
+      recallDepth === MAX_RECALL_DEPTH &&
+      (currentResp.stopReason === "max_tokens" ||
+        !hasRecallContinuationOutput(currentResp))
+    )
+      return failRecall("follow_up_failed");
     currentResp.usage = cumulativeUsage;
+    if (recallDepth === MAX_RECALL_DEPTH)
+      log.info("recall final continuation: completed");
     if (req.stream) {
       finishStreaming(currentResp);
     } else {
@@ -17593,8 +17695,18 @@ async function handleConversationTurn(
       longContext,
     );
   };
-  const finishWithRecall = async (resp: GatewayResponse): Promise<Response> =>
-    finishForeground(await awaitForeground(finalizeWithRecall(resp)));
+  const finishWithRecall = async (resp: GatewayResponse): Promise<Response> => {
+    try {
+      const response = await awaitForeground(finalizeWithRecall(resp));
+      bufferedRecallDiagnostics.finish(response.ok ? "completed" : "failed");
+      return finishForeground(response);
+    } catch (error) {
+      bufferedRecallDiagnostics.finish(
+        foregroundAbort.signal.aborted ? "aborted" : "failed",
+      );
+      throw error;
+    }
+  };
   function finishStreaming(resp: GatewayResponse): void {
     if (streamingFinalizerRegistered) return;
     streamingFinalizerRegistered = true;
@@ -17751,6 +17863,7 @@ async function handleConversationTurn(
               },
               sessionID: sessionState.sessionID,
               maxRecallDepth: MAX_RECALL_DEPTH,
+              noStore: suppressTemporalStorage,
               signal: foregroundAbort.signal,
               onRecall: async ({
                 query,
@@ -17865,6 +17978,7 @@ async function handleConversationTurn(
                 };
               },
               runFollowUp: async ({
+                finalRecallRound,
                 acc,
                 resultText,
                 toolUseId,
@@ -17909,6 +18023,7 @@ async function handleConversationTurn(
                   resultText,
                   recallBlock,
                   signal,
+                  finalRecallRound,
                 );
                 if (!follow.ok) {
                   throw new Error(
@@ -18015,6 +18130,7 @@ async function handleConversationTurn(
             cacheOptions,
             upstreamRoute: requestUpstreamRoute,
             noStore: suppressTemporalStorage,
+            onFailure: finishUnsuccessfulStreaming,
             clientSpeaksAnthropic: req.protocol === "anthropic",
             stableLtmText,
             ...(pendingKnowledgeDelta ? { pendingKnowledgeDelta } : {}),

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -6688,6 +6688,71 @@ async function forwardToUpstream(
 // Response builders
 // ---------------------------------------------------------------------------
 
+/** Stage recall effects; commit runs inside the successful-turn savepoint. */
+function createRecallPersistenceTransaction(
+  sessionState: SessionState,
+  noStore = false,
+) {
+  const pendingRecalls = new Map<string, StoredRecall>();
+  const pendingTransfers: Array<() => void> = [];
+  let baseline: Map<string, StoredRecall> | undefined;
+  let committed = false;
+  let rolledBack = false;
+  const candidateStore = (): Map<string, StoredRecall> => {
+    const candidate = new Map(sessionState.recallStore);
+    for (const [key, value] of pendingRecalls)
+      addRecallStoreEntry(candidate, key, value);
+    return candidate;
+  };
+  return {
+    deferTransfer: (record: () => void): void => {
+      if (!noStore && !committed && !rolledBack) pendingTransfers.push(record);
+    },
+    stage: (key: string, value: StoredRecall): void => {
+      if (noStore || committed || rolledBack) return;
+      // Enforce admission before exposing the marker without mutating live state.
+      addRecallStoreEntry(candidateStore(), key, value);
+      pendingRecalls.set(key, value);
+    },
+    commit: (): void => {
+      if (committed || rolledBack) return;
+      if (pendingRecalls.size === 0 && pendingTransfers.length === 0) {
+        committed = true;
+        return;
+      }
+      if (!noStore) {
+        candidateStore();
+        // Snapshot only within this synchronous commit, never across an await.
+        baseline = new Map(sessionState.recallStore);
+        for (const record of pendingTransfers) record();
+        for (const [key, value] of pendingRecalls) {
+          sessionState.recallStore.set(key, value);
+          recallPersistenceCommitObserver?.();
+        }
+        saveSessionTracking(sessionState.sessionID, {
+          recallStore: serializeRecallStore(sessionState.recallStore),
+        });
+      }
+      committed = true;
+      pendingRecalls.clear();
+      pendingTransfers.length = 0;
+    },
+    rollback: (): void => {
+      if (rolledBack) return;
+      rolledBack = true;
+      // The enclosing savepoint restores SQLite; restore the Map in place.
+      if (baseline) {
+        sessionState.recallStore.clear();
+        for (const [key, value] of baseline)
+          sessionState.recallStore.set(key, value);
+        baseline = undefined;
+      }
+      pendingRecalls.clear();
+      pendingTransfers.length = 0;
+    },
+  };
+}
+
 /**
  * Per-model cap for client usage scaling. Derives the model's real context
  * window and max-output budget (models.dev-backed) and mirrors Claude Code's
@@ -6744,6 +6809,11 @@ export function buildStreamingResponse(
     noStore?: boolean;
     /** Account failed recall continuations without persisting a successful reply. */
     onFailure?: (response: GatewayResponse) => void;
+    /** Transfer persistence to the request's downstream-success finalizer. */
+    onTransactionReady?: (transaction: {
+      commit: () => void;
+      rollback: () => void;
+    }) => void;
     /** True iff the inbound CLIENT speaks Anthropic SSE. Controls whether the
      *  recall marker is emitted as its own Anthropic SSE message envelope
      *  (split) or as an inline synthetic text content block (which the
@@ -6784,6 +6854,18 @@ export function buildStreamingResponse(
   maxReportedUsage: number = DEFAULT_MAX_REPORTED_USAGE,
   signal?: AbortSignal,
 ): Response {
+  const recallPersistence = recallContext
+    ? createRecallPersistenceTransaction(
+        recallContext.sessionState,
+        recallContext.noStore,
+      )
+    : undefined;
+  if (recallPersistence) recallContext?.onTransactionReady?.(recallPersistence);
+  let sourceSucceeded = false;
+  const complete = (response: GatewayResponse): void => {
+    onComplete(response);
+    sourceSucceeded = true;
+  };
   const recallDiagnostics = createRecallDiagnostics(
     recallContext !== undefined && !recallContext.noStore,
   );
@@ -6811,6 +6893,7 @@ export function buildStreamingResponse(
     ? AbortSignal.any([signal, recallAbort.signal])
     : recallAbort.signal;
   const onStreamAbort = (): void => {
+    recallPersistence?.rollback();
     resumeDemand?.();
     resumeDemand = undefined;
     if (signal?.aborted && !recallAbort.signal.aborted) {
@@ -7073,7 +7156,7 @@ export function buildStreamingResponse(
                         getLLMClient(recallContext.config),
                         alreadyInLtmIds.size > 0 ? alreadyInLtmIds : undefined,
                         streamSignal,
-                        recallContext.noStore ? () => {} : undefined,
+                        recallPersistence!.deferTransfer,
                       ),
                   ),
                 streamSignal,
@@ -7119,27 +7202,16 @@ export function buildStreamingResponse(
                 },
               );
               if (!recallContext.noStore) {
-                addRecallStoreEntry(
-                  recallContext.sessionState.recallStore,
-                  storeKey,
-                  {
-                    toolUseId: recallBlock.id,
-                    anchorId,
-                    anchorContextId,
-                    input,
-                    position,
-                    result,
-                    ...(companionToolUses.length > 0
-                      ? { companionToolUses }
-                      : {}),
-                  },
-                );
-                // Persist the store (v46) so the marker still expands byte-identically
-                // after a gateway restart instead of leaking raw marker text upstream.
-                saveSessionTracking(recallContext.sessionState.sessionID, {
-                  recallStore: serializeRecallStore(
-                    recallContext.sessionState.recallStore,
-                  ),
+                recallPersistence!.stage(storeKey, {
+                  toolUseId: recallBlock.id,
+                  anchorId,
+                  anchorContextId,
+                  input,
+                  position,
+                  result,
+                  ...(companionToolUses.length > 0
+                    ? { companionToolUses }
+                    : {}),
                 });
               }
 
@@ -7271,7 +7343,7 @@ export function buildStreamingResponse(
                 clearKeepalive();
                 markerResp.usage = cumulativeUsage;
                 recallDiagnostics.finish("completed");
-                onComplete(markerResp);
+                complete(markerResp);
                 safeClose();
                 return;
               }
@@ -7345,7 +7417,7 @@ export function buildStreamingResponse(
                 clearKeepalive();
                 markerResp.usage = cumulativeUsage;
                 recallDiagnostics.finish("failed");
-                onComplete(markerResp);
+                complete(markerResp);
                 safeClose();
                 return;
               }
@@ -7384,7 +7456,7 @@ export function buildStreamingResponse(
                 clearKeepalive();
                 markerResp.usage = cumulativeUsage;
                 recallDiagnostics.finish("failed");
-                onComplete(markerResp);
+                complete(markerResp);
                 safeClose();
                 return;
               }
@@ -7515,7 +7587,7 @@ export function buildStreamingResponse(
                 log.info("recall final continuation: completed");
               clearKeepalive();
               recallDiagnostics.finish("completed");
-              onComplete(continuationResp);
+              complete(continuationResp);
               safeClose();
               return;
             }
@@ -7524,9 +7596,10 @@ export function buildStreamingResponse(
           // No recall — normal path
           clearKeepalive();
           const response = accumulator.getResponse();
-          onComplete(response);
+          complete(response);
           safeClose();
         } catch (err) {
+          recallPersistence?.rollback();
           recallDiagnostics.finish(streamSignal.aborted ? "aborted" : "failed");
           if (err instanceof RecallContinuationFailure)
             reportRecallContinuationFailure(err.category);
@@ -7572,6 +7645,9 @@ export function buildStreamingResponse(
       resumeDemand = undefined;
     },
     cancel() {
+      // A translator may cancel its source after consuming a valid terminal.
+      // The request owner distinguishes that from actual downstream cancellation.
+      if (!recallContext?.onTransactionReady) recallPersistence?.rollback();
       recallDiagnostics.finish("aborted");
       resumeDemand?.();
       resumeDemand = undefined;
@@ -7588,7 +7664,7 @@ export function buildStreamingResponse(
     },
   });
 
-  return new Response(stream, {
+  const response = new Response(stream, {
     status: 200,
     headers: {
       "content-type": "text/event-stream",
@@ -7596,6 +7672,27 @@ export function buildStreamingResponse(
       connection: "keep-alive",
     },
   });
+  if (!recallPersistence || recallContext?.onTransactionReady) return response;
+  // Standalone callers also commit only when the returned body reaches EOF.
+  return wrapBodyWithCleanup(
+    response,
+    () => {
+      if (!sourceSucceeded || cancelled || streamSignal.aborted) {
+        recallPersistence.rollback();
+        return;
+      }
+      try {
+        withTenant(recallContext?.sessionState.storageTenantId ?? "", () =>
+          withSavepoint("native_recall_delivery", recallPersistence.commit),
+        );
+      } catch (error) {
+        recallPersistence.rollback();
+        throw error;
+      }
+    },
+    streamSignal,
+    recallPersistence.rollback,
+  );
 }
 
 /**
@@ -17273,6 +17370,7 @@ async function handleConversationTurn(
       response,
       releaseForeground,
       foregroundAbort.signal,
+      rollbackRecallPersistence,
     );
   };
   const awaitForeground = async <T>(operation: Promise<T>): Promise<T> => {
@@ -17374,49 +17472,10 @@ async function handleConversationTurn(
     let currentModifiedReq = modifiedReq;
     const responsesVisibleContent: GatewayContentBlock[] = [];
     const cumulativeUsage = { ...(resp.usage ?? ZERO_USAGE) };
-    const pendingRecalls = new Map<string, StoredRecall>();
-    const pendingTransfers: Array<() => void> = [];
-    let recallCommitBaseline: Map<string, StoredRecall> | undefined;
-    let recallCommitted = false;
-    let recallRolledBack = false;
-    const bufferedRecallTransaction = {
-      commit: (): void => {
-        if (recallCommitted || recallRolledBack) return;
-        if (!suppressTemporalStorage) {
-          // Validate against the live store before any writes. The baseline
-          // covers only this synchronous savepoint, never an upstream await.
-          const candidate = new Map(sessionState.recallStore);
-          for (const [key, value] of pendingRecalls)
-            addRecallStoreEntry(candidate, key, value);
-          recallCommitBaseline = new Map(sessionState.recallStore);
-          for (const record of pendingTransfers) record();
-          for (const [key, value] of pendingRecalls) {
-            sessionState.recallStore.set(key, value);
-            recallPersistenceCommitObserver?.();
-          }
-          saveSessionTracking(sessionState.sessionID, {
-            recallStore: serializeRecallStore(sessionState.recallStore),
-          });
-        }
-        recallCommitted = true;
-        pendingRecalls.clear();
-        pendingTransfers.length = 0;
-      },
-      rollback: (): void => {
-        if (recallRolledBack) return;
-        recallRolledBack = true;
-        // The enclosing savepoint restores DB writes. Restore the Map in
-        // place, including when savepoint release failed after commit().
-        if (recallCommitBaseline) {
-          sessionState.recallStore.clear();
-          for (const [key, value] of recallCommitBaseline)
-            sessionState.recallStore.set(key, value);
-          recallCommitBaseline = undefined;
-        }
-        pendingRecalls.clear();
-        pendingTransfers.length = 0;
-      },
-    };
+    const bufferedRecallTransaction = createRecallPersistenceTransaction(
+      sessionState,
+      suppressTemporalStorage,
+    );
     const finishBufferedResponse = (response: GatewayResponse): void => {
       if (req.stream || recallDepth > 0) {
         // Recall state and successful-turn storage share the existing atomic
@@ -17479,10 +17538,7 @@ async function handleConversationTurn(
             getLLMClient(config),
             alreadyInLtmIds.size > 0 ? alreadyInLtmIds : undefined,
             foregroundAbort.signal,
-            (record) => {
-              if (!suppressTemporalStorage && !recallRolledBack)
-                pendingTransfers.push(record);
-            },
+            bufferedRecallTransaction.deferTransfer,
           ),
         foregroundAbort.signal,
       );
@@ -17514,13 +17570,7 @@ async function handleConversationTurn(
           result,
           ...(companionToolUses.length > 0 ? { companionToolUses } : {}),
         };
-        // Preserve capacity checks before exposing a marker, while keeping
-        // staged entries invisible to other requests and persisted tracking.
-        const candidate = new Map(sessionState.recallStore);
-        for (const [key, value] of pendingRecalls)
-          addRecallStoreEntry(candidate, key, value);
-        addRecallStoreEntry(candidate, storeKey, storedRecall);
-        pendingRecalls.set(storeKey, storedRecall);
+        bufferedRecallTransaction.stage(storeKey, storedRecall);
       }
 
       const markerText = buildAnchoredRecallMarker(
@@ -18192,6 +18242,10 @@ async function handleConversationTurn(
             upstreamRoute: requestUpstreamRoute,
             noStore: suppressTemporalStorage,
             onFailure: finishUnsuccessfulStreaming,
+            onTransactionReady: (transaction) => {
+              rollbackRecallPersistence();
+              recallPersistenceTransaction = transaction;
+            },
             clientSpeaksAnthropic: req.protocol === "anthropic",
             stableLtmText,
             ...(pendingKnowledgeDelta ? { pendingKnowledgeDelta } : {}),

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -11784,6 +11784,13 @@ export function accumulateResponsesNonStreamJSON(
           for (const part of msgContent) {
             if (part.type === "output_text") {
               content.push({ type: "text", text: asString(part.text) });
+            } else if (
+              part.type === "refusal" &&
+              typeof part.refusal === "string"
+            ) {
+              // Other client protocols emit normalized content. Keep the raw
+              // refusal too for lossless native Responses output and replay.
+              content.push({ type: "text", text: part.refusal });
             }
           }
         }
@@ -11880,6 +11887,18 @@ export function responsesProvenanceContent(
     (block): block is Extract<GatewayContentBlock, { type: "text" }> =>
       block.type === "text",
   );
+  // Streaming refusals remain opaque; buffered refusals also have normalized
+  // text. Only the latter consume a text slot when replaying their raw part.
+  const opaqueMessageIds = new Set(
+    response.content.flatMap((block) =>
+      block.type === "opaque" &&
+      block.responsesItem === true &&
+      block.raw.type === "message" &&
+      typeof block.raw.id === "string"
+        ? [block.raw.id]
+        : [],
+    ),
+  );
   let textIndex = 0;
   for (const raw of response.rawOutputItems) {
     if (raw.type === "item_reference") continue;
@@ -11897,7 +11916,13 @@ export function responsesProvenanceContent(
           raw: { ...raw, content: [part] },
           responsesItem: true,
         });
-        if (part.type === "output_text" && typeof part.text === "string") {
+        if (
+          (part.type === "output_text" && typeof part.text === "string") ||
+          (part.type === "refusal" &&
+            typeof part.refusal === "string" &&
+            typeof raw.id === "string" &&
+            !opaqueMessageIds.has(raw.id))
+        ) {
           textIndex++;
         }
       }

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -11275,6 +11275,14 @@ async function preserveUpstreamErrorResponse(
   });
 }
 
+/** Parsed usage from a buffered response that lacks a valid completion. */
+class NonStreamCompletionError extends Error {
+  constructor(readonly response: GatewayResponse) {
+    super("upstream response did not complete");
+    this.name = "NonStreamCompletionError";
+  }
+}
+
 export async function accumulateNonStreamResponse(
   upstreamResponse: Response,
   protocol:
@@ -11345,19 +11353,29 @@ export async function accumulateNonStreamResponse(
     }
     return response;
   }
-  if (requireValidCompletion) {
-    assertValidNonStreamCompletion(json, protocol);
-  }
+  let response: GatewayResponse;
   switch (protocol) {
     case "openai":
-      return accumulateOpenAINonStreamJSON(json);
+      response = accumulateOpenAINonStreamJSON(json);
+      break;
     case "gemini":
-      return parseGeminiResponseJSON(json);
+      response = parseGeminiResponseJSON(json);
+      break;
     default:
       // Anthropic (incl. Bedrock via bedrock-mantle, which returns the native
       // Anthropic non-streaming JSON shape).
-      return accumulateAnthropicNonStreamJSON(json);
+      response = accumulateAnthropicNonStreamJSON(json);
   }
+  if (requireValidCompletion) {
+    try {
+      assertValidNonStreamCompletion(json, protocol);
+    } catch {
+      // The protocol parser validates usage before it can reach accounting.
+      // A missing terminal marker must still fail, never normalize to success.
+      throw new NonStreamCompletionError(response);
+    }
+  }
+  return response;
 }
 
 function parseResponsesNonStreamEnvelope(json: Record<string, unknown>): {
@@ -17352,10 +17370,73 @@ async function handleConversationTurn(
     let currentModifiedReq = modifiedReq;
     const responsesVisibleContent: GatewayContentBlock[] = [];
     const cumulativeUsage = { ...(resp.usage ?? ZERO_USAGE) };
+    const pendingRecalls = new Map<string, StoredRecall>();
+    const pendingTransfers: Array<() => void> = [];
+    let recallCommitBaseline: Map<string, StoredRecall> | undefined;
+    let recallCommitted = false;
+    let recallRolledBack = false;
+    const bufferedRecallTransaction = {
+      commit: (): void => {
+        if (recallCommitted || recallRolledBack) return;
+        if (!suppressTemporalStorage) {
+          // Validate against the live store before any writes. The baseline
+          // covers only this synchronous savepoint, never an upstream await.
+          const candidate = new Map(sessionState.recallStore);
+          for (const [key, value] of pendingRecalls)
+            addRecallStoreEntry(candidate, key, value);
+          recallCommitBaseline = new Map(sessionState.recallStore);
+          for (const record of pendingTransfers) record();
+          for (const [key, value] of pendingRecalls) {
+            sessionState.recallStore.set(key, value);
+            recallPersistenceCommitObserver?.();
+          }
+          saveSessionTracking(sessionState.sessionID, {
+            recallStore: serializeRecallStore(sessionState.recallStore),
+          });
+        }
+        recallCommitted = true;
+        pendingRecalls.clear();
+        pendingTransfers.length = 0;
+      },
+      rollback: (): void => {
+        if (recallRolledBack) return;
+        recallRolledBack = true;
+        // The enclosing savepoint restores DB writes. Restore the Map in
+        // place, including when savepoint release failed after commit().
+        if (recallCommitBaseline) {
+          sessionState.recallStore.clear();
+          for (const [key, value] of recallCommitBaseline)
+            sessionState.recallStore.set(key, value);
+          recallCommitBaseline = undefined;
+        }
+        pendingRecalls.clear();
+        pendingTransfers.length = 0;
+      },
+    };
+    const finishBufferedResponse = (response: GatewayResponse): void => {
+      if (req.stream || recallDepth > 0) {
+        // Recall state and successful-turn storage share the existing atomic
+        // finalizer, after downstream EOF, for buffered clients as well.
+        finishStreaming(response);
+      } else {
+        postResponse(
+          req,
+          response,
+          sessionState,
+          config,
+          temporalInput,
+          requestBody,
+          genAiSpan,
+          suppressTemporalStorage,
+          endGenAiSpan,
+        );
+      }
+    };
     const failRecall = (
       category: RecallContinuationFailureCategory,
     ): Response => {
       reportRecallContinuationFailure(category);
+      rollbackRecallPersistence();
       finishUnsuccessfulStreaming({ ...currentResp, usage: cumulativeUsage });
       return errorResponse(502, "Recall continuation failed");
     };
@@ -17382,6 +17463,7 @@ async function handleConversationTurn(
       )
         return failRecall("parallel_recall");
       recallDepth++;
+      recallPersistenceTransaction ??= bufferedRecallTransaction;
       const recallBlock = findRecallToolUse(currentResp);
       if (!recallBlock) break;
       const { result, input } = await promiseAgainstAbort(
@@ -17393,6 +17475,10 @@ async function handleConversationTurn(
             getLLMClient(config),
             alreadyInLtmIds.size > 0 ? alreadyInLtmIds : undefined,
             foregroundAbort.signal,
+            (record) => {
+              if (!suppressTemporalStorage && !recallRolledBack)
+                pendingTransfers.push(record);
+            },
           ),
         foregroundAbort.signal,
       );
@@ -17415,7 +17501,7 @@ async function handleConversationTurn(
         return [{ id: block.id, name: block.name, input: block.input, side }];
       });
       if (!suppressTemporalStorage) {
-        addRecallStoreEntry(sessionState.recallStore, storeKey, {
+        const storedRecall: StoredRecall = {
           toolUseId: recallBlock.id,
           anchorId,
           anchorContextId,
@@ -17423,12 +17509,14 @@ async function handleConversationTurn(
           position,
           result,
           ...(companionToolUses.length > 0 ? { companionToolUses } : {}),
-        });
-        // Persist the store (v46) so the marker still expands byte-identically
-        // after a gateway restart instead of leaking raw marker text upstream.
-        saveSessionTracking(sessionState.sessionID, {
-          recallStore: serializeRecallStore(sessionState.recallStore),
-        });
+        };
+        // Preserve capacity checks before exposing a marker, while keeping
+        // staged entries invisible to other requests and persisted tracking.
+        const candidate = new Map(sessionState.recallStore);
+        for (const [key, value] of pendingRecalls)
+          addRecallStoreEntry(candidate, key, value);
+        addRecallStoreEntry(candidate, storeKey, storedRecall);
+        pendingRecalls.set(storeKey, storedRecall);
       }
 
       const markerText = buildAnchoredRecallMarker(
@@ -17454,21 +17542,7 @@ async function handleConversationTurn(
           `recall (non-stream, mixed, depth=${recallDepth}): stored result for session ${sessionState.sessionID.slice(0, 16)}`,
         );
         markerResp.usage = cumulativeUsage;
-        if (req.stream) {
-          finishStreaming(markerResp);
-        } else {
-          postResponse(
-            req,
-            markerResp,
-            sessionState,
-            config,
-            temporalInput,
-            requestBody,
-            genAiSpan,
-            suppressTemporalStorage,
-            endGenAiSpan,
-          );
-        }
+        finishBufferedResponse(markerResp);
         return nonStreamHttpResponse(
           shouldInjectWarning
             ? injectContextWarning(markerResp, warningText)
@@ -17554,7 +17628,10 @@ async function handleConversationTurn(
         ) {
           throw fetchErr;
         }
-        if (fetchErr instanceof ResponsesTerminalError) {
+        if (
+          fetchErr instanceof ResponsesTerminalError ||
+          fetchErr instanceof NonStreamCompletionError
+        ) {
           Object.assign(
             cumulativeUsage,
             mergeRecallUsage(
@@ -17571,21 +17648,7 @@ async function handleConversationTurn(
         bufferedRecallDiagnostics.finish("failed");
         // Fall back to response with marker (no continuation)
         markerResp.usage = cumulativeUsage;
-        if (req.stream) {
-          finishStreaming(markerResp);
-        } else {
-          postResponse(
-            req,
-            markerResp,
-            sessionState,
-            config,
-            temporalInput,
-            requestBody,
-            genAiSpan,
-            suppressTemporalStorage,
-            endGenAiSpan,
-          );
-        }
+        finishBufferedResponse(markerResp);
         return nonStreamHttpResponse(
           shouldInjectWarning
             ? injectContextWarning(markerResp, warningText)
@@ -17617,21 +17680,7 @@ async function handleConversationTurn(
         bufferedRecallDiagnostics.finish("failed");
         // Fall back to response with marker (no continuation)
         markerResp.usage = cumulativeUsage;
-        if (req.stream) {
-          finishStreaming(markerResp);
-        } else {
-          postResponse(
-            req,
-            markerResp,
-            sessionState,
-            config,
-            temporalInput,
-            requestBody,
-            genAiSpan,
-            suppressTemporalStorage,
-            endGenAiSpan,
-          );
-        }
+        finishBufferedResponse(markerResp);
         return nonStreamHttpResponse(
           shouldInjectWarning
             ? injectContextWarning(markerResp, warningText)
@@ -17667,21 +17716,7 @@ async function handleConversationTurn(
     currentResp.usage = cumulativeUsage;
     if (recallDepth === MAX_RECALL_DEPTH)
       log.info("recall final continuation: completed");
-    if (req.stream) {
-      finishStreaming(currentResp);
-    } else {
-      postResponse(
-        req,
-        currentResp,
-        sessionState,
-        config,
-        temporalInput,
-        requestBody,
-        genAiSpan,
-        suppressTemporalStorage,
-        endGenAiSpan,
-      );
-    }
+    finishBufferedResponse(currentResp);
     // Telemetry: flag a completion we're about to hand back with NO usable
     // content (no text, no tool_use) — the "no response data" class
     // (github-copilot #1052 follow-up). Checked on the model's response, before
@@ -17722,6 +17757,7 @@ async function handleConversationTurn(
       bufferedRecallDiagnostics.finish(response.ok ? "completed" : "failed");
       return finishForeground(response);
     } catch (error) {
+      rollbackRecallPersistence();
       bufferedRecallDiagnostics.finish(
         foregroundAbort.signal.aborted ? "aborted" : "failed",
       );
@@ -17981,8 +18017,8 @@ async function handleConversationTurn(
                   anchorText,
                   resultText: result,
                   commit: () => {
-                    for (const record of deferredTransferRecordings) record();
                     if (suppressTemporalStorage) return;
+                    for (const record of deferredTransferRecordings) record();
                     addRecallStoreEntry(
                       sessionState.recallStore,
                       storeKey,

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -11346,36 +11346,39 @@ export async function accumulateNonStreamResponse(
   }
 
   const json = JSON.parse(body) as Record<string, unknown>;
-  if (protocol === "openai-responses") {
-    const { response, status } = parseResponsesNonStreamEnvelope(json);
-    if (status !== "completed") {
-      throw new ResponsesTerminalError(response, status);
+  const parseResponse =
+    protocol === "openai-responses"
+      ? accumulateResponsesNonStreamJSON
+      : protocol === "openai"
+        ? accumulateOpenAINonStreamJSON
+        : protocol === "gemini"
+          ? parseGeminiResponseJSON
+          : accumulateAnthropicNonStreamJSON;
+  let response: GatewayResponse | undefined;
+  try {
+    if (protocol === "openai-responses") {
+      const parsed = parseResponsesNonStreamEnvelope(json);
+      response = parsed.response;
+      if (parsed.status !== "completed")
+        throw new ResponsesTerminalError(response, parsed.status);
+    } else {
+      response = parseResponse(json);
+      if (requireValidCompletion)
+        assertValidNonStreamCompletion(json, protocol);
     }
     return response;
+  } catch (error) {
+    if (!requireValidCompletion || error instanceof ResponsesTerminalError)
+      throw error;
+    // Content parsing can fail before usage validation. Reuse the same parser
+    // on usage fields alone, retaining its numeric and cache consistency checks.
+    // Invalid usage still throws; the projection is never returned as success.
+    response ??= parseResponse({
+      usage: json.usage,
+      usageMetadata: json.usageMetadata,
+    });
+    throw new NonStreamCompletionError(response);
   }
-  let response: GatewayResponse;
-  switch (protocol) {
-    case "openai":
-      response = accumulateOpenAINonStreamJSON(json);
-      break;
-    case "gemini":
-      response = parseGeminiResponseJSON(json);
-      break;
-    default:
-      // Anthropic (incl. Bedrock via bedrock-mantle, which returns the native
-      // Anthropic non-streaming JSON shape).
-      response = accumulateAnthropicNonStreamJSON(json);
-  }
-  if (requireValidCompletion) {
-    try {
-      assertValidNonStreamCompletion(json, protocol);
-    } catch {
-      // The protocol parser validates usage before it can reach accounting.
-      // A missing terminal marker must still fail, never normalize to success.
-      throw new NonStreamCompletionError(response);
-    }
-  }
-  return response;
 }
 
 function parseResponsesNonStreamEnvelope(json: Record<string, unknown>): {

--- a/packages/gateway/src/recall-diagnostics.ts
+++ b/packages/gateway/src/recall-diagnostics.ts
@@ -1,0 +1,61 @@
+import { createHash } from "node:crypto";
+import { log } from "@loreai/core";
+import { MAX_RECALL_DEPTH } from "./recall";
+
+/** Request-local comparisons only. Fingerprints and recall content never leave this closure. */
+export function createRecallDiagnostics(enabled = true) {
+  const inputs = new Set<string>();
+  const results = new Set<string>();
+  const pairs = new Set<string>();
+  const started = performance.now();
+  let finished = false;
+  let rounds = 0;
+  let detailCalls = 0;
+  let emptyBodies = 0;
+  let resultBytes = 0;
+  const fingerprint = (value: string) =>
+    createHash("sha256").update(value).digest("hex");
+  return {
+    record(
+      input: { query: string; scope?: string; id?: string },
+      result: string,
+    ): void {
+      if (!enabled || finished || rounds >= MAX_RECALL_DEPTH) return;
+      rounds++;
+      if (input.id) detailCalls++;
+      if (!result.trim()) emptyBodies++;
+      resultBytes += Buffer.byteLength(result);
+      // ID lookup ignores query; scope stays part of the conservative comparison.
+      const inputKey = fingerprint(
+        JSON.stringify([
+          input.scope ?? "all",
+          input.id || null,
+          input.id ? null : input.query.trim(),
+        ]),
+      );
+      const resultKey = fingerprint(result);
+      const pair = `${inputKey}:${resultKey}`;
+      const repeatedInput = inputs.has(inputKey);
+      const repeatedResult = results.has(resultKey);
+      const repeatedPair = pairs.has(pair);
+      inputs.add(inputKey);
+      results.add(resultKey);
+      pairs.add(pair);
+      log.info(
+        `recall-round ${JSON.stringify({ round: rounds, kind: input.id ? "detail" : "search", repeatedInput, repeatedResult, repeatedPair, resultBytes: Buffer.byteLength(result) })}`,
+      );
+    },
+    finish(outcome: "completed" | "failed" | "aborted"): void {
+      if (finished) return;
+      finished = true;
+      if (enabled && rounds > 0) {
+        log.info(
+          `recall-chain ${JSON.stringify({ outcome, rounds, detailCalls, repeatedInputs: rounds - inputs.size, repeatedResults: rounds - results.size, repeatedPairs: rounds - pairs.size, emptyBodies, resultBytes, elapsedMs: Math.min(300_000, Math.max(0, Math.round(performance.now() - started))) })}`,
+        );
+      }
+      inputs.clear();
+      results.clear();
+      pairs.clear();
+    },
+  };
+}

--- a/packages/gateway/src/recall.ts
+++ b/packages/gateway/src/recall.ts
@@ -1013,7 +1013,13 @@ export interface RecallFollowUpCtx {
 }
 
 /** A final recall continuation must give the client an answer or a tool handoff. */
-export function hasRecallContinuationOutput(resp: GatewayResponse): boolean {
+export function isUsableRecallContinuation(resp: GatewayResponse): boolean {
+  if (
+    ["max_tokens", "pause_turn", "model_context_window_exceeded"].includes(
+      resp.stopReason,
+    )
+  )
+    return false;
   return resp.content.some((block) => {
     if (block.type === "text") return block.text.trim().length > 0;
     if (block.type === "tool_use") return block.name !== RECALL_TOOL_NAME;

--- a/packages/gateway/src/recall.ts
+++ b/packages/gateway/src/recall.ts
@@ -1012,7 +1012,23 @@ export interface RecallFollowUpCtx {
   ) => Promise<GatewayResponse>;
 }
 
-/** A final recall continuation must give the client an answer or a tool handoff. */
+function hasResponsesRefusal(item: Record<string, unknown>): boolean {
+  return (
+    item.type === "message" &&
+    Array.isArray(item.content) &&
+    item.content.some((part: unknown) => {
+      if (!part || typeof part !== "object") return false;
+      const refusal = part as Record<string, unknown>;
+      return (
+        refusal.type === "refusal" &&
+        typeof refusal.refusal === "string" &&
+        refusal.refusal.trim().length > 0
+      );
+    })
+  );
+}
+
+/** A final recall continuation must give the client an answer, refusal, or tool handoff. */
 export function isUsableRecallContinuation(resp: GatewayResponse): boolean {
   if (
     ["max_tokens", "pause_turn", "model_context_window_exceeded"].includes(
@@ -1020,26 +1036,19 @@ export function isUsableRecallContinuation(resp: GatewayResponse): boolean {
     )
   )
     return false;
-  return resp.content.some((block) => {
-    if (block.type === "text") return block.text.trim().length > 0;
-    if (block.type === "tool_use") return block.name !== RECALL_TOOL_NAME;
-    // Responses refusals stay opaque for lossless replay, but are visible output.
-    return (
-      block.type === "opaque" &&
-      block.responsesItem === true &&
-      block.raw.type === "message" &&
-      Array.isArray(block.raw.content) &&
-      block.raw.content.some((part: unknown) => {
-        if (!part || typeof part !== "object") return false;
-        const refusal = part as Record<string, unknown>;
-        return (
-          refusal.type === "refusal" &&
-          typeof refusal.refusal === "string" &&
-          refusal.refusal.trim().length > 0
-        );
-      })
-    );
-  });
+  return (
+    resp.content.some((block) => {
+      if (block.type === "text") return block.text.trim().length > 0;
+      if (block.type === "tool_use") return block.name !== RECALL_TOOL_NAME;
+      return (
+        block.type === "opaque" &&
+        block.responsesItem === true &&
+        hasResponsesRefusal(block.raw)
+      );
+    }) ||
+    // Buffered Responses refusals live only in the lossless raw output items.
+    (resp.rawOutputItems?.some(hasResponsesRefusal) ?? false)
+  );
 }
 
 /**

--- a/packages/gateway/src/recall.ts
+++ b/packages/gateway/src/recall.ts
@@ -1036,6 +1036,16 @@ export function isUsableRecallContinuation(resp: GatewayResponse): boolean {
     )
   )
     return false;
+  // A usable sibling must not hide an undispatchable tool call. Validate every
+  // name without changing the provider's tool names or cached tool definitions.
+  if (
+    resp.content.some(
+      (block) =>
+        block.type === "tool_use" &&
+        (typeof block.name !== "string" || block.name.trim().length === 0),
+    )
+  )
+    return false;
   return (
     resp.content.some((block) => {
       if (block.type === "text") return block.text.trim().length > 0;

--- a/packages/gateway/src/recall.ts
+++ b/packages/gateway/src/recall.ts
@@ -1552,7 +1552,7 @@ export function replaceRecallWithMarker(
     if (typeof item.id === "string") usedIds.add(item.id);
     if (typeof item.call_id === "string") usedIds.add(item.call_id);
   }
-  const rawOutputItems = resp.rawOutputItems?.map((item, index) => {
+  const rawOutputItems = resp.rawOutputItems?.map((item) => {
     const callId = typeof item.call_id === "string" ? item.call_id : item.id;
     if (
       item.type !== "function_call" ||
@@ -1561,7 +1561,15 @@ export function replaceRecallWithMarker(
       !replaced.has(callId)
     )
       return item;
-    const baseId = `msg_lore_recall_${index}`;
+    // Provider identities distinguish successive turns too: an array index
+    // would reuse the same message ID when clients replay multiple markers.
+    // Fixed-length hex keeps a local collision suffix from aliasing a
+    // different provider identity on a later turn (e.g. fc_a vs fc_a_1).
+    const identity = createHash("sha256")
+      .update(typeof item.id === "string" ? item.id : callId)
+      .digest("hex")
+      .slice(0, 32);
+    const baseId = `msg_lore_recall_${identity}`;
     let id = baseId;
     for (let suffix = 1; usedIds.has(id); suffix++) id = `${baseId}_${suffix}`;
     usedIds.add(id);

--- a/packages/gateway/src/recall.ts
+++ b/packages/gateway/src/recall.ts
@@ -1534,21 +1534,50 @@ export function replaceRecallWithMarker(
   resp: GatewayResponse,
   markers?: ReadonlyMap<string, string>,
 ): GatewayResponse {
+  const replaced = new Map<string, string>();
+  const content = resp.content.map((b) => {
+    if (b.type !== "tool_use" || b.name !== RECALL_TOOL_NAME) return b;
+    const input = b.input as Record<string, unknown>;
+    const query = typeof input.query === "string" ? input.query : "";
+    const scope = (input.scope as string) ?? "all";
+    const id = typeof input.id === "string" && input.id ? input.id : undefined;
+    const text = markers?.get(b.id) ?? buildRecallMarker(query, scope, id);
+    replaced.set(b.id, text);
+    return { type: "text" as const, text };
+  });
+  // Native Responses delivery uses the raw items. Rewrite only the calls we
+  // replaced above, preserving sibling items and provider-owned objects.
+  const usedIds = new Set<string>();
+  for (const item of resp.rawOutputItems ?? []) {
+    if (typeof item.id === "string") usedIds.add(item.id);
+    if (typeof item.call_id === "string") usedIds.add(item.call_id);
+  }
+  const rawOutputItems = resp.rawOutputItems?.map((item, index) => {
+    const callId = typeof item.call_id === "string" ? item.call_id : item.id;
+    if (
+      item.type !== "function_call" ||
+      item.name !== RECALL_TOOL_NAME ||
+      typeof callId !== "string" ||
+      !replaced.has(callId)
+    )
+      return item;
+    const baseId = `msg_lore_recall_${index}`;
+    let id = baseId;
+    for (let suffix = 1; usedIds.has(id); suffix++) id = `${baseId}_${suffix}`;
+    usedIds.add(id);
+    return {
+      type: "message",
+      id,
+      role: "assistant",
+      status: "completed",
+      content: [
+        { type: "output_text", text: replaced.get(callId)!, annotations: [] },
+      ],
+    };
+  });
   return {
     ...resp,
-    content: resp.content.map((b) => {
-      if (b.type === "tool_use" && b.name === RECALL_TOOL_NAME) {
-        const input = b.input as Record<string, unknown>;
-        const query = typeof input.query === "string" ? input.query : "";
-        const scope = (input.scope as string) ?? "all";
-        const id =
-          typeof input.id === "string" && input.id ? input.id : undefined;
-        return {
-          type: "text" as const,
-          text: markers?.get(b.id) ?? buildRecallMarker(query, scope, id),
-        };
-      }
-      return b;
-    }),
+    content,
+    ...(rawOutputItems ? { rawOutputItems } : {}),
   };
 }

--- a/packages/gateway/src/recall.ts
+++ b/packages/gateway/src/recall.ts
@@ -1012,6 +1012,30 @@ export interface RecallFollowUpCtx {
   ) => Promise<GatewayResponse>;
 }
 
+/** A final recall continuation must give the client an answer or a tool handoff. */
+export function hasRecallContinuationOutput(resp: GatewayResponse): boolean {
+  return resp.content.some((block) => {
+    if (block.type === "text") return block.text.trim().length > 0;
+    if (block.type === "tool_use") return block.name !== RECALL_TOOL_NAME;
+    // Responses refusals stay opaque for lossless replay, but are visible output.
+    return (
+      block.type === "opaque" &&
+      block.responsesItem === true &&
+      block.raw.type === "message" &&
+      Array.isArray(block.raw.content) &&
+      block.raw.content.some((part: unknown) => {
+        if (!part || typeof part !== "object") return false;
+        const refusal = part as Record<string, unknown>;
+        return (
+          refusal.type === "refusal" &&
+          typeof refusal.refusal === "string" &&
+          refusal.refusal.trim().length > 0
+        );
+      })
+    );
+  });
+}
+
 /**
  * Build a follow-up request after recall execution.
  *
@@ -1019,10 +1043,10 @@ export interface RecallFollowUpCtx {
  *  - All original messages
  *  - A synthetic assistant message with thinking blocks + recall tool_use
  *  - A user message with recall results as a tool_result
- *  - Full tools list (including recall — the continuation is recall-aware)
+ *  - Full tools list on every round, preserving the cached tool prefix
  *
  * The model continues from where it left off, now with recall results
- * in context. If it needs more detail it can call recall again.
+ * in context. On the final round, it must finish using the available results.
  *
  * `stream` is REQUIRED (no default) and MUST match how the caller consumes
  * the upstream response: `false` → JSON via `accumulateNonStreamResponse()`,
@@ -1038,7 +1062,9 @@ export function buildRecallFollowUpRequest(
   recallResult: string,
   recallToolUseBlock: GatewayToolUseBlock,
   stream: boolean,
+  finalRecallRound = false,
 ): GatewayRequest {
+  if (finalRecallRound) log.info("recall final continuation: budget exhausted");
   // Build the follow-up using proper tool_use/tool_result pairs.
   //
   // Why: sending recall results as plain user text causes the LLM to treat
@@ -1095,6 +1121,14 @@ export function buildRecallFollowUpRequest(
         toolName: recallToolUseBlock.name,
         content: [
           { type: "text", text: recallResult || "[No results found.]" },
+          ...(finalRecallRound
+            ? [
+                {
+                  type: "text" as const,
+                  text: "The recall budget for this turn has been used. Continue the user's task using the results already available. Give your best supported answer, state any remaining uncertainty, or use an available non-recall tool. Do not request recall again.",
+                },
+              ]
+            : []),
         ],
       },
     ],
@@ -1308,6 +1342,7 @@ export async function runRecallFollowUpStreaming(
   recallResult: string,
   recallToolUseBlock: GatewayToolUseBlock,
   signal?: AbortSignal,
+  finalRecallRound = false,
 ): Promise<RecallFollowUpStreaming | RecallFollowUpError> {
   const followUp = buildRecallFollowUpRequest(
     originalReq,
@@ -1315,6 +1350,7 @@ export async function runRecallFollowUpStreaming(
     recallResult,
     recallToolUseBlock,
     /* stream */ true,
+    finalRecallRound,
   );
   const { response } = await promiseAgainstAbort(
     () => ctx.forward(followUp, signal),
@@ -1359,6 +1395,7 @@ export async function runRecallFollowUpJSON(
   recallResult: string,
   recallToolUseBlock: GatewayToolUseBlock,
   signal?: AbortSignal,
+  finalRecallRound = false,
 ): Promise<RecallFollowUpJSON | RecallFollowUpError> {
   const followUp = buildRecallFollowUpRequest(
     originalReq,
@@ -1366,6 +1403,7 @@ export async function runRecallFollowUpJSON(
     recallResult,
     recallToolUseBlock,
     /* stream */ false,
+    finalRecallRound,
   );
   const { response, effectiveProtocol } = await promiseAgainstAbort(
     () => ctx.forward(followUp, signal),
@@ -1421,6 +1459,7 @@ export async function runRecallFollowUpStreamAccumulated(
   recallResult: string,
   recallToolUseBlock: GatewayToolUseBlock,
   signal?: AbortSignal,
+  finalRecallRound = false,
 ): Promise<RecallFollowUpJSON | RecallFollowUpError> {
   const parseSSE = ctx.parseSSE;
   if (!parseSSE) {
@@ -1434,6 +1473,7 @@ export async function runRecallFollowUpStreamAccumulated(
     recallResult,
     recallToolUseBlock,
     /* stream */ true,
+    finalRecallRound,
   );
   const { response } = await promiseAgainstAbort(
     () => ctx.forward(followUp, signal),

--- a/packages/gateway/src/stream/openai.ts
+++ b/packages/gateway/src/stream/openai.ts
@@ -83,7 +83,12 @@ function mapStopReason(reason: string): string {
  */
 export function translateAnthropicStreamToOpenAI(
   anthropicResponse: Response,
-  opts: { strict?: boolean; signal?: AbortSignal } = {},
+  opts: {
+    strict?: boolean;
+    signal?: AbortSignal;
+    /** Preserve failures from a validated source without revalidating generated SSE. */
+    propagateErrors?: boolean;
+  } = {},
 ): Response {
   const encoder = new TextEncoder();
   const accumulator = createStreamAccumulator();
@@ -392,7 +397,7 @@ export function translateAnthropicStreamToOpenAI(
           }
           validator?.assertDone();
         } catch (err) {
-          if (opts.strict) {
+          if (opts.strict || opts.propagateErrors) {
             log.error("openai stream translation validation error:", err);
             try {
               controller.error(err);

--- a/packages/gateway/test/anthropic-recall-continuation-abort.test.ts
+++ b/packages/gateway/test/anthropic-recall-continuation-abort.test.ts
@@ -168,16 +168,24 @@ afterEach(() => {
 });
 
 describe("Anthropic recall continuation abort", () => {
-  test.each(["caller", "deadline"] as const)(
-    "%s abort settles a hostile nonterminal follow-up",
-    async (mode) => {
+  test.each([
+    ["caller", 1],
+    ["deadline", 1],
+    ["caller", 10],
+    ["deadline", 10],
+  ] as const)(
+    "%s abort settles a hostile nonterminal follow-up at round %i",
+    async (mode, round) => {
       if (mode === "deadline") vi.useFakeTimers();
       mockedRecall.mockResolvedValue({
         result: "recall results",
         input: { query: "architecture" },
       });
       const continuation = hostileContinuation(mode === "deadline");
-      setUpstreamInterceptor(async () => continuation.response);
+      let follows = 0;
+      setUpstreamInterceptor(async () =>
+        ++follows < round ? recallOnlyResponse() : continuation.response,
+      );
       const caller = new AbortController();
       const req = request(caller.signal);
       const state = sessionState();
@@ -210,8 +218,138 @@ describe("Anthropic recall continuation abort", () => {
         await vi.advanceTimersByTimeAsync(300_000);
         await expect(outcome).resolves.toMatchObject({ name: "TimeoutError" });
       }
+      expect(follows).toBe(round);
       expect(continuation.cancelled()).toBe(true);
       expect(continuation.response.body?.locked).toBe(false);
     },
   );
 });
+
+describe.each([true, false])(
+  "Anthropic recall exhaustion recovery (native=%s)",
+  (clientSpeaksAnthropic) => {
+    test.each([
+      "answer",
+      "recall",
+      "http-error",
+      "empty",
+      "incomplete",
+    ] as const)("last continuation: %s", async (mode) => {
+      mockedRecall.mockResolvedValue({
+        result: "recall results",
+        input: { query: "architecture" },
+      });
+      const finalText =
+        mode === "empty" ? "" : "Finished using available results.";
+      const completed = vi.fn();
+      const failed = vi.fn();
+      let calls = 0;
+      const req = request();
+      req.tools.push({ name: "Read", description: "Read", inputSchema: {} });
+      req.metadata.tool_choice = { type: "tool", name: "recall" };
+      setUpstreamInterceptor(async (upstream) => {
+        calls++;
+        if (calls < 10) return recallOnlyResponse();
+        const body = upstream as Record<string, unknown>;
+        expect(body.tools).toEqual([
+          expect.objectContaining({ name: "recall" }),
+          expect.objectContaining({ name: "Read" }),
+        ]);
+        expect(body.tool_choice).toEqual({ type: "tool", name: "recall" });
+        expect(JSON.stringify(body.messages)).toContain(
+          "The recall budget for this turn has been used",
+        );
+        if (mode === "http-error")
+          return new Response("unavailable", { status: 503 });
+        if (mode === "recall") return recallOnlyResponse();
+        return new Response(
+          event("message_start", {
+            message: {
+              id: "msg_final",
+              type: "message",
+              role: "assistant",
+              model: "claude-test",
+              content: [],
+              stop_reason: null,
+              stop_sequence: null,
+              usage: { input_tokens: 3, output_tokens: 0 },
+            },
+          }) +
+            event("content_block_start", {
+              index: 0,
+              content_block: { type: "text", text: "" },
+            }) +
+            event("content_block_delta", {
+              index: 0,
+              delta: { type: "text_delta", text: finalText },
+            }) +
+            event("content_block_stop", { index: 0 }) +
+            event("message_delta", {
+              delta: {
+                stop_reason: mode === "incomplete" ? "max_tokens" : "end_turn",
+                stop_sequence: null,
+              },
+              usage: { output_tokens: 2 },
+            }) +
+            event("message_stop", {}),
+          { headers: { "content-type": "text/event-stream" } },
+        );
+      });
+      const state = sessionState();
+      const downstream = buildStreamingResponse(
+        recallOnlyResponse(),
+        completed,
+        {
+          clientMessages: req.messages,
+          modifiedReq: req,
+          config: loadLocalConfig(),
+          sessionState: state,
+          cacheOptions: { cacheConversation: false },
+          clientSpeaksAnthropic,
+          noStore: true,
+          onFailure: failed,
+        },
+      );
+      if (mode === "answer") {
+        expect(await downstream.text()).toContain(finalText);
+        expect(completed).toHaveBeenCalledTimes(1);
+        expect(completed.mock.calls[0][0]).toMatchObject({
+          content: [{ type: "text", text: finalText }],
+          usage: { inputTokens: 13, outputTokens: 12 },
+        });
+      } else {
+        const reader = downstream.body!.getReader();
+        let received = "";
+        let failure: unknown;
+        try {
+          for (;;) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            received += new TextDecoder().decode(value);
+          }
+        } catch (error) {
+          failure = error;
+        }
+        expect(failure).toBeInstanceOf(Error);
+        // Read wire events incrementally: response.text() discards earlier bytes
+        // on error and can hide a success terminal already delivered to a client.
+        expect(received).not.toContain('"stop_reason":"max_tokens"');
+        expect(received.match(/^event: message_delta$/gm) ?? []).toHaveLength(
+          clientSpeaksAnthropic ? 20 : 0,
+        );
+        expect(received.match(/^event: message_stop$/gm) ?? []).toHaveLength(
+          clientSpeaksAnthropic ? 20 : 0,
+        );
+        expect(completed).not.toHaveBeenCalled();
+        expect(failed).toHaveBeenCalledTimes(1);
+        const tokens = mode === "recall" ? 11 : 10;
+        expect(failed.mock.calls[0][0].usage).toMatchObject({
+          inputTokens: mode === "empty" || mode === "incomplete" ? 13 : tokens,
+          outputTokens: mode === "empty" || mode === "incomplete" ? 12 : tokens,
+        });
+      }
+      expect(calls).toBe(10);
+      expect(mockedRecall).toHaveBeenCalledTimes(10);
+    });
+  },
+);

--- a/packages/gateway/test/anthropic-recall-continuation-abort.test.ts
+++ b/packages/gateway/test/anthropic-recall-continuation-abort.test.ts
@@ -234,6 +234,8 @@ describe.each([true, false])(
       "http-error",
       "empty",
       "incomplete",
+      "pause_turn",
+      "model_context_window_exceeded",
     ] as const)("last continuation: %s", async (mode) => {
       mockedRecall.mockResolvedValue({
         result: "recall results",
@@ -286,7 +288,13 @@ describe.each([true, false])(
             event("content_block_stop", { index: 0 }) +
             event("message_delta", {
               delta: {
-                stop_reason: mode === "incomplete" ? "max_tokens" : "end_turn",
+                stop_reason:
+                  mode === "incomplete"
+                    ? "max_tokens"
+                    : mode === "pause_turn" ||
+                        mode === "model_context_window_exceeded"
+                      ? mode
+                      : "end_turn",
                 stop_sequence: null,
               },
               usage: { output_tokens: 2 },
@@ -344,8 +352,9 @@ describe.each([true, false])(
         expect(failed).toHaveBeenCalledTimes(1);
         const tokens = mode === "recall" ? 11 : 10;
         expect(failed.mock.calls[0][0].usage).toMatchObject({
-          inputTokens: mode === "empty" || mode === "incomplete" ? 13 : tokens,
-          outputTokens: mode === "empty" || mode === "incomplete" ? 12 : tokens,
+          inputTokens: mode !== "recall" && mode !== "http-error" ? 13 : tokens,
+          outputTokens:
+            mode !== "recall" && mode !== "http-error" ? 12 : tokens,
         });
       }
       expect(calls).toBe(10);

--- a/packages/gateway/test/foreground-body-limit.test.ts
+++ b/packages/gateway/test/foreground-body-limit.test.ts
@@ -209,7 +209,11 @@ describe("foreground response body limits", () => {
         undefined,
         true,
       ),
-    ).rejects.toThrow("upstream Responses request did not complete");
+    ).rejects.toMatchObject({
+      name: "NonStreamCompletionError",
+      message: "upstream response did not complete",
+      response: { usage: { inputTokens: 7, outputTokens: 2 } },
+    });
   });
 
   test("rejects provider-specific non-stream incomplete reasons for Codex", async () => {
@@ -233,7 +237,11 @@ describe("foreground response body limits", () => {
         undefined,
         true,
       ),
-    ).rejects.toThrow("upstream Responses request did not complete");
+    ).rejects.toMatchObject({
+      name: "NonStreamCompletionError",
+      message: "upstream response did not complete",
+      response: { usage: { inputTokens: 7, outputTokens: 2 } },
+    });
   });
 
   test("rejects in-progress items in a completed non-stream response", async () => {

--- a/packages/gateway/test/openai-responses-recall-aware-stream.test.ts
+++ b/packages/gateway/test/openai-responses-recall-aware-stream.test.ts
@@ -4259,6 +4259,169 @@ describe("streamResponsesRecallAware", () => {
     expect(await drain(client)).toContain(PUBLIC_RECALL_ERROR);
   });
 
+  test.each([1, 10])(
+    "marks only the final continuation at budget %i and preserves ordinary tools",
+    async (budget) => {
+      let recalls = 0;
+      let follows = 0;
+      let finalResponse: GatewayResponse | undefined;
+      const finalFlags: boolean[] = [];
+      const client = streamResponsesRecallAware(
+        streamFrom([
+          created("resp_initial", "gpt-5.6-terra"),
+          recallCall(0, { query: "start" }, "fc_initial", "call_initial"),
+          completed("resp_initial", { input_tokens: 1, output_tokens: 2 }),
+        ]),
+        {
+          maxRecallDepth: budget,
+          onComplete: (response, successful) => {
+            expect(successful).toBe(true);
+            finalResponse = response;
+          },
+          onRecall: async () => {
+            recalls++;
+            return {
+              anchorText: buildAnchor(`q${recalls}`),
+              resultText: "result",
+            };
+          },
+          runFollowUp: async ({ finalRecallRound }) => {
+            follows++;
+            finalFlags.push(finalRecallRound);
+            const item = recallCall(
+              0,
+              { query: `q${follows}` },
+              `fc_${follows}`,
+              `call_${follows}`,
+            );
+            return {
+              reader: streamFrom([
+                created(`resp_${follows}`, "gpt-5.6-terra"),
+                follows === budget
+                  ? item.replaceAll('"name":"recall"', '"name":"Read"')
+                  : item,
+                completed(`resp_${follows}`, {
+                  input_tokens: 3,
+                  output_tokens: 4,
+                }),
+              ]).body!.getReader(),
+            };
+          },
+        },
+      );
+      const output = await drain(client);
+      expect(recalls).toBe(budget);
+      expect(follows).toBe(budget);
+      expect(finalFlags).toEqual([
+        ...Array.from({ length: budget - 1 }, () => false),
+        true,
+      ]);
+      expect(output.match(/^event: response\.completed$/gm)).toHaveLength(1);
+      expect(finalResponse?.content).toContainEqual(
+        expect.objectContaining({ type: "tool_use", name: "Read" }),
+      );
+      expect(finalResponse?.usage).toMatchObject({
+        inputTokens: 1 + budget * 3,
+        outputTokens: 2 + budget * 4,
+      });
+    },
+  );
+
+  test.each([
+    "incomplete",
+    "transport",
+    "exhausted-recall",
+    "reasoning",
+  ] as const)(
+    "final continuation %s fails transactionally without retry",
+    async (mode) => {
+      let follows = 0;
+      let recalls = 0;
+      let commits = 0;
+      let rollbacks = 0;
+      let successful: boolean | undefined;
+      const client = streamResponsesRecallAware(
+        streamFrom([
+          created("resp_initial", "gpt-5.6-terra"),
+          recallCall(0, { query: "start" }, "fc_initial", "call_initial"),
+          completed("resp_initial"),
+        ]),
+        {
+          maxRecallDepth: 1,
+          onComplete: (_, success) => {
+            successful = success;
+          },
+          onRecall: async () => {
+            recalls++;
+            return {
+              anchorText: buildAnchor("start"),
+              resultText: "result",
+              commit: () => {
+                commits++;
+              },
+              rollback: () => {
+                rollbacks++;
+              },
+            };
+          },
+          runFollowUp: async ({ finalRecallRound }) => {
+            follows++;
+            expect(finalRecallRound).toBe(true);
+            if (mode === "transport")
+              return {
+                reader: new ReadableStream<Uint8Array>({
+                  start(controller) {
+                    controller.error(new Error("reset"));
+                  },
+                }).getReader(),
+              };
+            return {
+              reader: streamFrom([
+                created("resp_final", "gpt-5.6-terra"),
+                mode === "reasoning"
+                  ? sseEvent("response.output_item.added", {
+                      output_index: 0,
+                      item: {
+                        type: "reasoning",
+                        id: "rs_final",
+                        summary: [],
+                        encrypted_content: "opaque",
+                      },
+                    }) +
+                    sseEvent("response.output_item.done", {
+                      output_index: 0,
+                      item: {
+                        type: "reasoning",
+                        id: "rs_final",
+                        summary: [],
+                        encrypted_content: "opaque",
+                      },
+                    })
+                  : mode === "exhausted-recall"
+                    ? recallCall(
+                        0,
+                        { query: "again" },
+                        "fc_final",
+                        "call_final",
+                      )
+                    : textItem(0, "partial"),
+                mode === "incomplete"
+                  ? incomplete("resp_final")
+                  : completed("resp_final"),
+              ]).body!.getReader(),
+            };
+          },
+        },
+      );
+      const output = await drain(client);
+      expect(output.match(/^event: response\.failed$/gm)).toHaveLength(1);
+      expect(output).not.toContain("event: response.completed");
+      expect(output).not.toContain("event: response.incomplete");
+      expect(successful).toBe(false);
+      expect([recalls, follows, commits, rollbacks]).toEqual([1, 1, 0, 1]);
+    },
+  );
+
   test("caps chained recall depth", async () => {
     const chained = streamFrom([
       created("resp_chained", "gpt-5.6-terra"),
@@ -4305,7 +4468,10 @@ describe("streamResponsesRecallAware", () => {
           anchorText: buildAnchor("architecture"),
           resultText: "results",
         }),
-        runFollowUp: async () => ({ reader: final.body!.getReader() }),
+        runFollowUp: async ({ finalRecallRound }) => {
+          expect(finalRecallRound).toBe(true);
+          return { reader: final.body!.getReader() };
+        },
       },
     );
 
@@ -4315,7 +4481,7 @@ describe("streamResponsesRecallAware", () => {
     expect(out.match(/^event: response\.completed$/gm)).toHaveLength(1);
   });
 
-  test("replaces an exhausted continuation recall with a marker", async () => {
+  test("fails an exhausted continuation recall without executing it", async () => {
     const followUp = streamFrom([
       created("resp_depth_exhausted_followup", "gpt-5.6-terra"),
       recallCall(0, { query: "more detail" }, "fc_depth", "call_depth"),
@@ -4346,9 +4512,10 @@ describe("streamResponsesRecallAware", () => {
 
     const out = await drain(client);
     expect(recalls).toBe(1);
-    expect(out).toContain("Recall depth limit reached (1).");
-    expect(out).not.toContain(PUBLIC_RECALL_ERROR);
-    expect(out.match(/^event: response\.completed$/gm)).toHaveLength(1);
+    expect(out).not.toContain("Recall depth limit reached (1).");
+    expect(out).toContain(PUBLIC_RECALL_ERROR);
+    expect(out.match(/^event: response\.failed$/gm)).toHaveLength(1);
+    expect(out).not.toContain("event: response.completed");
   });
 
   test("recall-only: emits marker, pipes the continuation inline, rebuilds completed", async () => {
@@ -5699,52 +5866,56 @@ describe("streamResponsesRecallAware", () => {
     expect(callbackSignal?.aborted).toBe(true);
   });
 
-  test("foreground abort cancels and unlocks a hostile continuation reader", async () => {
-    const foreground = new AbortController();
-    const continuationStarted = Promise.withResolvers<void>();
-    let cancelled = false;
-    const continuation = new Response(
-      new ReadableStream<Uint8Array>({
-        start(controller) {
-          controller.enqueue(
-            new TextEncoder().encode(
-              created("resp_hostile_continuation", "gpt-5.6-terra"),
-            ),
-          );
-        },
-        pull() {
-          continuationStarted.resolve();
-          return new Promise(() => {});
-        },
-        cancel() {
-          cancelled = true;
-          return new Promise<void>(() => {});
-        },
-      }),
-    );
-    const client = streamResponsesRecallAware(
-      streamFrom([
-        created("resp_hostile_principal", "gpt-5.6-terra"),
-        recallCall(0, { query: "architecture" }),
-        completed("resp_hostile_principal"),
-      ]),
-      {
-        signal: foreground.signal,
-        onComplete: () => {},
-        onRecall: async () => ({
-          anchorText: buildAnchor("architecture"),
-          resultText: "results",
+  test.each([1, 10])(
+    "foreground abort cancels and unlocks a hostile continuation reader (budget %i)",
+    async (maxRecallDepth) => {
+      const foreground = new AbortController();
+      const continuationStarted = Promise.withResolvers<void>();
+      let cancelled = false;
+      const continuation = new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(
+              new TextEncoder().encode(
+                created("resp_hostile_continuation", "gpt-5.6-terra"),
+              ),
+            );
+          },
+          pull() {
+            continuationStarted.resolve();
+            return new Promise(() => {});
+          },
+          cancel() {
+            cancelled = true;
+            return new Promise<void>(() => {});
+          },
         }),
-        runFollowUp: async () => ({ reader: continuation.body!.getReader() }),
-      },
-    );
-    const pending = drain(client);
-    await continuationStarted.promise;
-    foreground.abort(new DOMException("caller aborted", "AbortError"));
-    await expect(pending).rejects.toMatchObject({ name: "AbortError" });
-    expect(cancelled).toBe(true);
-    expect(continuation.body?.locked).toBe(false);
-  });
+      );
+      const client = streamResponsesRecallAware(
+        streamFrom([
+          created("resp_hostile_principal", "gpt-5.6-terra"),
+          recallCall(0, { query: "architecture" }),
+          completed("resp_hostile_principal"),
+        ]),
+        {
+          maxRecallDepth,
+          signal: foreground.signal,
+          onComplete: () => {},
+          onRecall: async () => ({
+            anchorText: buildAnchor("architecture"),
+            resultText: "results",
+          }),
+          runFollowUp: async () => ({ reader: continuation.body!.getReader() }),
+        },
+      );
+      const pending = drain(client);
+      await continuationStarted.promise;
+      foreground.abort(new DOMException("caller aborted", "AbortError"));
+      await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+      expect(cancelled).toBe(true);
+      expect(continuation.body?.locked).toBe(false);
+    },
+  );
 
   test("rejects a chained recall whose arguments never complete", async () => {
     const failures: RecallContinuationFailureCategory[] = [];

--- a/packages/gateway/test/pipeline-streaming.test.ts
+++ b/packages/gateway/test/pipeline-streaming.test.ts
@@ -531,13 +531,16 @@ describe("non-stream recall usage aggregation", () => {
         (candidate) => candidate.headerSessionId === "failed-json-recall-usage",
       );
       expect(state).toBeDefined();
-      expect(
-        getSessionCosts(state?.sessionID ?? "")?.conversation,
-      ).toMatchObject({
-        inputTokens: 1_010,
-        outputTokens: 101,
-        turns: 1,
-      });
+      // Buffered recall commits usage in the deferred finalizer after EOF.
+      await vi.waitFor(() =>
+        expect(
+          getSessionCosts(state?.sessionID ?? "")?.conversation,
+        ).toMatchObject({
+          inputTokens: 1_010,
+          outputTokens: 101,
+          turns: 1,
+        }),
+      );
     } finally {
       setUpstreamInterceptor(undefined);
       await resetPipelineState();

--- a/packages/gateway/test/recall-buffered-transaction.test.ts
+++ b/packages/gateway/test/recall-buffered-transaction.test.ts
@@ -341,7 +341,7 @@ function providerResponse(
     ? toolCalls
     : [{ type: "text", text: "Completed answer" }];
   if (protocol === "anthropic") {
-    return Response.json({
+    const response = {
       id: `msg_${round}`,
       model: "claude-test",
       type: "message",
@@ -349,7 +349,8 @@ function providerResponse(
       content,
       stop_reason: invalid ? null : recalling ? "tool_use" : "end_turn",
       usage: { input_tokens: input, output_tokens: output },
-    });
+    };
+    return stream ? anthropicStream(response) : Response.json(response);
   }
   if (protocol === "openai") {
     return Response.json({
@@ -413,6 +414,11 @@ function providerResponse(
     usage: { input_tokens: input, output_tokens: output },
   };
   if (!stream) return Response.json(response);
+  return responsesStream(response);
+}
+
+function responsesStream(response: Record<string, unknown>): Response {
+  const items = response.output as Array<Record<string, unknown>>;
   const event = (type: string, data: object) =>
     `event: ${type}\ndata: ${JSON.stringify({ type, ...data })}\n\n`;
   return new Response(
@@ -450,13 +456,230 @@ function providerResponse(
             event("response.output_item.done", { output_index: index, item }),
         )
         .join("") +
-      event(invalid ? "response.failed" : "response.completed", { response }),
+      event(
+        response.status === "failed" ? "response.failed" : "response.completed",
+        { response },
+      ),
     { headers: { "content-type": "text/event-stream" } },
   );
 }
 
+function anthropicStream(json: Record<string, unknown>): Response {
+  const event = (type: string, data: object) =>
+    `event: ${type}\ndata: ${JSON.stringify({ type, ...data })}\n\n`;
+  const usage = json.usage as Record<string, unknown>;
+  return new Response(
+    event("message_start", {
+      message: {
+        ...json,
+        content: [],
+        stop_reason: null,
+        stop_sequence: null,
+        usage: { input_tokens: usage.input_tokens, output_tokens: 0 },
+      },
+    }) +
+      (json.content as Array<Record<string, unknown>>)
+        .map(
+          (block, index) =>
+            event("content_block_start", {
+              index,
+              content_block:
+                block.type === "tool_use"
+                  ? { ...block, input: {} }
+                  : { type: "text", text: "" },
+            }) +
+            event("content_block_delta", {
+              index,
+              delta:
+                block.type === "tool_use"
+                  ? {
+                      type: "input_json_delta",
+                      partial_json: JSON.stringify(block.input),
+                    }
+                  : { type: "text_delta", text: block.text },
+            }) +
+            event("content_block_stop", { index }),
+        )
+        .join("") +
+      event("message_delta", {
+        delta: { stop_reason: json.stop_reason, stop_sequence: null },
+        usage: { output_tokens: usage.output_tokens },
+      }) +
+      event("message_stop", {}),
+    { headers: { "content-type": "text/event-stream" } },
+  );
+}
+
+describe.each(["anthropic", "openai", "openai-responses", "gemini"] as const)(
+  "Anthropic streaming transfer retention for %s client",
+  (client) => {
+    test.each([true, false])("no-store=%s", async (noStore) => {
+      const id = knowledge();
+      const alias = crypto.randomUUID();
+      const req = request(client, alias);
+      req.stream = true;
+      req.rawHeaders["x-lore-provider"] = "anthropic";
+      req.rawHeaders["x-lore-upstream-url"] = "https://api.anthropic.com";
+      req.rawHeaders["x-api-key"] = "test-key";
+      delete req.rawHeaders.authorization;
+      if (noStore) req.rawHeaders["x-lore-no-store"] = "true";
+      let calls = 0;
+      setUpstreamInterceptor(async () =>
+        providerResponse(
+          "anthropic",
+          ++calls,
+          calls === 1 ? "recall" : "answer",
+          true,
+        ),
+      );
+      const response = await handleRequest(req, config());
+      expect(await response.text()).toContain("Completed answer");
+      await settled();
+      expect(calls).toBe(2);
+      expect(ltm.transferCount(id)).toBe(noStore ? 0 : 1);
+      expect(stateFor(alias).recallStore.size).toBe(noStore ? 0 : 1);
+    });
+  },
+);
+
+describe.each([
+  ["anthropic", false, "anthropic"],
+  ["openai", false, "openai"],
+  ["openai-responses", false, "openai-responses"],
+  ["anthropic", true, "anthropic"],
+  ["openai", true, "anthropic"],
+  ["openai-responses", true, "anthropic"],
+  ["gemini", true, "anthropic"],
+  ["openai-responses", true, "openai-responses"],
+] as const)(
+  "blank final tool name: %s stream=%s upstream=%s",
+  (client, stream, upstreamProtocol) => {
+    test.each(["", " \t\n"])(
+      "rejects name %j alone or with valid text",
+      async (name) => {
+        for (const withText of [false, true]) {
+          const alias = crypto.randomUUID();
+          const req = request(client, alias);
+          req.stream = stream;
+          if (upstreamProtocol === "anthropic") {
+            req.rawHeaders["x-lore-provider"] = "anthropic";
+            req.rawHeaders["x-lore-upstream-url"] = "https://api.anthropic.com";
+            req.rawHeaders["x-api-key"] = "test-key";
+            delete req.rawHeaders.authorization;
+          }
+          let calls = 0;
+          setUpstreamInterceptor(async (body) => {
+            calls++;
+            const upstreamStream =
+              (body as Record<string, unknown>).stream === true;
+            if (calls < 11)
+              return providerResponse(
+                upstreamProtocol,
+                calls,
+                "recall",
+                upstreamStream,
+              );
+            const json = await providerResponse(
+              upstreamProtocol,
+              calls,
+              "mixed",
+            ).json();
+            if (upstreamProtocol === "anthropic") {
+              json.content = [
+                { ...json.content[0], name },
+                ...(withText
+                  ? [{ type: "text", text: "Completed answer" }]
+                  : []),
+              ];
+            } else if (upstreamProtocol === "openai") {
+              const message = json.choices[0].message;
+              message.tool_calls = [
+                {
+                  ...message.tool_calls[0],
+                  function: { ...message.tool_calls[0].function, name },
+                },
+              ];
+              message.content = withText ? "Completed answer" : null;
+            } else {
+              json.output = [
+                { ...json.output[0], name },
+                ...(withText
+                  ? [
+                      {
+                        type: "message",
+                        id: "msg_final_text",
+                        role: "assistant",
+                        status: "completed",
+                        content: [
+                          { type: "output_text", text: "Completed answer" },
+                        ],
+                      },
+                    ]
+                  : []),
+              ];
+            }
+            return upstreamStream
+              ? upstreamProtocol === "anthropic"
+                ? anthropicStream(json)
+                : responsesStream(json)
+              : Response.json(json);
+          });
+          const response = await handleRequest(req, config());
+          if (stream) {
+            const reader = response.body!.getReader();
+            let received = "";
+            let failure: unknown;
+            try {
+              for (;;) {
+                const { done, value } = await reader.read();
+                if (done) break;
+                received += new TextDecoder().decode(value);
+              }
+            } catch (error) {
+              failure = error;
+            } finally {
+              reader.releaseLock();
+            }
+            // Responses may represent failure on the wire; neither failure
+            // form may deliver a successful terminal to an incremental reader.
+            if (
+              client === "openai-responses" &&
+              received.includes("event: response.failed")
+            ) {
+              expect(received.match(/^event: response.failed$/gm)).toHaveLength(
+                1,
+              );
+            } else expect(failure).toBeInstanceOf(Error);
+            if (client === "anthropic") {
+              expect(received.match(/^event: message_stop$/gm)).toHaveLength(
+                20,
+              );
+            } else {
+              expect(received).not.toContain("data: [DONE]");
+              expect(received).not.toContain("event: response.completed");
+              expect(received).not.toMatch(/"finish_reason":"|"finishReason":/);
+            }
+          } else {
+            expect(response.status).toBe(502);
+            await response.text();
+          }
+          await settled();
+          expect(calls).toBe(11);
+          expect(
+            db()
+              .query(
+                "SELECT COUNT(*) AS count FROM temporal_messages WHERE session_id = ? AND role = 'assistant'",
+              )
+              .get(stateFor(alias).sessionID),
+          ).toEqual({ count: 0 });
+        }
+      },
+    );
+  },
+);
+
 function request(
-  protocol: Protocol,
+  protocol: Protocol | "gemini",
   alias: string,
   codex = false,
 ): GatewayRequest {

--- a/packages/gateway/test/recall-buffered-transaction.test.ts
+++ b/packages/gateway/test/recall-buffered-transaction.test.ts
@@ -3,6 +3,7 @@ import { db, ltm, loadSessionTracking, temporal } from "@loreai/core";
 import { loadConfig } from "../src/config";
 import { clearAllCosts, getSessionCosts } from "../src/cost-tracker";
 import {
+  accumulateNonStreamResponse,
   getActiveSessions,
   handleRequest,
   resetPipelineState,
@@ -27,6 +28,117 @@ afterEach(async () => {
   createdKnowledge.clear();
   vi.restoreAllMocks();
 });
+
+describe.each(["anthropic", "openai", "openai-responses"] as const)(
+  "malformed buffered %s content",
+  (protocol) => {
+    test.each([
+      "valid",
+      "negative",
+      "overflow",
+      "cache",
+      "missing",
+      "json",
+    ] as const)("retains only validated usage: %s", async (usageKind) => {
+      const alias = crypto.randomUUID();
+      let calls = 0;
+      setUpstreamInterceptor(async () => {
+        calls++;
+        if (calls < 11) return providerResponse(protocol, calls, "recall");
+        if (usageKind === "json")
+          return new Response('{"usage":', {
+            headers: { "content-type": "application/json" },
+          });
+        const json = await providerResponse(protocol, calls, "invalid").json();
+        // Duplicate identities force the content parser to reject before it
+        // reaches usage validation, even with a claimed successful terminal.
+        if (protocol === "anthropic") {
+          const call = {
+            type: "tool_use",
+            id: "duplicate",
+            name: "Read",
+            input: {},
+          };
+          json.content = [call, call];
+          json.stop_reason = "tool_use";
+        } else if (protocol === "openai") {
+          json.choices[0].finish_reason = "stop";
+          json.choices.push(json.choices[0]);
+        } else {
+          json.status = "completed";
+          json.output.push(json.output[0]);
+        }
+        const inputKey =
+          protocol === "openai" ? "prompt_tokens" : "input_tokens";
+        const outputKey =
+          protocol === "openai" ? "completion_tokens" : "output_tokens";
+        if (usageKind === "negative") json.usage[inputKey] = -1;
+        if (usageKind === "overflow")
+          json.usage[outputKey] = Number.MAX_SAFE_INTEGER;
+        if (usageKind === "cache") {
+          if (protocol === "anthropic") json.usage.cache_read_input_tokens = -1;
+          else
+            json.usage[
+              protocol === "openai"
+                ? "prompt_tokens_details"
+                : "input_tokens_details"
+            ] = { cached_tokens: 1001 };
+        }
+        if (usageKind === "missing") delete json.usage;
+        return Response.json(json);
+      });
+      const response = await handleRequest(request(protocol, alias), config());
+      expect(response.status).toBe(502);
+      await response.text();
+      await settled();
+      const state = stateFor(alias);
+      expect(calls).toBe(11);
+      expect(state.recallStore.size).toBe(0);
+      expect(getSessionCosts(state.sessionID)?.conversation).toMatchObject({
+        inputTokens: usageKind === "valid" ? 1030 : 30,
+        outputTokens: usageKind === "valid" ? 120 : 20,
+        turns: 1,
+      });
+    });
+  },
+);
+
+test.each(["valid", "negative", "overflow"] as const)(
+  "malformed Gemini content carries only validated %s usage",
+  async (usageKind) => {
+    const call = { functionCall: { id: "duplicate", name: "Read", args: {} } };
+    const json = {
+      candidates: [{ content: { parts: [call, call] }, finishReason: "STOP" }],
+      usageMetadata: {
+        promptTokenCount: usageKind === "negative" ? -1 : 1000,
+        candidatesTokenCount:
+          usageKind === "overflow" ? Number.MAX_SAFE_INTEGER : 100,
+        thoughtsTokenCount: 20,
+        cachedContentTokenCount: 50,
+      },
+    };
+    const error = await accumulateNonStreamResponse(
+      Response.json(json),
+      "gemini",
+      false,
+      undefined,
+      true,
+    ).catch((error: unknown) => error);
+    expect(error).toBeInstanceOf(Error);
+    if (usageKind === "valid") {
+      expect(error).toMatchObject({
+        response: {
+          content: [],
+          usage: {
+            inputTokens: 950,
+            outputTokens: 120,
+            cacheReadInputTokens: 50,
+          },
+        },
+      });
+    } else expect(error).not.toHaveProperty("response");
+  },
+);
 
 test("a cancelled in-flight continuation discards staged recall effects", async () => {
   const id = knowledge();

--- a/packages/gateway/test/recall-buffered-transaction.test.ts
+++ b/packages/gateway/test/recall-buffered-transaction.test.ts
@@ -1,0 +1,660 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { db, ltm, loadSessionTracking, temporal } from "@loreai/core";
+import { loadConfig } from "../src/config";
+import { clearAllCosts, getSessionCosts } from "../src/cost-tracker";
+import {
+  getActiveSessions,
+  handleRequest,
+  resetPipelineState,
+  setRecallPersistenceCommitObserverForTest,
+  setUpstreamInterceptor,
+  streamingPostResponsePendingForTest,
+} from "../src/pipeline";
+import type { GatewayRequest } from "../src/translate/types";
+import { parseAnthropicResponseJSON } from "../src/translate/anthropic";
+import {
+  buildRecallAnchor,
+  recallAnchorContext,
+  MAX_RECALL_STORE_ENTRIES,
+} from "../src/recall";
+
+afterEach(async () => {
+  setUpstreamInterceptor(undefined);
+  setRecallPersistenceCommitObserverForTest(undefined);
+  await resetPipelineState();
+  clearAllCosts();
+  for (const id of createdKnowledge) ltm.remove(id);
+  createdKnowledge.clear();
+  vi.restoreAllMocks();
+});
+
+test("a cancelled in-flight continuation discards staged recall effects", async () => {
+  const id = knowledge();
+  const alias = crypto.randomUUID();
+  const caller = new AbortController();
+  const req = request("anthropic", alias);
+  req.signal = caller.signal;
+  let calls = 0;
+  setUpstreamInterceptor(async () => {
+    calls++;
+    if (calls === 2)
+      caller.abort(new DOMException("client cancelled", "AbortError"));
+    return providerResponse(
+      "anthropic",
+      calls,
+      calls === 1 ? "recall" : "answer",
+    );
+  });
+  const response = await handleRequest(req, config());
+  expect(response.status).toBe(502);
+  await response.text();
+  await settled();
+  const state = stateFor(alias);
+  expect(state.recallStore.size).toBe(0);
+  expect(loadSessionTracking(state.sessionID)?.recallStore ?? null).toBeNull();
+  expect(ltm.transferCount(id)).toBe(0);
+});
+
+test.each(["failure", "commit", "capacity"] as const)(
+  "preserves existing replay anchors after %s",
+  async (mode) => {
+    knowledge();
+    const alias = crypto.randomUUID();
+    const req = request("anthropic", alias);
+    setUpstreamInterceptor(async () =>
+      providerResponse("anthropic", 1, "mixed"),
+    );
+    const first = await handleRequest(req, config());
+    const firstContent = parseAnthropicResponseJSON(await first.json()).content;
+    await settled();
+    const state = stateFor(alias);
+    expect(state.recallStore.size).toBe(1);
+    const existing = new Map(state.recallStore);
+    const existingTracking = loadSessionTracking(state.sessionID)?.recallStore;
+    let transfersBefore: unknown;
+    req.messages.push(
+      { role: "assistant", content: firstContent },
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            toolUseId: "read",
+            content: [{ type: "text", text: "file contents" }],
+          },
+        ],
+      },
+    );
+    if (mode === "capacity") {
+      const [key, value] = [...existing][0];
+      // Existing valid state was produced by a real mixed handoff. Fill the
+      // bounded map before the next request to exercise admission at capacity.
+      for (let i = 1; i < MAX_RECALL_STORE_ENTRIES; i++) {
+        const anchorId = crypto.randomUUID();
+        state.recallStore.set(`anchor:${anchorId}`, {
+          ...value,
+          anchorId,
+          anchorContextId: recallAnchorContext(
+            req.messages,
+            1,
+            req.messages[1].content,
+          ),
+        });
+        req.messages[1].content.push({
+          type: "text",
+          text: buildRecallAnchor(anchorId),
+        });
+      }
+      expect(state.recallStore.has(key)).toBe(true);
+    }
+    const mapBefore = new Map(state.recallStore);
+    if (mode === "commit")
+      setRecallPersistenceCommitObserverForTest(() => {
+        throw new Error("commit failed");
+      });
+    let calls = 0;
+    setUpstreamInterceptor(async () => {
+      // Preparation may legitimately record LTM transfers. Snapshot after it,
+      // before this request executes any recall.
+      if (calls === 0)
+        transfersBefore = db()
+          .query("SELECT SUM(hit_count) AS count FROM knowledge_transfers")
+          .get();
+      return providerResponse(
+        "anthropic",
+        100 + ++calls,
+        mode === "failure" || calls === 1 ? "recall" : "answer",
+      );
+    });
+    if (mode === "capacity") {
+      const response = await handleRequest(req, config());
+      expect(response.status).toBe(502);
+      await response.text();
+    } else {
+      const response = await handleRequest(req, config());
+      expect(response.status).toBe(mode === "failure" ? 502 : 200);
+      await response.text();
+    }
+    await settled();
+    expect(state.recallStore).toEqual(mapBefore);
+    expect(loadSessionTracking(state.sessionID)?.recallStore).toBe(
+      existingTracking,
+    );
+    expect(
+      db()
+        .query("SELECT SUM(hit_count) AS count FROM knowledge_transfers")
+        .get(),
+    ).toEqual(transfersBefore);
+  },
+);
+
+test.each(["answer", "invalid"] as const)(
+  "buffers Responses upstream for a streaming Chat client: %s",
+  async (outcome) => {
+    const id = knowledge();
+    const alias = crypto.randomUUID();
+    const req = request("openai", alias);
+    req.stream = true;
+    req.rawHeaders["x-lore-provider"] = "openai";
+    let calls = 0;
+    setUpstreamInterceptor(async (body) =>
+      providerResponse(
+        "openai-responses",
+        ++calls,
+        calls === 11 ? outcome : "recall",
+        (body as Record<string, unknown>).stream === true,
+      ),
+    );
+    const response = await handleRequest(req, config());
+    expect(response.status).toBe(outcome === "answer" ? 200 : 502);
+    expect(stateFor(alias).recallStore.size).toBe(0);
+    expect(ltm.transferCount(id)).toBe(0);
+    await response.text();
+    await settled();
+    expect(stateFor(alias).recallStore.size).toBe(
+      outcome === "answer" ? 10 : 0,
+    );
+    expect(ltm.transferCount(id)).toBe(outcome === "answer" ? 1 : 0);
+  },
+);
+
+test("live Responses no-store recall does not record transfers", async () => {
+  const id = knowledge();
+  const alias = crypto.randomUUID();
+  const req = request("openai-responses", alias);
+  req.stream = true;
+  req.rawHeaders["x-lore-no-store"] = "true";
+  let calls = 0;
+  setUpstreamInterceptor(async (body) =>
+    providerResponse(
+      "openai-responses",
+      ++calls,
+      calls === 2 ? "answer" : "recall",
+      (body as Record<string, unknown>).stream === true,
+    ),
+  );
+  const response = await handleRequest(req, config());
+  expect(await response.text()).toContain("Completed answer");
+  await settled();
+  expect(stateFor(alias).recallStore.size).toBe(0);
+  expect(ltm.transferCount(id)).toBe(0);
+});
+
+const query =
+  "transactional glacier orchard telescope cobalt lantern mercury compass velvet island";
+type Protocol = "anthropic" | "openai" | "openai-responses";
+type Outcome = "recall" | "answer" | "mixed" | "invalid" | "bad-usage";
+
+function providerResponse(
+  protocol: Protocol,
+  round: number,
+  outcome: Outcome,
+  stream = false,
+): Response {
+  const recalling = outcome === "recall" || outcome === "mixed";
+  const invalid = outcome === "invalid" || outcome === "bad-usage";
+  const input = outcome === "bad-usage" ? -1000 : invalid ? 1000 : 3;
+  const output = invalid ? 100 : 2;
+  const tool = {
+    type: "tool_use",
+    id: `call_${round}`,
+    name: "recall",
+    input: { query },
+  };
+  const toolCalls = [
+    tool,
+    ...(outcome === "mixed" ? [{ ...tool, id: "read", name: "Read" }] : []),
+  ];
+  const content = recalling
+    ? toolCalls
+    : [{ type: "text", text: "Completed answer" }];
+  if (protocol === "anthropic") {
+    return Response.json({
+      id: `msg_${round}`,
+      model: "claude-test",
+      type: "message",
+      role: "assistant",
+      content,
+      stop_reason: invalid ? null : recalling ? "tool_use" : "end_turn",
+      usage: { input_tokens: input, output_tokens: output },
+    });
+  }
+  if (protocol === "openai") {
+    return Response.json({
+      id: `chatcmpl_${round}`,
+      model: "gpt-test",
+      choices: [
+        {
+          index: 0,
+          finish_reason: invalid ? null : recalling ? "tool_calls" : "stop",
+          message: {
+            role: "assistant",
+            content: recalling ? null : "Completed answer",
+            ...(recalling
+              ? {
+                  tool_calls: toolCalls.map((block) => ({
+                    id: block.id,
+                    type: "function",
+                    function: {
+                      name: block.name,
+                      arguments: JSON.stringify({ query }),
+                    },
+                  })),
+                }
+              : {}),
+          },
+        },
+      ],
+      usage: {
+        prompt_tokens: input,
+        completion_tokens: output,
+        total_tokens: input + output,
+      },
+    });
+  }
+  const items = recalling
+    ? toolCalls.map((block) => ({
+        type: "function_call" as const,
+        id: `fc_${block.id}`,
+        call_id: block.id,
+        name: block.name,
+        arguments: JSON.stringify({ query }),
+        status: "completed",
+      }))
+    : [
+        {
+          type: "message" as const,
+          id: `msg_${round}`,
+          role: "assistant",
+          status: "completed",
+          content: [{ type: "output_text", text: "Completed answer" }],
+        },
+      ];
+  const response = {
+    id: `resp_${round}`,
+    model: "gpt-test",
+    status: invalid ? (stream ? "failed" : "in_progress") : "completed",
+    ...(invalid && stream
+      ? { error: { type: "server_error", message: "did not complete" } }
+      : {}),
+    output: items,
+    usage: { input_tokens: input, output_tokens: output },
+  };
+  if (!stream) return Response.json(response);
+  const event = (type: string, data: object) =>
+    `event: ${type}\ndata: ${JSON.stringify({ type, ...data })}\n\n`;
+  return new Response(
+    event("response.created", {
+      response: { id: response.id, model: response.model },
+    }) +
+      items
+        .map(
+          (item, index) =>
+            event("response.output_item.added", {
+              output_index: index,
+              item:
+                item.type === "function_call"
+                  ? {
+                      type: item.type,
+                      id: item.id,
+                      call_id: item.call_id,
+                      name: item.name,
+                      arguments: "",
+                    }
+                  : { type: item.type, id: item.id, role: "assistant" },
+            }) +
+            (item.type === "function_call"
+              ? event("response.function_call_arguments.done", {
+                  output_index: index,
+                  item_id: item.id,
+                  arguments: item.arguments,
+                })
+              : event("response.output_text.done", {
+                  output_index: index,
+                  item_id: item.id,
+                  content_index: 0,
+                  text: "Completed answer",
+                })) +
+            event("response.output_item.done", { output_index: index, item }),
+        )
+        .join("") +
+      event(invalid ? "response.failed" : "response.completed", { response }),
+    { headers: { "content-type": "text/event-stream" } },
+  );
+}
+
+function request(
+  protocol: Protocol,
+  alias: string,
+  codex = false,
+): GatewayRequest {
+  return {
+    protocol,
+    codex,
+    stream: false,
+    model: protocol === "anthropic" ? "claude-test" : "gpt-test",
+    system: "You are a coding agent.",
+    messages: [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "Use project memory to complete the task." },
+        ],
+      },
+    ],
+    tools: [
+      {
+        name: "Read",
+        description: "Read a file",
+        inputSchema: { type: "object", properties: {} },
+      },
+    ],
+    maxTokens: 1024,
+    metadata: {},
+    rawHeaders: {
+      ...(protocol === "anthropic"
+        ? { "x-api-key": "test-key" }
+        : { authorization: "Bearer test-key" }),
+      "x-lore-session-id": alias,
+      "x-lore-agent": "coder",
+      "x-lore-project": "/test/buffered-recall-destination",
+      "x-lore-provider":
+        protocol === "anthropic"
+          ? "anthropic"
+          : protocol === "openai"
+            ? "vllm"
+            : "openai",
+      "x-lore-upstream-url":
+        protocol === "anthropic"
+          ? "https://api.anthropic.com"
+          : "https://api.openai.com/v1",
+    },
+  };
+}
+
+function config() {
+  const cfg = loadConfig();
+  cfg.remoteGateway = false;
+  cfg.hostedMode = false;
+  return cfg;
+}
+
+const createdKnowledge = new Set<string>();
+
+function knowledge() {
+  const id = ltm.create({
+    projectPath: `/test/buffered-recall-origin/${crypto.randomUUID()}`,
+    category: "gotcha",
+    title: query,
+    content: `${query}: preserve transaction boundaries.`,
+    scope: "project",
+    crossProject: true,
+  });
+  createdKnowledge.add(id);
+  return id;
+}
+
+function stateFor(alias: string) {
+  const state = [...getActiveSessions().values()].find(
+    (s) => s.headerSessionId === alias,
+  );
+  expect(state).toBeDefined();
+  return state!;
+}
+
+async function settled() {
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  await vi.waitFor(() => expect(streamingPostResponsePendingForTest()).toBe(0));
+}
+
+describe.each([
+  ["anthropic", false],
+  ["openai", false],
+  ["openai-responses", false],
+  ["openai-responses", true],
+] as const)("buffered recall transaction: %s codex=%s", (protocol, codex) => {
+  test.each(["answer", "mixed", "fallback"] as const)(
+    "commits %s anchors and real transfers only after downstream EOF",
+    async (outcome) => {
+      const id = knowledge();
+      const alias = crypto.randomUUID();
+      let calls = 0;
+      setUpstreamInterceptor(async (body) => {
+        calls++;
+        expect(stateFor(alias).recallStore.size).toBe(0);
+        expect(ltm.transferCount(id)).toBe(0);
+        if (outcome === "fallback" && calls === 2)
+          return new Response("failure", { status: 503 });
+        return providerResponse(
+          protocol,
+          calls,
+          outcome === "mixed" ? "mixed" : calls === 11 ? "answer" : "recall",
+          (body as Record<string, unknown>).stream === true,
+        );
+      });
+      const response = await handleRequest(
+        request(protocol, alias, codex),
+        config(),
+      );
+      const state = stateFor(alias);
+      expect(response.status).toBe(200);
+      expect(state.recallStore.size).toBe(0);
+      expect(ltm.transferCount(id)).toBe(0);
+      const body = await response.text();
+      await settled();
+      expect(calls).toBe(
+        outcome === "answer" ? 11 : outcome === "mixed" ? 1 : 2,
+      );
+      expect(body).toContain(
+        outcome === "answer"
+          ? "Completed answer"
+          : outcome === "mixed"
+            ? "Read"
+            : "lore-recall:",
+      );
+      if (protocol === "openai-responses" && outcome !== "answer") {
+        const envelope = JSON.parse(body);
+        expect(body).toContain("lore-recall:");
+        expect(
+          envelope.output.some(
+            (item: Record<string, unknown>) =>
+              item.type === "function_call" && item.name === "recall",
+          ),
+        ).toBe(false);
+      }
+      expect(state.recallStore.size).toBe(outcome === "answer" ? 10 : 1);
+      expect(
+        JSON.parse(loadSessionTracking(state.sessionID)!.recallStore!).length,
+      ).toBe(state.recallStore.size);
+      expect(ltm.transferCount(id)).toBeGreaterThan(0);
+      expect(getSessionCosts(state.sessionID)?.conversation.turns).toBe(1);
+      ltm.remove(id);
+    },
+  );
+
+  test.each(["cancel", "no-store"] as const)(
+    "discards successful recall writes on %s",
+    async (mode) => {
+      const id = knowledge();
+      const alias = crypto.randomUUID();
+      let calls = 0;
+      setUpstreamInterceptor(async (body) =>
+        providerResponse(
+          protocol,
+          ++calls,
+          calls === 2 ? "answer" : "recall",
+          (body as Record<string, unknown>).stream === true,
+        ),
+      );
+      const req = request(protocol, alias, codex);
+      if (mode === "no-store") req.rawHeaders["x-lore-no-store"] = "true";
+      const response = await handleRequest(req, config());
+      expect(response.status).toBe(200);
+      if (mode === "cancel") await response.body!.cancel();
+      else await response.text();
+      await settled();
+      const state = stateFor(alias);
+      expect(calls).toBe(2);
+      expect(state.recallStore.size).toBe(0);
+      expect(
+        loadSessionTracking(state.sessionID)?.recallStore ?? null,
+      ).toBeNull();
+      expect(ltm.transferCount(id)).toBe(0);
+      expect(
+        db()
+          .query(
+            "SELECT COUNT(*) AS count FROM temporal_messages WHERE session_id = ? AND role = 'assistant'",
+          )
+          .get(state.sessionID),
+      ).toEqual({ count: 0 });
+      expect(getSessionCosts(state.sessionID)?.conversation).toMatchObject({
+        inputTokens: 6,
+        outputTokens: 4,
+        turns: 1,
+      });
+      ltm.remove(id);
+    },
+  );
+
+  test.each(["storage", "commit"] as const)(
+    "rolls back partial writes after %s failure",
+    async (mode) => {
+      const id = knowledge();
+      const alias = crypto.randomUUID();
+      let calls = 0;
+      let commits = 0;
+      if (mode === "storage")
+        vi.spyOn(temporal, "store").mockImplementation(() => {
+          throw new Error("injected storage failure");
+        });
+      setRecallPersistenceCommitObserverForTest(() => {
+        commits++;
+        throw new Error("injected commit failure");
+      });
+      setUpstreamInterceptor(async (body) =>
+        providerResponse(
+          protocol,
+          ++calls,
+          calls === 3 ? "answer" : "recall",
+          (body as Record<string, unknown>).stream === true,
+        ),
+      );
+      const response = await handleRequest(
+        request(protocol, alias, codex),
+        config(),
+      );
+      expect(response.status).toBe(200);
+      await response.text();
+      await settled();
+      const state = stateFor(alias);
+      expect(commits).toBe(mode === "commit" ? 1 : 0);
+      expect(state.recallStore.size).toBe(0);
+      expect(
+        loadSessionTracking(state.sessionID)?.recallStore ?? null,
+      ).toBeNull();
+      expect(ltm.transferCount(id)).toBe(0);
+      expect(
+        db()
+          .query(
+            "SELECT COUNT(*) AS count FROM temporal_messages WHERE session_id = ?",
+          )
+          .get(state.sessionID),
+      ).toEqual({ count: 0 });
+      ltm.remove(id);
+    },
+  );
+
+  test.each(["recall", "invalid", "bad-usage", "http"] as const)(
+    "discards anchors and real transfers after final %s failure",
+    async (outcome) => {
+      const id = knowledge();
+      const alias = crypto.randomUUID();
+      let calls = 0;
+      setUpstreamInterceptor(async (body) => {
+        calls++;
+        if (calls === 11 && outcome === "http")
+          return new Response("failure", { status: 503 });
+        return providerResponse(
+          protocol,
+          calls,
+          calls === 11 && outcome !== "http" ? outcome : "recall",
+          (body as Record<string, unknown>).stream === true,
+        );
+      });
+      const response = await handleRequest(
+        request(protocol, alias, codex),
+        config(),
+      );
+      expect(response.status).toBe(502);
+      await response.text();
+      await settled();
+      const state = stateFor(alias);
+      expect(calls).toBe(11);
+      expect.soft(state.recallStore.size).toBe(0);
+      expect
+        .soft(
+          (loadSessionTracking(state.sessionID)?.recallStore ?? null) === null,
+        )
+        .toBe(true);
+      expect.soft(ltm.transferCount(id)).toBe(0);
+      expect(
+        db()
+          .query(
+            "SELECT COUNT(*) AS count FROM temporal_messages WHERE session_id = ? AND role = 'assistant'",
+          )
+          .get(state.sessionID),
+      ).toEqual({ count: 0 });
+      ltm.remove(id);
+    },
+  );
+
+  test.each(["invalid", "bad-usage"] as const)(
+    "accounts only validated final %s usage",
+    async (outcome) => {
+      const alias = crypto.randomUUID();
+      let calls = 0;
+      setUpstreamInterceptor(async (body) =>
+        providerResponse(
+          protocol,
+          ++calls,
+          calls === 11 ? outcome : "recall",
+          (body as Record<string, unknown>).stream === true,
+        ),
+      );
+      const response = await handleRequest(
+        request(protocol, alias, codex),
+        config(),
+      );
+      expect(response.status).toBe(502);
+      await response.text();
+      await settled();
+      expect(
+        getSessionCosts(stateFor(alias).sessionID)?.conversation,
+      ).toMatchObject({
+        inputTokens: outcome === "invalid" ? 1030 : 30,
+        outputTokens: outcome === "invalid" ? 120 : 20,
+        turns: 1,
+      });
+    },
+  );
+});

--- a/packages/gateway/test/recall-buffered-transaction.test.ts
+++ b/packages/gateway/test/recall-buffered-transaction.test.ts
@@ -1,9 +1,11 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
 import { db, ltm, loadSessionTracking, temporal } from "@loreai/core";
+import * as core from "@loreai/core";
 import { loadConfig } from "../src/config";
 import { clearAllCosts, getSessionCosts } from "../src/cost-tracker";
 import {
   accumulateNonStreamResponse,
+  buildStreamingResponse,
   getActiveSessions,
   handleRequest,
   resetPipelineState,
@@ -167,9 +169,13 @@ test("a cancelled in-flight continuation discards staged recall effects", async 
   expect(ltm.transferCount(id)).toBe(0);
 });
 
-test.each(["failure", "commit", "capacity"] as const)(
-  "preserves existing replay anchors after %s",
-  async (mode) => {
+test.each(
+  (["failure", "commit", "capacity", "late-capacity"] as const).flatMap(
+    (mode) => [false, true].map((stream) => ({ mode, stream })),
+  ),
+)(
+  "preserves existing replay anchors after $mode (stream=$stream)",
+  async ({ mode, stream }) => {
     knowledge();
     const alias = crypto.randomUUID();
     const req = request("anthropic", alias);
@@ -183,6 +189,7 @@ test.each(["failure", "commit", "capacity"] as const)(
     expect(state.recallStore.size).toBe(1);
     const existing = new Map(state.recallStore);
     const existingTracking = loadSessionTracking(state.sessionID)?.recallStore;
+    req.stream = stream;
     let transfersBefore: unknown;
     req.messages.push(
       { role: "assistant", content: firstContent },
@@ -197,7 +204,7 @@ test.each(["failure", "commit", "capacity"] as const)(
         ],
       },
     );
-    if (mode === "capacity") {
+    const fillCapacity = () => {
       const [key, value] = [...existing][0];
       // Existing valid state was produced by a real mixed handoff. Fill the
       // bounded map before the next request to exercise admission at capacity.
@@ -218,8 +225,9 @@ test.each(["failure", "commit", "capacity"] as const)(
         });
       }
       expect(state.recallStore.has(key)).toBe(true);
-    }
-    const mapBefore = new Map(state.recallStore);
+    };
+    if (mode === "capacity") fillCapacity();
+    let mapBefore = new Map(state.recallStore);
     if (mode === "commit")
       setRecallPersistenceCommitObserverForTest(() => {
         throw new Error("commit failed");
@@ -232,13 +240,23 @@ test.each(["failure", "commit", "capacity"] as const)(
         transfersBefore = db()
           .query("SELECT SUM(hit_count) AS count FROM knowledge_transfers")
           .get();
+      if (mode === "late-capacity" && calls === 1) {
+        fillCapacity();
+        mapBefore = new Map(state.recallStore);
+      }
       return providerResponse(
         "anthropic",
         100 + ++calls,
         mode === "failure" || calls === 1 ? "recall" : "answer",
+        stream,
       );
     });
-    if (mode === "capacity") {
+    if (stream) {
+      const response = await handleRequest(req, config());
+      expect(response.status).toBe(200);
+      if (mode === "commit" || mode === "late-capacity") await response.text();
+      else await expect(response.text()).rejects.toBeInstanceOf(Error);
+    } else if (mode === "capacity") {
       const response = await handleRequest(req, config());
       expect(response.status).toBe(502);
       await response.text();
@@ -726,6 +744,286 @@ function request(
     },
   };
 }
+
+describe.each(["anthropic", "openai", "openai-responses", "gemini"] as const)(
+  "native Anthropic recall transaction for %s client",
+  (client) => {
+    test.each([false, true])(
+      "mixed handoff waits for EOF (cancel=%s)",
+      async (cancel) => {
+        const id = knowledge();
+        const alias = crypto.randomUUID();
+        const req = request(client, alias);
+        req.stream = true;
+        req.rawHeaders["x-lore-provider"] = "anthropic";
+        req.rawHeaders["x-lore-upstream-url"] = "https://api.anthropic.com";
+        req.rawHeaders["x-api-key"] = "test-key";
+        delete req.rawHeaders.authorization;
+        setUpstreamInterceptor(async () =>
+          providerResponse("anthropic", 1, "mixed", true),
+        );
+        const response = await handleRequest(req, config());
+        const reader = response.body!.getReader();
+        let wire = "";
+        for (;;) {
+          const { done, value } = await reader.read();
+          expect(done).toBe(false);
+          wire += new TextDecoder().decode(value);
+          if (
+            client === "anthropic"
+              ? (wire.match(/^event: message_stop$/gm)?.length ?? 0) === 2
+              : client === "openai"
+                ? wire.includes("data: [DONE]")
+                : client === "openai-responses"
+                  ? wire.includes("event: response.completed")
+                  : wire.includes('"finishReason":')
+          )
+            break;
+        }
+        await vi.waitFor(() =>
+          expect(streamingPostResponsePendingForTest()).toBe(1),
+        );
+        const state = stateFor(alias);
+        expect.soft(state.recallStore.size).toBe(0);
+        expect
+          .soft(loadSessionTracking(state.sessionID)?.recallStore ?? null)
+          .toBeNull();
+        expect.soft(ltm.transferCount(id)).toBe(0);
+        if (cancel) await reader.cancel();
+        else expect((await reader.read()).done).toBe(true);
+        reader.releaseLock();
+        await settled();
+        expect(state.recallStore.size).toBe(cancel ? 0 : 1);
+        expect(ltm.transferCount(id)).toBe(cancel ? 0 : 1);
+        expect(getSessionCosts(state.sessionID)?.conversation).toMatchObject({
+          inputTokens: 3,
+          outputTokens: 2,
+          turns: 1,
+        });
+      },
+    );
+    test.each([
+      "answer",
+      "mixed",
+      "fallback",
+      "exhausted",
+      "cancel",
+      "abort",
+      "storage",
+      "commit",
+    ] as const)("stages effects through %s", async (mode) => {
+      const id = knowledge();
+      const alias = crypto.randomUUID();
+      const req = request(client, alias);
+      req.stream = true;
+      req.rawHeaders["x-lore-provider"] = "anthropic";
+      req.rawHeaders["x-lore-upstream-url"] = "https://api.anthropic.com";
+      req.rawHeaders["x-api-key"] = "test-key";
+      delete req.rawHeaders.authorization;
+      const caller = new AbortController();
+      req.signal = caller.signal;
+      const continuationStarted = Promise.withResolvers<void>();
+      const releaseContinuation = Promise.withResolvers<void>();
+      const snapshots: Array<{
+        anchors: number;
+        tracking: string | null;
+        transfers: number;
+      }> = [];
+      let calls = 0;
+      let commits = 0;
+      if (mode === "storage")
+        vi.spyOn(temporal, "store").mockImplementation(() => {
+          throw new Error("injected storage failure");
+        });
+      setRecallPersistenceCommitObserverForTest(() => {
+        commits++;
+        if (mode === "commit") throw new Error("injected commit failure");
+      });
+      setUpstreamInterceptor(async () => {
+        calls++;
+        const state = stateFor(alias);
+        snapshots.push({
+          anchors: state.recallStore.size,
+          tracking: loadSessionTracking(state.sessionID)?.recallStore ?? null,
+          transfers: ltm.transferCount(id),
+        });
+        if (calls === 2 && (mode === "cancel" || mode === "abort")) {
+          continuationStarted.resolve();
+          await releaseContinuation.promise;
+        }
+        if (mode === "fallback" && calls === 2)
+          return new Response("failure", { status: 503 });
+        return providerResponse(
+          "anthropic",
+          calls,
+          mode === "mixed"
+            ? "mixed"
+            : mode !== "exhausted" && calls === 3
+              ? "answer"
+              : "recall",
+          true,
+        );
+      });
+      const response = await handleRequest(req, config());
+      const reader = response.body!.getReader();
+      let wire = "";
+      let failure: unknown;
+      const read = (async () => {
+        try {
+          for (;;) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            wire += new TextDecoder().decode(value);
+          }
+        } catch (error) {
+          failure = error;
+        }
+      })();
+      try {
+        if (mode === "cancel" || mode === "abort") {
+          await continuationStarted.promise;
+          if (mode === "cancel") await reader.cancel();
+          else caller.abort(new DOMException("client cancelled", "AbortError"));
+        }
+      } finally {
+        releaseContinuation.resolve();
+      }
+      await read;
+      reader.releaseLock();
+      await settled();
+      const state = stateFor(alias);
+      const successful =
+        mode === "answer" || mode === "mixed" || mode === "fallback";
+      expect(calls).toBe(
+        mode === "exhausted"
+          ? 11
+          : mode === "mixed"
+            ? 1
+            : ["cancel", "abort", "fallback"].includes(mode)
+              ? 2
+              : 3,
+      );
+      expect(snapshots).toEqual(
+        snapshots.map(() => ({ anchors: 0, tracking: null, transfers: 0 })),
+      );
+      expect(state.recallStore.size).toBe(
+        successful ? (mode === "answer" ? 2 : 1) : 0,
+      );
+      expect(ltm.transferCount(id)).toBe(successful ? 1 : 0);
+      if (!successful)
+        expect(
+          loadSessionTracking(state.sessionID)?.recallStore ?? null,
+        ).toBeNull();
+      if (mode === "exhausted") {
+        if (client === "openai-responses")
+          expect(wire).toContain("event: response.failed");
+        else expect(failure).toBeInstanceOf(Error);
+      } else if (successful) {
+        expect(failure).toBeUndefined();
+        expect(wire).toContain(
+          mode === "answer" ? "Completed answer" : "lore-recall:",
+        );
+        expect(
+          JSON.parse(loadSessionTracking(state.sessionID)!.recallStore!).length,
+        ).toBe(state.recallStore.size);
+      }
+      if (mode === "commit") expect(commits).toBe(1);
+      if (mode === "storage") expect(commits).toBe(0);
+      if (!successful)
+        expect(
+          db()
+            .query(
+              "SELECT COUNT(*) AS count FROM temporal_messages WHERE session_id = ? AND role = 'assistant'",
+            )
+            .get(state.sessionID),
+        ).toEqual({ count: 0 });
+    });
+  },
+);
+
+test.each(["success", "cancel", "late-recall"] as const)(
+  "standalone native recall delivery: %s",
+  async (mode) => {
+    const id = knowledge();
+    const alias = crypto.randomUUID();
+    const req = request("anthropic", alias);
+    setUpstreamInterceptor(async () =>
+      providerResponse("anthropic", 1, "answer"),
+    );
+    await (await handleRequest(req, config())).text();
+    await settled();
+    const state = stateFor(alias);
+    const beforeTracking =
+      loadSessionTracking(state.sessionID)?.recallStore ?? null;
+    const recallStarted = Promise.withResolvers<void>();
+    const releaseRecall = Promise.withResolvers<void>();
+    const recallFinished = Promise.withResolvers<void>();
+    if (mode === "late-recall") {
+      const realRecall = core.runRecall;
+      vi.spyOn(core, "runRecall").mockImplementationOnce(async (input) => {
+        recallStarted.resolve();
+        await releaseRecall.promise;
+        try {
+          // Model a non-cooperative in-flight search returning its real transfer
+          // callback after cancellation; the gateway must discard it.
+          return await realRecall({ ...input, signal: undefined });
+        } finally {
+          recallFinished.resolve();
+        }
+      });
+    }
+    setUpstreamInterceptor(async () =>
+      providerResponse("anthropic", 2, "answer", true),
+    );
+    const completed = vi.fn();
+    const response = buildStreamingResponse(
+      providerResponse("anthropic", 1, "recall", true),
+      completed,
+      {
+        clientMessages: req.messages,
+        modifiedReq: req,
+        config: config(),
+        sessionState: state,
+        cacheOptions: {},
+        clientSpeaksAnthropic: true,
+      },
+    );
+    const reader = response.body!.getReader();
+    if (mode === "late-recall") {
+      const drain = (async () => {
+        while (!(await reader.read()).done) {
+          /* drive source */
+        }
+      })();
+      await recallStarted.promise;
+      await reader.cancel();
+      releaseRecall.resolve();
+      await recallFinished.promise;
+      await drain;
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(completed).not.toHaveBeenCalled();
+    } else {
+      let wire = "";
+      do {
+        const { done, value } = await reader.read();
+        expect(done).toBe(false);
+        wire += new TextDecoder().decode(value);
+      } while ((wire.match(/^event: message_stop$/gm)?.length ?? 0) < 3);
+      await vi.waitFor(() => expect(completed).toHaveBeenCalledTimes(1));
+      expect(state.recallStore.size).toBe(0);
+      expect(ltm.transferCount(id)).toBe(0);
+      if (mode === "cancel") await reader.cancel();
+      else expect((await reader.read()).done).toBe(true);
+    }
+    reader.releaseLock();
+    expect(state.recallStore.size).toBe(mode === "success" ? 1 : 0);
+    expect(ltm.transferCount(id)).toBe(mode === "success" ? 1 : 0);
+    if (mode !== "success")
+      expect(loadSessionTracking(state.sessionID)?.recallStore ?? null).toBe(
+        beforeTracking,
+      );
+  },
+);
 
 function config() {
   const cfg = loadConfig();

--- a/packages/gateway/test/recall-diagnostics.test.ts
+++ b/packages/gateway/test/recall-diagnostics.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, expect, test, vi } from "vitest";
+import { log } from "@loreai/core";
+import { createRecallDiagnostics } from "../src/recall-diagnostics";
+
+afterEach(() => vi.restoreAllMocks());
+
+test("distinguishes repeated calls, repeated results, changed results, and ID lookups without exposing content", () => {
+  const sink = vi.spyOn(log, "info").mockImplementation(() => {});
+  const diagnostics = createRecallDiagnostics();
+  const secret = "PRIVATE-recall-content";
+  diagnostics.record({ query: secret }, secret);
+  diagnostics.record({ query: ` ${secret} ` }, secret);
+  diagnostics.record({ query: secret }, "changed result");
+  diagnostics.record({ query: "different query" }, secret);
+  diagnostics.record({ query: "one", id: "d:PRIVATE-id" }, secret);
+  diagnostics.record({ query: "two", id: "d:PRIVATE-id" }, secret);
+  diagnostics.record({ query: secret, scope: "session" }, "");
+  diagnostics.finish("completed");
+  diagnostics.finish("failed");
+  diagnostics.record({ query: secret }, secret);
+  const messages = sink.mock.calls.map(([message]) => String(message));
+  expect(messages).toHaveLength(8);
+  expect(messages.join("\n")).not.toContain(secret);
+  expect(messages.join("\n")).not.toContain("PRIVATE-id");
+  expect(messages.join("\n")).not.toMatch(/[a-f0-9]{64}/);
+  expect(
+    JSON.parse(messages.at(-1)!.slice("recall-chain ".length)),
+  ).toMatchObject({
+    outcome: "completed",
+    rounds: 7,
+    detailCalls: 2,
+    repeatedInputs: 3,
+    repeatedResults: 4,
+    repeatedPairs: 2,
+    emptyBodies: 1,
+  });
+  expect(JSON.parse(messages[2].slice("recall-round ".length))).toMatchObject({
+    repeatedInput: true,
+    repeatedResult: false,
+    repeatedPair: false,
+  });
+});
+
+test.each([true, false])(
+  "diagnostics are bounded and honor no-store (enabled=%s)",
+  (enabled) => {
+    const sink = vi.spyOn(log, "info").mockImplementation(() => {});
+    const diagnostics = createRecallDiagnostics(enabled);
+    for (let i = 0; i < 50; i++)
+      diagnostics.record({ query: String(i) }, String(i));
+    diagnostics.finish("aborted");
+    expect(sink).toHaveBeenCalledTimes(enabled ? 11 : 0);
+  },
+);

--- a/packages/gateway/test/recall-exhaustion.test.ts
+++ b/packages/gateway/test/recall-exhaustion.test.ts
@@ -211,13 +211,15 @@ function upstream(
 }
 
 describe.each([
-  ["anthropic", false, false],
-  ["openai-responses", false, false],
-  ["openai-responses", true, false],
-  ["openai-responses", false, true],
+  ["anthropic", false, false, "anthropic"],
+  ["openai-responses", false, false, "openai-responses"],
+  ["openai-responses", true, false, "openai-responses"],
+  ["openai-responses", false, true, "openai-responses"],
+  ["anthropic", false, false, "openai-responses"],
+  ["openai", false, false, "openai-responses"],
 ] as const)(
-  "recall exhaustion: %s stream=%s codex=%s",
-  (protocol, stream, codex) => {
+  "recall exhaustion: %s stream=%s codex=%s upstream=%s",
+  (protocol, stream, codex, upstreamProtocol) => {
     test.each([
       "answer",
       "tool",
@@ -240,7 +242,8 @@ describe.each([
         protocol,
         stream,
         codex,
-        model: protocol === "anthropic" ? "claude-test" : "gpt-5.6-terra",
+        model:
+          upstreamProtocol === "anthropic" ? "claude-test" : "gpt-5.6-terra",
         system: "You are a coding agent.",
         messages: [
           {
@@ -267,15 +270,16 @@ describe.each([
             ? { tool_choice: { type: "function", name: "recall" } }
             : {},
         rawHeaders: {
-          ...(protocol === "anthropic"
+          ...(upstreamProtocol === "anthropic"
             ? { "x-api-key": "test-key" }
             : { authorization: "Bearer test-key" }),
           "x-lore-session-id": session,
           "x-lore-agent": "coder",
           "x-lore-project": process.cwd(),
-          "x-lore-provider": protocol === "anthropic" ? "anthropic" : "openai",
+          "x-lore-provider":
+            upstreamProtocol === "anthropic" ? "anthropic" : "openai",
           "x-lore-upstream-url":
-            protocol === "anthropic"
+            upstreamProtocol === "anthropic"
               ? "https://api.anthropic.com"
               : "https://api.openai.com/v1",
         },
@@ -296,14 +300,14 @@ describe.each([
               status: 503,
             });
           return upstream(
-            protocol,
+            upstreamProtocol,
             requestBody.stream === true,
             calls,
             mode === "parallel" ? "answer" : mode,
           );
         }
         return upstream(
-          protocol,
+          upstreamProtocol,
           requestBody.stream === true,
           calls,
           mode === "parallel" ? "parallel" : "recall",
@@ -351,6 +355,16 @@ describe.each([
               ],
             });
           }
+        }
+        if (mode === "refusal" && protocol === "anthropic") {
+          expect(JSON.parse(body).content).toEqual([
+            { type: "text", text: "I cannot help with that." },
+          ]);
+        }
+        if (mode === "refusal" && protocol === "openai") {
+          expect(JSON.parse(body).choices[0].message.content).toBe(
+            "I cannot help with that.",
+          );
         }
         expect(body).not.toContain("Recall depth limit reached");
       } else {

--- a/packages/gateway/test/recall-exhaustion.test.ts
+++ b/packages/gateway/test/recall-exhaustion.test.ts
@@ -1,0 +1,322 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { db } from "@loreai/core";
+import { loadConfig } from "../src/config";
+import {
+  handleRequest,
+  resetPipelineState,
+  setUpstreamInterceptor,
+} from "../src/pipeline";
+import { executeRecall } from "../src/recall";
+import type { GatewayRequest } from "../src/translate/types";
+
+vi.mock("../src/recall", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/recall")>();
+  return { ...actual, executeRecall: vi.fn() };
+});
+
+afterEach(async () => {
+  setUpstreamInterceptor(undefined);
+  vi.mocked(executeRecall).mockReset();
+  await resetPipelineState();
+});
+
+function event(type: string, data: unknown): string {
+  return `event: ${type}\ndata: ${JSON.stringify({ type, ...(data as object) })}\n\n`;
+}
+
+function upstream(
+  protocol: string,
+  streaming: boolean,
+  round: number,
+  kind: "recall" | "answer" | "tool" | "parallel" | "reasoning" | "unfinished",
+): Response {
+  if (kind === "unfinished") {
+    if (protocol === "anthropic")
+      return Response.json({
+        id: `msg_${round}`,
+        type: "message",
+        role: "assistant",
+        model: "claude-test",
+        content: [{ type: "text", text: "partial answer" }],
+        stop_reason: null,
+        stop_sequence: null,
+        usage: { input_tokens: 3, output_tokens: 2 },
+      });
+    return Response.json({
+      id: `resp_${round}`,
+      model: "gpt-5.6-terra",
+      status: "in_progress",
+      output: [
+        {
+          type: "message",
+          id: `msg_${round}`,
+          status: "in_progress",
+          role: "assistant",
+          content: [{ type: "output_text", text: "partial answer" }],
+        },
+      ],
+      usage: { input_tokens: 3, output_tokens: 2 },
+    });
+  }
+  if (kind === "reasoning") {
+    if (protocol === "anthropic")
+      return Response.json({
+        id: `msg_${round}`,
+        type: "message",
+        role: "assistant",
+        model: "claude-test",
+        content: [
+          { type: "thinking", thinking: "private", signature: "signed" },
+        ],
+        stop_reason: "end_turn",
+        stop_sequence: null,
+        usage: { input_tokens: 3, output_tokens: 2 },
+      });
+    const item = {
+      type: "reasoning",
+      id: `rs_${round}`,
+      summary: [],
+      encrypted_content: "opaque",
+    };
+    const response = {
+      id: `resp_${round}`,
+      model: "gpt-5.6-terra",
+      status: "completed",
+      output: [item],
+      usage: { input_tokens: 3, output_tokens: 2 },
+    };
+    return streaming
+      ? new Response(
+          event("response.created", {
+            response: { id: response.id, model: response.model },
+          }) +
+            event("response.output_item.added", { output_index: 0, item }) +
+            event("response.output_item.done", { output_index: 0, item }) +
+            event("response.completed", { response }),
+          { headers: { "content-type": "text/event-stream" } },
+        )
+      : Response.json(response);
+  }
+  const tool = {
+    type: "tool_use",
+    id: `call_${round}`,
+    name: kind === "tool" ? "Read" : "recall",
+    input: { query: `query ${round}` },
+  };
+  const content =
+    kind === "answer"
+      ? [{ type: "text", text: "Finished the task." }]
+      : kind === "parallel"
+        ? [tool, { ...tool, id: `call_other_${round}` }]
+        : [tool];
+  if (protocol === "anthropic")
+    return Response.json({
+      id: `msg_${round}`,
+      type: "message",
+      role: "assistant",
+      model: "claude-test",
+      content,
+      stop_reason: kind === "answer" ? "end_turn" : "tool_use",
+      stop_sequence: null,
+      usage: { input_tokens: 3, output_tokens: 2 },
+    });
+  const items = content.map((block, index) =>
+    block.type === "text"
+      ? {
+          type: "message",
+          id: `msg_${round}`,
+          status: "completed",
+          role: "assistant",
+          content: [{ type: "output_text", text: "Finished the task." }],
+        }
+      : {
+          type: "function_call",
+          id: `fc_${round}_${index}`,
+          call_id: index ? `call_other_${round}` : `call_${round}`,
+          name: kind === "tool" ? "Read" : "recall",
+          arguments: JSON.stringify({ query: `query ${round}` }),
+          status: "completed",
+        },
+  );
+  const response = {
+    id: `resp_${round}`,
+    model: "gpt-5.6-terra",
+    status: "completed",
+    output: items,
+    usage: { input_tokens: 3, output_tokens: 2 },
+  };
+  if (!streaming) return Response.json(response);
+  return new Response(
+    event("response.created", {
+      response: { id: response.id, model: response.model },
+    }) +
+      items
+        .map((item, index) => {
+          const added =
+            item.type === "function_call"
+              ? {
+                  type: item.type,
+                  id: item.id,
+                  call_id: item.call_id,
+                  name: item.name,
+                }
+              : { type: item.type, id: item.id, role: "assistant" };
+          return (
+            event("response.output_item.added", {
+              output_index: index,
+              item: added,
+            }) +
+            (item.type === "function_call"
+              ? event("response.function_call_arguments.done", {
+                  output_index: index,
+                  item_id: item.id,
+                  arguments: item.arguments,
+                })
+              : event("response.output_text.done", {
+                  output_index: index,
+                  item_id: item.id,
+                  content_index: 0,
+                  text: "Finished the task.",
+                })) +
+            event("response.output_item.done", { output_index: index, item })
+          );
+        })
+        .join("") +
+      event("response.completed", { response }),
+    { headers: { "content-type": "text/event-stream" } },
+  );
+}
+
+describe.each([
+  ["anthropic", false, false],
+  ["openai-responses", false, false],
+  ["openai-responses", true, false],
+  ["openai-responses", false, true],
+] as const)(
+  "recall exhaustion: %s stream=%s codex=%s",
+  (protocol, stream, codex) => {
+    test.each([
+      "answer",
+      "tool",
+      "recall",
+      "failed",
+      "parallel",
+      "reasoning",
+      "unfinished",
+    ] as const)("final result %s", async (mode) => {
+      vi.mocked(executeRecall).mockResolvedValue({
+        result: "real recall result",
+        input: { query: "architecture" },
+      });
+      const config = loadConfig();
+      config.remoteGateway = false;
+      config.hostedMode = false;
+      const session = `exhaustion-${crypto.randomUUID()}`;
+      const req: GatewayRequest = {
+        protocol,
+        stream,
+        codex,
+        model: protocol === "anthropic" ? "claude-test" : "gpt-5.6-terra",
+        system: "You are a coding agent.",
+        messages: [
+          {
+            role: "user",
+            content: [
+              { type: "text", text: "Finish the task using project memory." },
+            ],
+          },
+        ],
+        tools: [
+          {
+            name: "Read",
+            description: "Read a file",
+            inputSchema: { type: "object", properties: {} },
+          },
+        ],
+        maxTokens: 1024,
+        metadata:
+          protocol === "anthropic"
+            ? { tool_choice: { type: "tool", name: "recall" } }
+            : {},
+        extras:
+          protocol === "openai-responses"
+            ? { tool_choice: { type: "function", name: "recall" } }
+            : {},
+        rawHeaders: {
+          ...(protocol === "anthropic"
+            ? { "x-api-key": "test-key" }
+            : { authorization: "Bearer test-key" }),
+          "x-lore-session-id": session,
+          "x-lore-agent": "coder",
+          "x-lore-project": process.cwd(),
+          "x-lore-provider": protocol === "anthropic" ? "anthropic" : "openai",
+          "x-lore-upstream-url":
+            protocol === "anthropic"
+              ? "https://api.anthropic.com"
+              : "https://api.openai.com/v1",
+        },
+      };
+      let calls = 0;
+      let lastBody: Record<string, unknown> | undefined;
+      let firstBody: Record<string, unknown> | undefined;
+      setUpstreamInterceptor(async (body) => {
+        calls++;
+        const requestBody = body as Record<string, unknown>;
+        firstBody ??= structuredClone(requestBody);
+        if (calls === 11) {
+          lastBody = requestBody;
+          if (mode === "failed")
+            return new Response("provider diagnostic must not leak", {
+              status: 503,
+            });
+          return upstream(
+            protocol,
+            requestBody.stream === true,
+            calls,
+            mode === "parallel" ? "answer" : mode,
+          );
+        }
+        return upstream(
+          protocol,
+          requestBody.stream === true,
+          calls,
+          mode === "parallel" ? "parallel" : "recall",
+        );
+      });
+      const response = await handleRequest(req, config);
+      const body = await response.text();
+      if (mode === "parallel") {
+        expect(vi.mocked(executeRecall)).not.toHaveBeenCalled();
+        expect(calls).toBe(1);
+      } else {
+        expect(calls).toBe(11);
+        expect(vi.mocked(executeRecall)).toHaveBeenCalledTimes(10);
+        expect(lastBody?.tools).toEqual(firstBody?.tools);
+        expect(lastBody?.tool_choice).toEqual(firstBody?.tool_choice);
+        expect(JSON.stringify(lastBody)).toContain(
+          "The recall budget for this turn has been used",
+        );
+      }
+      if (mode === "answer" || mode === "tool") {
+        expect(response.status).toBe(200);
+        expect(body).toContain(
+          mode === "answer" ? "Finished the task." : '"Read"',
+        );
+        expect(body).not.toContain("Recall depth limit reached");
+      } else {
+        if (stream) {
+          expect(body.match(/^event: response\.failed$/gm)).toHaveLength(1);
+          expect(body).not.toContain("event: response.completed");
+        } else expect(response.status).toBe(502);
+        expect(body).not.toContain("provider diagnostic");
+        expect(
+          db()
+            .query(
+              "SELECT count(*) AS count FROM temporal_messages WHERE session_id = ? AND role = 'assistant'",
+            )
+            .get(session),
+        ).toMatchObject({ count: 0 });
+      }
+    });
+  },
+);

--- a/packages/gateway/test/recall-exhaustion.test.ts
+++ b/packages/gateway/test/recall-exhaustion.test.ts
@@ -28,7 +28,14 @@ function upstream(
   protocol: string,
   streaming: boolean,
   round: number,
-  kind: "recall" | "answer" | "tool" | "parallel" | "reasoning" | "unfinished",
+  kind:
+    | "recall"
+    | "answer"
+    | "tool"
+    | "parallel"
+    | "reasoning"
+    | "refusal"
+    | "unfinished",
 ): Response {
   if (kind === "unfinished") {
     if (protocol === "anthropic")
@@ -58,26 +65,36 @@ function upstream(
       usage: { input_tokens: 3, output_tokens: 2 },
     });
   }
-  if (kind === "reasoning") {
+  if (kind === "reasoning" || kind === "refusal") {
     if (protocol === "anthropic")
       return Response.json({
         id: `msg_${round}`,
         type: "message",
         role: "assistant",
         model: "claude-test",
-        content: [
-          { type: "thinking", thinking: "private", signature: "signed" },
-        ],
+        content:
+          kind === "refusal"
+            ? [{ type: "text", text: "I cannot help with that." }]
+            : [{ type: "thinking", thinking: "private", signature: "signed" }],
         stop_reason: "end_turn",
         stop_sequence: null,
         usage: { input_tokens: 3, output_tokens: 2 },
       });
-    const item = {
-      type: "reasoning",
-      id: `rs_${round}`,
-      summary: [],
-      encrypted_content: "opaque",
-    };
+    const item =
+      kind === "refusal"
+        ? {
+            type: "message",
+            id: `msg_${round}`,
+            status: "completed",
+            role: "assistant",
+            content: [{ type: "refusal", refusal: "I cannot help with that." }],
+          }
+        : {
+            type: "reasoning",
+            id: `rs_${round}`,
+            summary: [],
+            encrypted_content: "opaque",
+          };
     const response = {
       id: `resp_${round}`,
       model: "gpt-5.6-terra",
@@ -90,7 +107,13 @@ function upstream(
           event("response.created", {
             response: { id: response.id, model: response.model },
           }) +
-            event("response.output_item.added", { output_index: 0, item }) +
+            event("response.output_item.added", {
+              output_index: 0,
+              item:
+                kind === "refusal"
+                  ? { type: item.type, id: item.id, role: "assistant" }
+                  : item,
+            }) +
             event("response.output_item.done", { output_index: 0, item }) +
             event("response.completed", { response }),
           { headers: { "content-type": "text/event-stream" } },
@@ -202,6 +225,7 @@ describe.each([
       "failed",
       "parallel",
       "reasoning",
+      "refusal",
       "unfinished",
     ] as const)("final result %s", async (mode) => {
       vi.mocked(executeRecall).mockResolvedValue({
@@ -299,11 +323,35 @@ describe.each([
           "The recall budget for this turn has been used",
         );
       }
-      if (mode === "answer" || mode === "tool") {
+      if (mode === "answer" || mode === "tool" || mode === "refusal") {
         expect(response.status).toBe(200);
         expect(body).toContain(
-          mode === "answer" ? "Finished the task." : '"Read"',
+          mode === "answer"
+            ? "Finished the task."
+            : mode === "refusal"
+              ? "I cannot help with that."
+              : '"Read"',
         );
+        if (mode === "refusal" && protocol === "openai-responses") {
+          if (stream) {
+            expect(body.match(/^event: response\.completed$/gm)).toHaveLength(
+              1,
+            );
+            expect(body).not.toContain("event: response.failed");
+          } else {
+            expect(JSON.parse(body)).toMatchObject({
+              status: "completed",
+              output: [
+                {
+                  type: "message",
+                  content: [
+                    { type: "refusal", refusal: "I cannot help with that." },
+                  ],
+                },
+              ],
+            });
+          }
+        }
         expect(body).not.toContain("Recall depth limit reached");
       } else {
         if (stream) {

--- a/packages/gateway/test/recall-exhaustion.test.ts
+++ b/packages/gateway/test/recall-exhaustion.test.ts
@@ -263,6 +263,8 @@ describe.each([
         calls++;
         const requestBody = body as Record<string, unknown>;
         firstBody ??= structuredClone(requestBody);
+        expect(requestBody.tools).toEqual(firstBody.tools);
+        expect(requestBody.tool_choice).toEqual(firstBody.tool_choice);
         if (calls === 11) {
           lastBody = requestBody;
           if (mode === "failed")

--- a/packages/gateway/test/recall.test.ts
+++ b/packages/gateway/test/recall.test.ts
@@ -3043,6 +3043,72 @@ describe("cleanupRecallStore", () => {
 // ---------------------------------------------------------------------------
 
 describe("replaceRecallWithMarker", () => {
+  test("replaces raw Responses recall calls without losing other items or colliding IDs", () => {
+    const recall = {
+      type: "tool_use" as const,
+      id: "call_recall",
+      name: "recall",
+      input: { query: "memory" },
+    };
+    const read = {
+      type: "tool_use" as const,
+      id: "call_read",
+      name: "Read",
+      input: {},
+    };
+    const existing = {
+      type: "message",
+      id: "msg_lore_recall_1",
+      role: "assistant",
+      status: "completed",
+      content: [{ type: "refusal", refusal: "earlier refusal" }],
+    };
+    const rawRecall = {
+      type: "function_call",
+      id: "fc_recall",
+      call_id: recall.id,
+      name: recall.name,
+      arguments: JSON.stringify(recall.input),
+      status: "completed",
+    };
+    const rawRead = {
+      type: "function_call",
+      id: "fc_read",
+      call_id: read.id,
+      name: read.name,
+      arguments: "{}",
+      status: "completed",
+    };
+    const response = {
+      ...makeResponse([recall, read]),
+      rawOutputItems: [existing, rawRecall, rawRead],
+    };
+    const snapshot = structuredClone(response);
+    Object.freeze(response.rawOutputItems);
+    for (const item of response.rawOutputItems) Object.freeze(item);
+    const marker = buildRecallAnchor("123e4567-e89b-42d3-a456-426614174001");
+    const rewritten = replaceRecallWithMarker(
+      response,
+      new Map([[recall.id, marker]]),
+    );
+    expect(rewritten.rawOutputItems?.map((item) => item.type)).toEqual([
+      "message",
+      "message",
+      "function_call",
+    ]);
+    expect(rewritten.rawOutputItems?.[0]).toBe(existing);
+    expect(rewritten.rawOutputItems?.[2]).toBe(rawRead);
+    expect(rewritten.rawOutputItems?.[1]).toMatchObject({
+      role: "assistant",
+      status: "completed",
+      content: [{ type: "output_text", text: marker }],
+    });
+    expect(new Set(rewritten.rawOutputItems?.map((item) => item.id)).size).toBe(
+      3,
+    );
+    expect(response).toEqual(snapshot);
+  });
+
   test("replaces recall tool_use with marker text", () => {
     const resp = makeResponse([
       { type: "text", text: "hello" },

--- a/packages/gateway/test/recall.test.ts
+++ b/packages/gateway/test/recall.test.ts
@@ -3116,10 +3116,15 @@ describe("final recall continuation output", () => {
         },
       ],
     });
-    expect(response.content).toEqual([]);
+    expect(response.content).toEqual(
+      typeof refusal === "string" ? [{ type: "text", text: refusal }] : [],
+    );
     const original = structuredClone(response);
     Object.freeze(response.rawOutputItems);
     expect(isUsableRecallContinuation(response)).toBe(expected);
+    expect(isUsableRecallContinuation({ ...response, content: [] })).toBe(
+      expected,
+    );
     expect(response).toEqual(original);
 
     for (const stopReason of [
@@ -3130,7 +3135,49 @@ describe("final recall continuation output", () => {
       expect(isUsableRecallContinuation({ ...response, stopReason })).toBe(
         false,
       );
+      expect(
+        isUsableRecallContinuation({ ...response, content: [], stopReason }),
+      ).toBe(false);
     }
+  });
+
+  test("buffered refusal provenance does not duplicate its normalized text", () => {
+    const refusal = {
+      type: "message",
+      id: "msg_refusal",
+      role: "assistant",
+      status: "completed",
+      content: [{ type: "refusal", refusal: "I cannot help with that." }],
+    };
+    const response = accumulateResponsesNonStreamJSON({
+      id: "resp_refusal",
+      model: "gpt-test",
+      status: "completed",
+      output: [refusal, { ...refusal, id: "msg_empty", content: [] }],
+    });
+    expect(responsesProvenanceContent(response)).toEqual([
+      { type: "opaque", raw: refusal, responsesItem: true },
+    ]);
+  });
+
+  test("opaque refusal provenance preserves the next normalized text fallback", () => {
+    const refusal = {
+      type: "message",
+      id: "msg_refusal",
+      role: "assistant",
+      content: [{ type: "refusal", refusal: "I cannot help with that." }],
+    };
+    const opaque = {
+      type: "opaque" as const,
+      raw: refusal,
+      responsesItem: true,
+    };
+    const text = { type: "text" as const, text: "fallback text" };
+    const response = {
+      ...makeResponse([opaque, text]),
+      rawOutputItems: [refusal, { ...refusal, id: "msg_empty", content: [] }],
+    };
+    expect(responsesProvenanceContent(response)).toEqual([opaque, text]);
   });
 
   test.each([

--- a/packages/gateway/test/recall.test.ts
+++ b/packages/gateway/test/recall.test.ts
@@ -18,7 +18,7 @@ import {
   responsesAnchorContext,
 } from "../src/pipeline";
 import {
-  hasRecallContinuationOutput,
+  isUsableRecallContinuation,
   RECALL_GATEWAY_TOOL,
   RECALL_TOOL_NAME,
   MAX_RECALL_DEPTH,
@@ -3134,7 +3134,7 @@ describe("final recall continuation output", () => {
     ],
   ] as const)("requires client-usable output: %j", (content, expected) => {
     expect(
-      hasRecallContinuationOutput(
+      isUsableRecallContinuation(
         makeResponse(
           structuredClone(content) as unknown as GatewayContentBlock[],
         ),
@@ -3142,3 +3142,14 @@ describe("final recall continuation output", () => {
     ).toBe(expected);
   });
 });
+
+test.each(["max_tokens", "pause_turn", "model_context_window_exceeded"])(
+  "unfinished final recall stop %s is not usable even with text",
+  (stopReason) => {
+    expect(
+      isUsableRecallContinuation(
+        makeResponse([{ type: "text", text: "partial answer" }], stopReason),
+      ),
+    ).toBe(false);
+  },
+);

--- a/packages/gateway/test/recall.test.ts
+++ b/packages/gateway/test/recall.test.ts
@@ -12,6 +12,7 @@ import { describe, test, expect, vi } from "vitest";
 import {
   LORE_COMMIT_REMINDER,
   accumulateOpenAINonStreamJSON,
+  accumulateResponsesNonStreamJSON,
   loreMessagesToGateway,
   responsesProvenanceContent,
   responsesProvenanceByMessageId,
@@ -3094,6 +3095,58 @@ describe("replaceRecallWithMarker", () => {
 });
 
 describe("final recall continuation output", () => {
+  test.each([
+    ["I cannot help with that.", true],
+    ["", false],
+    [" \n ", false],
+    [undefined, false],
+    [42, false],
+  ])("buffered Responses refusal %j is usable: %s", (refusal, expected) => {
+    const response = accumulateResponsesNonStreamJSON({
+      id: "resp_refusal",
+      model: "gpt-test",
+      status: "completed",
+      output: [
+        {
+          type: "message",
+          id: "msg_refusal",
+          role: "assistant",
+          status: "completed",
+          content: [{ type: "refusal", refusal }],
+        },
+      ],
+    });
+    expect(response.content).toEqual([]);
+    const original = structuredClone(response);
+    Object.freeze(response.rawOutputItems);
+    expect(isUsableRecallContinuation(response)).toBe(expected);
+    expect(response).toEqual(original);
+
+    for (const stopReason of [
+      "max_tokens",
+      "pause_turn",
+      "model_context_window_exceeded",
+    ]) {
+      expect(isUsableRecallContinuation({ ...response, stopReason })).toBe(
+        false,
+      );
+    }
+  });
+
+  test.each([
+    { type: "reasoning", content: [{ type: "refusal", refusal: "no" }] },
+    { type: "message", content: [{ type: "output_text", refusal: "no" }] },
+    { type: "message", content: { type: "refusal", refusal: "no" } },
+    { type: "message", content: [null, 42, "no"] },
+  ])("does not accept a malformed refusal item: %j", (item) => {
+    expect(
+      isUsableRecallContinuation({
+        ...makeResponse([]),
+        rawOutputItems: [item],
+      }),
+    ).toBe(false);
+  });
+
   test.each([
     [
       [

--- a/packages/gateway/test/recall.test.ts
+++ b/packages/gateway/test/recall.test.ts
@@ -3043,6 +3043,72 @@ describe("cleanupRecallStore", () => {
 // ---------------------------------------------------------------------------
 
 describe("replaceRecallWithMarker", () => {
+  test("local collision suffixes cannot alias another turn's provider identity", () => {
+    const rewrite = (providerId: string, siblingId?: string) => {
+      const call = {
+        type: "tool_use" as const,
+        id: `call_${providerId}`,
+        name: "recall",
+        input: { query: "memory" },
+      };
+      return replaceRecallWithMarker({
+        ...makeResponse([call]),
+        rawOutputItems: [
+          {
+            type: "function_call",
+            id: providerId,
+            call_id: call.id,
+            name: call.name,
+            arguments: JSON.stringify(call.input),
+            status: "completed",
+          },
+          ...(siblingId
+            ? [
+                {
+                  type: "message",
+                  id: siblingId,
+                  role: "assistant",
+                  status: "completed",
+                  content: [{ type: "output_text", text: "sibling" }],
+                },
+              ]
+            : []),
+        ],
+      }).rawOutputItems!;
+    };
+    const candidate = rewrite("fc_recall")[0].id as string;
+    const firstTurn = rewrite("fc_recall", candidate);
+    const nextTurn = rewrite("fc_recall_1");
+    expect(firstTurn[0].id).not.toBe(candidate);
+    expect(firstTurn[0].id).not.toBe(nextTurn[0].id);
+  });
+
+  test("keeps raw marker identities distinct across successive Responses turns", () => {
+    const outputs = [1, 2].map((turn) => {
+      const call = {
+        type: "tool_use" as const,
+        id: `call_recall_${turn}`,
+        name: "recall",
+        input: { query: "same search" },
+      };
+      return replaceRecallWithMarker({
+        ...makeResponse([call]),
+        rawOutputItems: [
+          {
+            type: "function_call",
+            id: `fc_recall_${turn}`,
+            call_id: call.id,
+            name: call.name,
+            arguments: JSON.stringify(call.input),
+            status: "completed",
+          },
+        ],
+      }).rawOutputItems![0];
+    });
+    expect(outputs.every((item) => item.type === "message")).toBe(true);
+    expect(outputs[0].id).not.toBe(outputs[1].id);
+  });
+
   test("replaces raw Responses recall calls without losing other items or colliding IDs", () => {
     const recall = {
       type: "tool_use" as const,
@@ -3058,7 +3124,7 @@ describe("replaceRecallWithMarker", () => {
     };
     const existing = {
       type: "message",
-      id: "msg_lore_recall_1",
+      id: "msg_lore_recall_fc_recall",
       role: "assistant",
       status: "completed",
       content: [{ type: "refusal", refusal: "earlier refusal" }],
@@ -3079,6 +3145,10 @@ describe("replaceRecallWithMarker", () => {
       arguments: "{}",
       status: "completed",
     };
+    existing.id = replaceRecallWithMarker({
+      ...makeResponse([recall]),
+      rawOutputItems: [rawRecall],
+    }).rawOutputItems![0].id as string;
     const response = {
       ...makeResponse([recall, read]),
       rawOutputItems: [existing, rawRecall, rawRead],

--- a/packages/gateway/test/recall.test.ts
+++ b/packages/gateway/test/recall.test.ts
@@ -3231,6 +3231,66 @@ describe("replaceRecallWithMarker", () => {
 });
 
 describe("final recall continuation output", () => {
+  test.each(["Read", "custom.namespace_tool", " Read "])(
+    "preserves the nonblank tool name %j",
+    (name) => {
+      const block = Object.freeze({
+        type: "tool_use" as const,
+        id: "ordinary",
+        name,
+        input: {},
+      });
+      const response = makeResponse([block]);
+      Object.freeze(response.content);
+      expect(isUsableRecallContinuation(response)).toBe(true);
+      expect(response.content[0]).toBe(block);
+      expect(block.name).toBe(name);
+    },
+  );
+  test.each(["", " \t\n", null, undefined, 7])(
+    "rejects malformed name %j even beside usable output",
+    (name) => {
+      const malformed = {
+        type: "tool_use" as const,
+        id: "invalid",
+        name: name as string,
+        input: {},
+      };
+      const companions = [
+        [],
+        [{ type: "text" as const, text: "Useful answer" }],
+        [
+          {
+            type: "tool_use" as const,
+            id: "ordinary",
+            name: "Read",
+            input: {},
+          },
+        ],
+        [
+          {
+            type: "opaque" as const,
+            responsesItem: true,
+            raw: {
+              type: "message",
+              content: [{ type: "refusal", refusal: "Cannot help" }],
+            },
+          },
+        ],
+      ];
+      for (const companion of companions) {
+        for (const content of [
+          [malformed, ...companion],
+          [...companion, malformed],
+        ]) {
+          const response = makeResponse(content);
+          Object.freeze(response.content);
+          for (const block of response.content) Object.freeze(block);
+          expect(isUsableRecallContinuation(response)).toBe(false);
+        }
+      }
+    },
+  );
   test.each([
     ["I cannot help with that.", true],
     ["", false],

--- a/packages/gateway/test/recall.test.ts
+++ b/packages/gateway/test/recall.test.ts
@@ -18,6 +18,7 @@ import {
   responsesAnchorContext,
 } from "../src/pipeline";
 import {
+  hasRecallContinuationOutput,
   RECALL_GATEWAY_TOOL,
   RECALL_TOOL_NAME,
   MAX_RECALL_DEPTH,
@@ -58,6 +59,7 @@ import {
   resolveToolResults,
 } from "../src/temporal-adapter";
 import type {
+  GatewayContentBlock,
   GatewayResponse,
   GatewayRequest,
   GatewayToolUseBlock,
@@ -782,6 +784,47 @@ describe("recallStoreKey", () => {
 // ---------------------------------------------------------------------------
 
 describe("buildRecallFollowUpRequest", () => {
+  test.each([
+    ["anthropic", { type: "tool", name: "recall" }],
+    ["openai-responses", { type: "function", name: "recall" }],
+  ] as const)(
+    "final %s continuation preserves cached tools and controls",
+    (protocol, choice) => {
+      const req = makeRequest(
+        [],
+        [
+          { name: "Read", description: "Read", inputSchema: {} },
+          { name: "recall", description: "Recall", inputSchema: {} },
+        ],
+      );
+      req.protocol = protocol;
+      req.metadata = Object.freeze({ tool_choice: Object.freeze(choice) });
+      req.extras = Object.freeze({ tool_choice: Object.freeze(choice) });
+      Object.freeze(req.tools);
+      Object.freeze(req.messages);
+      Object.freeze(req);
+      const block = makeRecallToolUse("architecture");
+      const follow = buildRecallFollowUpRequest(
+        req,
+        makeResponse([block], "tool_use"),
+        "real result",
+        block,
+        true,
+        true,
+      );
+      expect(follow.tools).toBe(req.tools);
+      expect(follow.metadata).toBe(req.metadata);
+      expect(follow.extras).toBe(req.extras);
+      expect(JSON.stringify(follow.messages.at(-1))).toContain("real result");
+      expect(JSON.stringify(follow.messages.at(-1))).toContain(
+        "The recall budget for this turn has been used",
+      );
+      expect(req.tools.map((tool) => tool.name)).toEqual(["Read", "recall"]);
+      expect(req.metadata.tool_choice).toBe(choice);
+      expect(req.extras?.tool_choice).toBe(choice);
+    },
+  );
+
   test("builds correct follow-up request structure with tool_use/tool_result", () => {
     const req = makeRequest(
       [{ role: "user", content: [{ type: "text", text: "hello" }] }],
@@ -3047,5 +3090,55 @@ describe("replaceRecallWithMarker", () => {
     expect(replaced.model).toBe(resp.model);
     expect(replaced.stopReason).toBe(resp.stopReason);
     expect(replaced.usage?.inputTokens).toBe(999);
+  });
+});
+
+describe("final recall continuation output", () => {
+  test.each([
+    [
+      [
+        {
+          type: "thinking",
+          thinking: "private reasoning",
+          signature: "signed",
+        },
+      ],
+      false,
+    ],
+    [
+      [
+        {
+          type: "opaque",
+          responsesItem: true,
+          raw: { type: "reasoning", encrypted_content: "private" },
+        },
+      ],
+      false,
+    ],
+    [[{ type: "text", text: "   " }], false],
+    [[{ type: "text", text: "answer" }], true],
+    [[{ type: "tool_use", id: "call", name: "Read", input: {} }], true],
+    [[{ type: "tool_use", id: "call", name: "recall", input: {} }], false],
+    [
+      [
+        {
+          type: "opaque",
+          responsesItem: true,
+          raw: {
+            type: "message",
+            content: [{ type: "refusal", refusal: "I cannot help with that." }],
+          },
+        },
+      ],
+      true,
+    ],
+  ] as const)("requires client-usable output: %j", (content, expected) => {
+    expect(
+      hasRecallContinuationOutput(
+        makeResponse(
+          structuredClone(content) as unknown as GatewayContentBlock[],
+        ),
+      ),
+    ).toBe(expected);
   });
 });

--- a/packages/gateway/test/stream-openai.test.ts
+++ b/packages/gateway/test/stream-openai.test.ts
@@ -529,59 +529,68 @@ describe("accumulateOpenAISSEStream", () => {
   });
 });
 
-test("Anthropic translator completes at message_stop and cancels an open source", async () => {
-  const event = (type: string, data: Record<string, unknown>) =>
-    `event: ${type}\ndata: ${JSON.stringify({ type, ...data })}\n\n`;
-  const wire =
-    event("message_start", {
-      message: {
-        id: "msg-open",
-        type: "message",
-        role: "assistant",
-        model: "claude-test",
-        content: [],
-        stop_reason: null,
-        stop_sequence: null,
-        usage: { input_tokens: 1, output_tokens: 0 },
-      },
-    }) +
-    event("content_block_start", {
-      index: 0,
-      content_block: { type: "text", text: "" },
-    }) +
-    event("content_block_delta", {
-      index: 0,
-      delta: { type: "text_delta", text: "done" },
-    }) +
-    event("content_block_stop", { index: 0 }) +
-    event("message_delta", {
-      delta: { stop_reason: "end_turn", stop_sequence: null },
-      usage: { output_tokens: 1 },
-    }) +
-    event("message_stop", {});
-  let cancelled = false;
-  const upstream = new Response(
-    new ReadableStream<Uint8Array>({
-      start(controller) {
-        controller.enqueue(new TextEncoder().encode(wire));
-      },
-      pull() {
-        return new Promise(() => {});
-      },
-      cancel() {
-        cancelled = true;
-        return new Promise<void>(() => {});
-      },
-    }),
-  );
-  const translated = translateAnthropicStreamToOpenAI(upstream);
-  await new Promise((resolve) => setImmediate(resolve));
-  const output = await translated.text();
-  expect(output).toContain("done");
-  expect(output.match(/data: \[DONE\]/g)).toHaveLength(1);
-  expect(cancelled).toBe(true);
-  expect(upstream.body?.locked).toBe(false);
-});
+test.each([false, true])(
+  "Anthropic translator completes and cancels an open source (large=%s)",
+  async (large) => {
+    const text = large ? "z".repeat(2 * 1024 * 1024) : "done";
+    const event = (type: string, data: Record<string, unknown>) =>
+      `event: ${type}\ndata: ${JSON.stringify({ type, ...data })}\n\n`;
+    const wire =
+      event("message_start", {
+        message: {
+          id: "msg-open",
+          type: "message",
+          role: "assistant",
+          model: "claude-test",
+          content: [],
+          stop_reason: null,
+          stop_sequence: null,
+          usage: { input_tokens: 1, output_tokens: 0 },
+        },
+      }) +
+      event("content_block_start", {
+        index: 0,
+        content_block: { type: "text", text: "" },
+      }) +
+      Array.from({ length: large ? 3 : 1 }, () =>
+        event("content_block_delta", {
+          index: 0,
+          delta: { type: "text_delta", text },
+        }),
+      ).join("") +
+      event("content_block_stop", { index: 0 }) +
+      event("message_delta", {
+        delta: { stop_reason: "end_turn", stop_sequence: null },
+        usage: { output_tokens: 1 },
+      }) +
+      event("message_stop", {});
+    let cancelled = false;
+    const upstream = new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode(wire));
+        },
+        pull() {
+          return new Promise(() => {});
+        },
+        cancel() {
+          cancelled = true;
+          return new Promise<void>(() => {});
+        },
+      }),
+    );
+    const translated = translateAnthropicStreamToOpenAI(upstream, {
+      propagateErrors: true,
+    });
+    await new Promise((resolve) => setImmediate(resolve));
+    const output = await translated.text();
+    expect(output).toContain(text);
+    if (large) expect(output.length).toBeGreaterThan(4 * 1024 * 1024);
+    expect(output.match(/data: \[DONE\]/g)).toHaveLength(1);
+    expect(cancelled).toBe(true);
+    expect(upstream.body?.locked).toBe(false);
+  },
+);
 
 test("Anthropic translator emits inclusive OpenAI cache usage", async () => {
   const event = (type: string, data: Record<string, unknown>) =>


### PR DESCRIPTION
A long-running session could finish with “Recall depth limit reached (10).” after ten recalls, without a usable answer or ordinary tool handoff.

This keeps the ten-execution limit and gives the continuation after the last permitted recall explicit guidance to finish from available results. **Tool definitions and tool controls stay unchanged throughout the chain**, preserving the cached tool prefix. The gateway enforces the limit even if the model requests recall again. The final continuation cannot receive a transport retry.

Final failures, unfinished output, and reasoning-only responses fail explicitly. Anthropic terminal events are held until validation, buffered JSON requires a valid provider completion, and successful Anthropic continuation content/usage are accounted from the actual final response. Parallel recall is rejected consistently while mixed ordinary tools remain available.

Request-local diagnostics report search/detail counts, repeated inputs, byte-identical results, repeated input/result pairs, empty bodies, result bytes and elapsed time. They never export queries, results, IDs or fingerprints, and no-store requests skip collection. Changed output bytes do not prove useful progress.

The static recall description strongly encourages recall, source drill-down, and verification of compressed details; it does not explicitly bound repeated retrieval. This is a possible contributor, not a confirmed cause of the reported loop. Its cached definition remains unchanged. Broad recall deduplication and #1710’s full source-frontier architecture are separate work.

Review fixes make native Anthropic streaming and buffered recall persistence atomic with successful downstream delivery. Failed/cancelled/no-store requests leave no new recall anchors or transfer records. Invalid completions retain validated usage, including when malformed content makes the parser fail first; recovery uses the existing protocol validator on usage fields alone and always throws. Native Responses mixed/fallback output uses replay markers with immutable sibling items and collision-safe identities across turns.

Latest follow-up in `89e20ed80817ef440fa445a47b91cb45c134c263` addresses [Copilot's native persistence finding](https://github.com/BYK/loreai/pull/1719#pullrequestreview-5135724204):

- Native streaming and buffered recall share staged anchors/transfers, committed with response storage only after successful downstream EOF.
- Failure, abort, cancellation, late callbacks and commit errors discard pending effects; rollback preserves existing state. Capacity is checked before marker exposure and again at commit.
- Real Anthropic/Chat/Responses/Gemini routes cover ordinary success, mixed handoff, fallback, exhaustion, cancellation, storage errors and commit errors. Additional tests cover cancellation after terminal bytes but before EOF, standalone calls, late results, and capacity changes during an upstream wait.
- Earlier fixes remain covered: invalid tool names cannot hide behind usable siblings; no-store suppresses recall retention; translated Chat propagates source failure without applying extra strict-wire limits.

Validation on this exact tree:

- Independent affected/security run: **204 passed** across six suites, including all **152 transaction tests**. This follow-up adds **48 passing regression cases**.
- Full suite: **9,816 passed, 7 failed, 229 skipped**, 460 files, **654.91 seconds, exit 1**. Both reviewers compared the final failures with the parent run: the same raw-window eviction assertion, two compact summary-budget assertions, three installer process/environment cases, and optional Linux GPU asset assertion remain. No new failing case; the local full suite is not all green.
- Bundle, typecheck, lint and formatting pass (exit 0). Ten consecutive sync-property runs pass (five tests each).
- Initial real-route reproduction: **28 failures before the fix**, with four mixed-handoff controls passing. Four deliberate mutations are caught: early anchor writes (8 failures), early transfer writes (8), removed Map rollback (2), and removed commit-time capacity validation (2). Source bytes were restored.
- Independent [correctness review](https://github.com/BYK/loreai/pull/1719#pullrequestreview-5135900817) and [security review](https://github.com/BYK/loreai/pull/1719#pullrequestreview-5135902398) are complete with no unresolved blocking findings, subject to hosted gates. Local and published tree match `08210e21541739363296669013bc7b4eaba732a0`; checkout clean.
- Exact-head **Seer 16552231 passed with no issues**. Hosted semantic lint and Postgres integration pass. Hosted tests and dependent build/platform smoke gates remain pending; no gate is bypassed. [Fresh Copilot review](https://github.com/BYK/loreai/pull/1719#pullrequestreview-5135902043) completed with zero new comments and recommends final human review of these cross-protocol lifecycle changes. All existing inline threads are resolved.
- Streaming remains incremental: partial text and tool-item events can precede overall failure. Tests establish explicit failure, withheld overall success terminals and rollback, not atomic stream delivery or control over a client's early tool execution.

Fixes #1716