### PR TITLE
fix(core): keep HTTP responsive during temporal re-chunking

### DIFF
--- a/packages/core/src/embedding.ts
+++ b/packages/core/src/embedding.ts
@@ -3440,9 +3440,23 @@ export async function runStartupBackfill(
   // + done-flagged, so this is the heavy walk only on the first vec0 run (and
   // again after a config change); a no-op in blob mode and once converged. Idle-
   // gated (opts.shouldPause) so it yields the shared embed pool to live traffic.
+  const temporalConnection = db();
   const temporalRechunked = await backfillTemporalEmbeddings({
     shouldPause: opts.shouldPause,
   });
+  // The walk may stop after shutdown. Do not reopen storage for GC or coverage
+  // stats, or use a successor connection that belongs to a different startup.
+  if (!isCurrentDatabase(temporalConnection)) {
+    return {
+      ...emptyBackfillStats(),
+      pendingKnowledge,
+      pendingDistillations,
+      knowledgeEmbedded,
+      distillationEmbedded,
+      entityEmbedded,
+      temporalRechunked,
+    };
+  }
 
   // Startup backstop: reclaim vec0 rows orphaned by bulk base-row deletes
   // (project/session/prune) since the last run. Harmless if there are none.

--- a/packages/core/src/embedding.ts
+++ b/packages/core/src/embedding.ts
@@ -14,11 +14,13 @@
  */
 
 import { freemem } from "node:os";
+import { randomUUID } from "node:crypto";
 import { performance } from "node:perf_hooks";
 import {
   databaseInTransaction,
   db,
   getKV,
+  isCurrentDatabase,
   setKV,
   withSavepoint,
   withTransaction,
@@ -3827,6 +3829,10 @@ const TEMPORAL_RECHUNK_DONE_KEY = "lore:temporal_rechunk.done";
  * and the redo cost of a crash mid-page.
  */
 const TEMPORAL_RECHUNK_PAGE = 256;
+/** Bound synchronous admission bursts, independently of provider duty settings.
+ * The time budget is checked between rows; a single SQLite statement may exceed it. */
+const TEMPORAL_RECHUNK_YIELD_ROWS = 32;
+const TEMPORAL_RECHUNK_YIELD_MS = 8;
 const TEMPORAL_RECHUNK_ELIGIBLE_SQL = `length(CAST(content AS BLOB)) >= ${TEMPORAL_EMBEDDING_MIN_CONTENT_LENGTH}`;
 /** Legacy keys retained only so reset clears state written by pre-v85 builds. */
 const TEMPORAL_RECHUNK_ATTEMPTS_KEY = "lore:temporal_rechunk.attempts";
@@ -3834,6 +3840,8 @@ const TEMPORAL_RECHUNK_INFLIGHT_KEY = "lore:temporal_rechunk.inflight";
 const TEMPORAL_RECHUNK_ROW_ATTEMPTS_KEY = "lore:temporal_rechunk.row_attempts";
 const TEMPORAL_RECHUNK_SKIP_KEY = "lore:temporal_rechunk.skip";
 const TEMPORAL_RECHUNK_MAX_ROWID_KEY = "lore:temporal_rechunk.max_rowid";
+/** Fence active walks across config resets, including resets by other processes. */
+const TEMPORAL_RECHUNK_EPOCH_KEY = "lore:temporal_rechunk.epoch";
 /**
  * Poll interval while the temporal walk is parked waiting for the host to go
  * idle. Short enough to resume promptly once traffic stops; a parked walk is
@@ -3848,6 +3856,7 @@ const TEMPORAL_RECHUNK_PAUSE_POLL_MS = 250;
  */
 async function awaitBackfillIdle(
   shouldPause: (() => boolean) | undefined,
+  isCurrent: () => boolean,
 ): Promise<void> {
   if (!shouldPause) return;
   // Edge-triggered logging: because this call blocks until the host is idle,
@@ -3855,6 +3864,7 @@ async function awaitBackfillIdle(
   // pair — so a long park is visible in the logs instead of looking like a wedge.
   let parked = false;
   for (;;) {
+    if (!isCurrent()) return;
     let paused = false;
     try {
       paused = shouldPause();
@@ -3882,13 +3892,16 @@ async function awaitBackfillIdle(
  * repopulates them from the queue under the new fingerprint.
  */
 export function resetTemporalRechunkProgress(): void {
-  setKV(TEMPORAL_RECHUNK_DONE_KEY, "0");
-  setKV(TEMPORAL_RECHUNK_CURSOR_KEY, "");
-  setKV(TEMPORAL_RECHUNK_ATTEMPTS_KEY, "0");
-  setKV(TEMPORAL_RECHUNK_INFLIGHT_KEY, "");
-  setKV(TEMPORAL_RECHUNK_ROW_ATTEMPTS_KEY, "0");
-  setKV(TEMPORAL_RECHUNK_SKIP_KEY, "");
-  setKV(TEMPORAL_RECHUNK_MAX_ROWID_KEY, "0");
+  withSavepoint("reset_temporal_rechunk", () => {
+    setKV(TEMPORAL_RECHUNK_EPOCH_KEY, randomUUID());
+    setKV(TEMPORAL_RECHUNK_DONE_KEY, "0");
+    setKV(TEMPORAL_RECHUNK_CURSOR_KEY, "");
+    setKV(TEMPORAL_RECHUNK_ATTEMPTS_KEY, "0");
+    setKV(TEMPORAL_RECHUNK_INFLIGHT_KEY, "");
+    setKV(TEMPORAL_RECHUNK_ROW_ATTEMPTS_KEY, "0");
+    setKV(TEMPORAL_RECHUNK_SKIP_KEY, "");
+    setKV(TEMPORAL_RECHUNK_MAX_ROWID_KEY, "0");
+  });
 }
 
 /**
@@ -3954,21 +3967,32 @@ export async function backfillTemporalEmbeddings(
   // the first walk after a blob->vec0 cutover is always armed and re-embeds the
   // rows that cutover skipped. (maybeCutoverToVec0 also explicitly re-arms the
   // walk on cutover as belt-and-suspenders.) Do not reorder these two lines.
-  if (readStorageMode(db()) !== "vec0") return 0;
-  if (getKV(TEMPORAL_RECHUNK_DONE_KEY) === "1") return 0;
-
-  let cursor = getKV(TEMPORAL_RECHUNK_CURSOR_KEY) ?? "";
-  let maxRowid = Number(getKV(TEMPORAL_RECHUNK_MAX_ROWID_KEY) ?? "0");
-  if (!Number.isSafeInteger(maxRowid) || maxRowid <= 0) {
-    maxRowid = (
-      db()
-        .query(
-          `SELECT COALESCE(MAX(rowid), 0) AS n FROM temporal_messages WHERE ${TEMPORAL_RECHUNK_ELIGIBLE_SQL}`,
-        )
-        .get() as { n: number }
-    ).n;
-    setKV(TEMPORAL_RECHUNK_MAX_ROWID_KEY, String(maxRowid));
-  }
+  const connection = db();
+  const snapshot = withSavepoint("start_temporal_rechunk", () => {
+    if (readStorageMode(connection) !== "vec0") return null;
+    if (getKV(TEMPORAL_RECHUNK_DONE_KEY) === "1") return null;
+    const cursor = getKV(TEMPORAL_RECHUNK_CURSOR_KEY) ?? "";
+    const epoch = getKV(TEMPORAL_RECHUNK_EPOCH_KEY);
+    let maxRowid = Number(getKV(TEMPORAL_RECHUNK_MAX_ROWID_KEY) ?? "0");
+    if (!Number.isSafeInteger(maxRowid) || maxRowid <= 0) {
+      maxRowid = (
+        connection
+          .query(
+            `SELECT COALESCE(MAX(rowid), 0) AS n FROM temporal_messages WHERE ${TEMPORAL_RECHUNK_ELIGIBLE_SQL}`,
+          )
+          .get() as { n: number }
+      ).n;
+      setKV(TEMPORAL_RECHUNK_MAX_ROWID_KEY, String(maxRowid));
+    }
+    return { cursor, epoch, maxRowid };
+  });
+  if (!snapshot) return 0;
+  let { cursor } = snapshot;
+  const { maxRowid, epoch } = snapshot;
+  // Identity must be checked first: getKV/db() would reopen storage after close.
+  const isCurrent = () =>
+    isCurrentDatabase(connection) &&
+    getKV(TEMPORAL_RECHUNK_EPOCH_KEY) === epoch;
   let scheduled = 0;
   let scanned = 0;
 
@@ -4017,37 +4041,43 @@ export async function backfillTemporalEmbeddings(
   // the walk visible regardless of speed.
   const PROGRESS_INTERVAL_MS = 30_000;
   let lastProgressAt = Date.now();
+  let sliceStarted = performance.now();
 
   for (;;) {
+    if (!isCurrent()) return scheduled;
     // Keep the legacy walk aligned with scheduler eligibility.
     const rows = db()
       .query(
-        `SELECT id, content FROM temporal_messages
+        `SELECT id FROM temporal_messages
          WHERE id > ? AND rowid <= ? AND ${TEMPORAL_RECHUNK_ELIGIBLE_SQL}
          ORDER BY id ASC LIMIT ?`,
       )
-      .all(cursor, maxRowid, TEMPORAL_RECHUNK_PAGE) as Array<{
-      id: string;
-      content: string;
-    }>;
+      .all(cursor, maxRowid, TEMPORAL_RECHUNK_PAGE) as Array<{ id: string }>;
 
     if (!rows.length) {
-      setKV(TEMPORAL_RECHUNK_DONE_KEY, "1");
-      setKV(TEMPORAL_RECHUNK_ATTEMPTS_KEY, "0");
-      setKV(TEMPORAL_RECHUNK_INFLIGHT_KEY, "");
-      setKV(TEMPORAL_RECHUNK_ROW_ATTEMPTS_KEY, "0");
-      setKV(TEMPORAL_RECHUNK_SKIP_KEY, "");
+      withSavepoint("finish_temporal_rechunk", () => {
+        if (!isCurrent()) return;
+        setKV(TEMPORAL_RECHUNK_DONE_KEY, "1");
+        setKV(TEMPORAL_RECHUNK_ATTEMPTS_KEY, "0");
+        setKV(TEMPORAL_RECHUNK_INFLIGHT_KEY, "");
+        setKV(TEMPORAL_RECHUNK_ROW_ATTEMPTS_KEY, "0");
+        setKV(TEMPORAL_RECHUNK_SKIP_KEY, "");
+      });
       break;
     }
 
     for (const row of rows) {
       // Admission performs synchronous SQLite work only. Keep the host gate so a
       // one-time full-corpus walk still yields between rows under request load.
-      await awaitBackfillIdle(opts.shouldPause);
-      withSavepoint("schedule_temporal_rechunk", () => {
+      await awaitBackfillIdle(opts.shouldPause, isCurrent);
+      if (!isCurrentDatabase(connection)) return scheduled;
+      const admitted = withSavepoint("schedule_temporal_rechunk", () => {
+        if (!isCurrent()) return false;
         const current = db()
-          .query("SELECT content FROM temporal_messages WHERE id = ?")
-          .get(row.id) as { content: string } | null;
+          .query(
+            "SELECT content FROM temporal_messages WHERE id = ? AND rowid <= ?",
+          )
+          .get(row.id, maxRowid) as { content: string } | null;
         if (current) {
           const enqueued = enqueueTemporalEmbedding(row.id, current.content);
           if (enqueued) {
@@ -4058,13 +4088,28 @@ export async function backfillTemporalEmbeddings(
         cursor = row.id;
         scanned++;
         setKV(TEMPORAL_RECHUNK_CURSOR_KEY, cursor);
+        return true;
       });
+      if (!admitted) return scheduled;
 
       if (Date.now() - lastProgressAt >= PROGRESS_INTERVAL_MS) {
         log.info(
           formatTemporalRechunkProgress(baseDone + scanned, total, scheduled),
         );
         lastProgressAt = Date.now();
+      }
+
+      // awaitBackfillIdle resolves immediately when the gate is clear. Awaiting
+      // it only yields to microtasks, starving HTTP/timers for the entire walk.
+      // Yield after SCANNED rows (including already-queued/deleted rows), with
+      // every queue/vector/cursor savepoint committed before other work runs.
+      if (
+        scanned % TEMPORAL_RECHUNK_YIELD_ROWS === 0 ||
+        performance.now() - sliceStarted >= TEMPORAL_RECHUNK_YIELD_MS
+      ) {
+        await new Promise<void>((resolve) => setImmediate(resolve));
+        if (!isCurrent()) return scheduled;
+        sliceStarted = performance.now();
       }
     }
   }

--- a/packages/core/test/embedding-backfill-throttle.test.ts
+++ b/packages/core/test/embedding-backfill-throttle.test.ts
@@ -1,7 +1,11 @@
 import { readFileSync } from "node:fs";
+import { createServer, get } from "node:http";
+import { once } from "node:events";
+import { performance } from "node:perf_hooks";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { db, ensureProject } from "../src/db";
+import { db, ensureProject, getKV, databaseInTransaction } from "../src/db";
 import { ensureVec0Store, setStorageMode } from "../src/db/vec-store";
+import { enqueueTemporalEmbedding } from "../src/temporal-embedding-admission";
 import {
   backfillTemporalEmbeddings,
   resetTemporalRechunkProgress,
@@ -47,9 +51,140 @@ describe("temporal re-chunk backfill CPU throttle", () => {
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     _restoreProvider(providerToken);
     delete process.env.LORE_BACKFILL_CPU_DUTY;
   });
+
+  it.each([false, true])(
+    "serves HTTP during admission (already queued: %s)",
+    async (alreadyQueued) => {
+      const count = 1_024;
+      for (let i = 0; i < count; i++) {
+        const id = `http-${String(i).padStart(5, "0")}`;
+        insertMsg(id, pid);
+        if (alreadyQueued)
+          enqueueTemporalEmbedding(
+            id,
+            `temporal message ${id} with more than enough content to embed`,
+          );
+      }
+      const server = createServer((_req, res) => {
+        res.end(
+          JSON.stringify({
+            cursor: getKV("lore:temporal_rechunk.cursor"),
+            done: getKV("lore:temporal_rechunk.done"),
+            inTransaction: databaseInTransaction(db()),
+          }),
+        );
+      });
+      server.listen(0, "127.0.0.1");
+      await once(server, "listening");
+      const address = server.address();
+      if (!address || typeof address === "string")
+        throw new Error("missing HTTP listener");
+      let probe:
+        | Promise<{
+            cursor: string | null;
+            done: string | null;
+            inTransaction: boolean;
+          }>
+        | undefined;
+      try {
+        const processed = await backfillTemporalEmbeddings({
+          shouldPause: () => {
+            // Issue real I/O only after admission has started. A resolved Promise
+            // or queueMicrotask does not allow this request's callback to run.
+            probe ??= new Promise((resolve, reject) => {
+              get(`http://127.0.0.1:${address.port}/health`, (res) => {
+                let body = "";
+                res.setEncoding("utf8");
+                res.on("data", (chunk) => {
+                  body += chunk;
+                });
+                res.on("end", () => {
+                  resolve(JSON.parse(body));
+                });
+                res.on("error", reject);
+              }).on("error", reject);
+            });
+            return false;
+          },
+        });
+        const observed = await probe;
+        expect(processed).toBe(alreadyQueued ? 0 : count);
+        expect(observed?.cursor).toMatch(/^http-/);
+        expect(observed?.inTransaction).toBe(false);
+        expect(observed?.cursor).not.toBe("http-01023");
+        expect(observed?.done).not.toBe("1");
+        expect(getKV("lore:temporal_rechunk.done")).toBe("1");
+        expect(embed).not.toHaveBeenCalled();
+      } finally {
+        server.closeAllConnections();
+        await new Promise<void>((resolve) => server.close(() => resolve()));
+      }
+    },
+  );
+
+  it.each(["absent", "throws"])(
+    "yields to timers with a %s pause gate",
+    async (gate) => {
+      for (let i = 0; i < 128; i++)
+        insertMsg(`timer-${String(i).padStart(5, "0")}`, pid);
+      const timer = new Promise<{ cursor: string | null; done: string | null }>(
+        (resolve) => {
+          setTimeout(
+            () =>
+              resolve({
+                cursor: getKV("lore:temporal_rechunk.cursor"),
+                done: getKV("lore:temporal_rechunk.done"),
+              }),
+            0,
+          );
+        },
+      );
+      await backfillTemporalEmbeddings(
+        gate === "absent"
+          ? {}
+          : {
+              shouldPause: () => {
+                throw new Error("host predicate failed");
+              },
+            },
+      );
+      const observed = await timer;
+      expect(observed.cursor).toMatch(/^timer-/);
+      expect(observed.cursor).not.toBe("timer-00127");
+      expect(observed.done).not.toBe("1");
+      expect(getKV("lore:temporal_rechunk.done")).toBe("1");
+    },
+  );
+
+  it.each([0, 5])(
+    "bounds admission bursts with %sms of per-row work",
+    async (rowMs) => {
+      for (let i = 0; i < 128; i++)
+        insertMsg(`burst-${String(i).padStart(5, "0")}`, pid);
+      let elapsed = 0;
+      vi.spyOn(performance, "now").mockImplementation(() => elapsed);
+      const tick = new Promise<string | null>((resolve) => {
+        setImmediate(() => resolve(getKV("lore:temporal_rechunk.cursor")));
+      });
+      await backfillTemporalEmbeddings({
+        shouldPause: () => {
+          elapsed += rowMs;
+          return false;
+        },
+      });
+      const cursor = await tick;
+      expect(cursor).toMatch(/^burst-/);
+      // Cheap rows must still yield; expensive rows must yield before 32 rows.
+      const scannedAtTick = Number(cursor!.slice("burst-".length)) + 1;
+      if (rowMs === 0) expect(scannedAtTick).toBeLessThanOrEqual(32);
+      else expect(scannedAtTick).toBeLessThan(32);
+      expect(getKV("lore:temporal_rechunk.done")).toBe("1");
+    },
+  );
 
   it("does not invoke providers or inference-duty sleeps", async () => {
     process.env.LORE_BACKFILL_CPU_DUTY = "0.5";

--- a/packages/core/test/vec0-cutover.test.ts
+++ b/packages/core/test/vec0-cutover.test.ts
@@ -59,6 +59,7 @@ import {
   MAX_TEMPORAL_CHUNKS_PER_MESSAGE,
   maybeCutoverToVec0,
   resetTemporalRechunkProgress,
+  runStartupBackfill,
 } from "../src/embedding";
 import * as log from "../src/log";
 import {
@@ -2142,6 +2143,41 @@ describeVec("temporal re-chunk durable admission", () => {
     expect(queuedIds()).toEqual(["m1"]);
     expect(await backfillTemporalEmbeddings()).toBe(1);
     expect(queuedIds()).toEqual(["m1", "m2"]);
+  });
+
+  test("startup caller does not reopen after temporal shutdown", async () => {
+    setStorageMode(db(), "vec0");
+    ensureVec0Store(db(), DIM);
+    insertContent("m1");
+    insertContent("m2");
+    const token = _saveAndClearProvider();
+    _restoreProvider({ provider: { maxBatchSize: 8, embed: vi.fn() } });
+    const originalPath = process.env.LORE_DB_PATH;
+    const directory = mkdtempSync(join(tmpdir(), "lore-rechunk-close-"));
+    const successorPath = join(directory, "successor.db");
+    let checks = 0;
+    try {
+      const result = await runStartupBackfill({
+        shouldPause: () => {
+          if (++checks === 2) {
+            close();
+            process.env.LORE_DB_PATH = successorPath;
+          }
+          return false;
+        },
+      });
+      expect(result.temporalRechunked).toBe(1);
+      expect(existsSync(successorPath)).toBe(false);
+    } finally {
+      _restoreProvider(token);
+      close();
+      if (originalPath === undefined) delete process.env.LORE_DB_PATH;
+      else process.env.LORE_DB_PATH = originalPath;
+      rmSync(directory, { recursive: true, force: true });
+    }
+    expect(getKV(CURSOR_KEY)).toBe("m1");
+    expect(getKV(DONE_KEY)).not.toBe("1");
+    expect(await backfillTemporalEmbeddings()).toBe(1);
   });
 
   test("does not open a successor database after shutdown during admission", async () => {

--- a/packages/core/test/vec0-cutover.test.ts
+++ b/packages/core/test/vec0-cutover.test.ts
@@ -16,6 +16,9 @@ import {
   vi,
 } from "vitest";
 import { config } from "../src/config";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   close,
   db,
@@ -2049,6 +2052,128 @@ describeVec("temporal re-chunk durable admission", () => {
     } finally {
       info.mockRestore();
     }
+  });
+
+  test("preserves a completed live replacement outside the captured rowid snapshot", async () => {
+    setStorageMode(db(), "vec0");
+    ensureVec0Store(db(), DIM);
+    insertContent("m1");
+    insertContent("m2"); // Keep the high-water row alive so SQLite cannot reuse it.
+    let replaced = false;
+    const processed = await backfillTemporalEmbeddings({
+      shouldPause: () => {
+        if (!replaced) {
+          replaced = true;
+          db().query("DELETE FROM temporal_messages WHERE id = 'm1'").run();
+          insertContent("m1", `${LONG} Replaced during the walk.`);
+          storeTemporalChunks(db(), "m1", [v(0, 1, 0, 0)]);
+        }
+        return false;
+      },
+    });
+    expect(processed).toBe(1);
+    expect(queuedIds()).toEqual(["m2"]);
+    expect(chunkIds("m1")).toEqual(["m1#0"]);
+    expect(getKV(DONE_KEY)).toBe("1");
+  });
+
+  test.each(["gate", "event loop"])(
+    "does not overwrite a reset during the %s yield",
+    async (during) => {
+      setStorageMode(db(), "vec0");
+      ensureVec0Store(db(), DIM);
+      for (let i = 0; i < 128; i++)
+        insertContent(`reset-${String(i).padStart(3, "0")}`);
+      let reset = false;
+      const resetProgress = () => {
+        reset = true;
+        // Config changes clear completed vectors and must revisit the prefix.
+        clearAllEmbeddings(db());
+        resetTemporalRechunkProgress();
+      };
+      const callback =
+        during === "event loop"
+          ? new Promise<void>((resolve) =>
+              setImmediate(() => {
+                resetProgress();
+                resolve();
+              }),
+            )
+          : undefined;
+      let checks = 0;
+      const processed = await backfillTemporalEmbeddings({
+        shouldPause: () => {
+          if (during === "gate" && ++checks === 2) resetProgress();
+          return false;
+        },
+      });
+      await callback;
+      expect(reset).toBe(true);
+      expect(processed).toBeLessThan(128);
+      expect(getKV(CURSOR_KEY)).toBe("");
+      expect(getKV(DONE_KEY)).toBe("0");
+      expect(getKV(MAX_ROWID_KEY)).toBe("0");
+      // Drain the previously queued prefix, then prove the reset revisits it.
+      db().query("DELETE FROM temporal_embedding_queue").run();
+      expect(await backfillTemporalEmbeddings()).toBe(128);
+      expect(queuedIds()).toHaveLength(128);
+      expect(getKV(DONE_KEY)).toBe("1");
+    },
+  );
+
+  test("does not resume an old walk after the database is closed and reopened", async () => {
+    setStorageMode(db(), "vec0");
+    ensureVec0Store(db(), DIM);
+    insertContent("m1");
+    insertContent("m2");
+    let checks = 0;
+    const processed = await backfillTemporalEmbeddings({
+      shouldPause: () => {
+        if (++checks === 2) {
+          close();
+          db(); // Same file and epoch, but a successor connection owns it now.
+        }
+        return false;
+      },
+    });
+    expect(processed).toBe(1);
+    expect(getKV(CURSOR_KEY)).toBe("m1");
+    expect(getKV(DONE_KEY)).not.toBe("1");
+    expect(queuedIds()).toEqual(["m1"]);
+    expect(await backfillTemporalEmbeddings()).toBe(1);
+    expect(queuedIds()).toEqual(["m1", "m2"]);
+  });
+
+  test("does not open a successor database after shutdown during admission", async () => {
+    setStorageMode(db(), "vec0");
+    ensureVec0Store(db(), DIM);
+    insertContent("m1");
+    insertContent("m2");
+    const originalPath = process.env.LORE_DB_PATH;
+    const directory = mkdtempSync(join(tmpdir(), "lore-rechunk-close-"));
+    const successorPath = join(directory, "successor.db");
+    let checks = 0;
+    try {
+      const processed = await backfillTemporalEmbeddings({
+        shouldPause: () => {
+          if (++checks === 2) {
+            close();
+            process.env.LORE_DB_PATH = successorPath;
+          }
+          return false;
+        },
+      });
+      expect(processed).toBe(1);
+      expect(existsSync(successorPath)).toBe(false);
+    } finally {
+      close();
+      if (originalPath === undefined) delete process.env.LORE_DB_PATH;
+      else process.env.LORE_DB_PATH = originalPath;
+      rmSync(directory, { recursive: true, force: true });
+    }
+    expect(getKV(CURSOR_KEY)).toBe("m1");
+    expect(getKV(DONE_KEY)).not.toBe("1");
+    expect(await backfillTemporalEmbeddings()).toBe(1);
   });
 });
 


### PR DESCRIPTION
A large temporal re-chunk scan can keep printing progress while blocking HTTP requests and tool continuations. Its per-row await resolves immediately when the pause gate is clear, leaving the scan in a microtask loop for the entire corpus.

This change yields to normal event-loop work after 32 scanned rows or 8 ms of admission work. Already-queued rows yield too. Each queue/vector/cursor savepoint finishes before yielding, and pages load only IDs instead of unused message content.

Resuming after a yield also checks the captured database connection and a durable reset epoch, so an old scan cannot reopen a closed database or overwrite a config reset. Its startup caller also returns partial counts after shutdown, before running cleanup or coverage queries. Re-fetching content also checks the captured rowid ceiling, preserving completed live replacements above that ceiling.

Validation so far:
- 174 affected embedding/startup tests pass (6 skipped), including a real loopback HTTP server during fresh and already-queued scans.
- The first 11 new regressions fail against the PR base implementation; the additional startup-caller regression failed before its separate review fix.
- Six deliberate breakages are caught: replacing the yield with a resolved promise; removing either work budget; removing the snapshot, reset-epoch, or connection guard.
- Final typecheck, lint, formatting, and gateway bundle pass. Independent correctness and security reviews are complete with no unresolved blocking findings; each ran the sync property battery ten times successfully.
- Each review's full run on the frozen first candidate finished with 9,876 passes, the same 7 known baseline/environment failures, and 229 skips. The final 14-line startup guard and regression were then independently reviewed and revalidated in the affected suites and source gates. These full-suite counts are not a second full run of the final delta.
- Seer's low-severity epoch-check concern was independently examined by both reviewers, explained and resolved: the full epoch check is the first statement inside the admission savepoint, before any temporal read or write. Hosted CI is still completing.
- Published tree `29f896b5e8676ec4db3f952559166b9ab7c1a464` matches the locally tested tree exactly.

The work budget is checked between rows: initial counts and individual SQLite statements remain synchronous. This does not claim to fix the separate embedding-provider/drain failures or establish the cause of the reported process restart.

Fixes #1721