### PR TITLE
fix(core): diagnose temporal embedding failures and back off retries

### DIFF
--- a/packages/core/src/temporal-embedding-queue.ts
+++ b/packages/core/src/temporal-embedding-queue.ts
@@ -32,6 +32,18 @@ const HASH_CHUNK_BYTES = 16 * 1024;
 const IDLE_DRAIN_INTERVAL_MS = 250;
 const UNAVAILABLE_DRAIN_INTERVAL_MS = 30_000;
 const DEFAULT_REQUEST_TIMEOUT_MS = 60_000;
+const FAILURE_RETRY_BASE_MS = 1_000;
+const FAILURE_RETRY_MAX_MS = 30_000;
+
+interface DrainDiagnostics {
+  stage: "read" | "prepare" | "embed" | "validate" | "commit";
+  startedAt: number;
+  messages: number;
+  inputBytes: number;
+  units: number;
+  providerUnavailable: boolean;
+  abortReason?: "deadline" | "shutdown";
+}
 
 interface QueueRow {
   message_id: string;
@@ -54,6 +66,10 @@ let schedulerStarted = false;
 let schedulerTimer: ReturnType<typeof setTimeout> | undefined;
 let activeDrain: Promise<number> | undefined;
 let activeDrainAbort: AbortController | undefined;
+let activeDiagnostics: DrainDiagnostics | undefined;
+let schedulerGeneration = 0;
+let consecutiveFailures = 0;
+let failureRetryMs = 0;
 let requestTimeoutMs = DEFAULT_REQUEST_TIMEOUT_MS;
 const drainSettlers = new Set<() => void>();
 
@@ -190,7 +206,10 @@ function commitJob(job: CapturedJob, vectors: Float32Array[]): boolean {
   return committed;
 }
 
-async function drainOnce(signal: AbortSignal): Promise<number> {
+async function drainOnce(
+  signal: AbortSignal,
+  diagnostics: DrainDiagnostics,
+): Promise<number> {
   const candidates = db()
     .query(
       `SELECT q.message_id, q.content_hash, q.fingerprint,
@@ -215,6 +234,7 @@ async function drainOnce(signal: AbortSignal): Promise<number> {
     return true;
   });
   const placeholders = admitted.map(() => "?").join(",");
+  diagnostics.messages = admitted.length;
   const contentById = new Map(
     (
       db()
@@ -237,6 +257,11 @@ async function drainOnce(signal: AbortSignal): Promise<number> {
       }>
     ).map((row) => [row.id, row.content_bytes]),
   );
+  diagnostics.inputBytes = [...contentById.values()].reduce(
+    (sum, bytes) => sum + bytes.byteLength,
+    0,
+  );
+  diagnostics.stage = "prepare";
   const rows = admitted
     .map((candidate): QueueRow | null => {
       const contentBytes = contentById.get(candidate.message_id);
@@ -276,7 +301,12 @@ async function drainOnce(signal: AbortSignal): Promise<number> {
   const emptyJobs = jobs.filter((job) => job.texts.length === 0);
   const embeddingJobs = jobs.filter((job) => job.texts.length > 0);
   const texts = embeddingJobs.flatMap((job) => job.texts);
-  if (texts.length > 0 && !embedding.isAvailable()) return 0;
+  diagnostics.units = texts.length;
+  diagnostics.stage = "embed";
+  if (texts.length > 0 && !embedding.isAvailable()) {
+    diagnostics.providerUnavailable = true;
+    return 0;
+  }
   const vectors =
     texts.length > 0
       ? await embedding.embedInTokenBatches(texts, "document", signal)
@@ -284,8 +314,10 @@ async function drainOnce(signal: AbortSignal): Promise<number> {
   if (signal.aborted) {
     throw new embedding.EmbeddingRequestAbortedError();
   }
+  diagnostics.stage = "validate";
   validateVectors(vectors);
 
+  diagnostics.stage = "commit";
   let committed = emptyJobs.reduce(
     (count, job) => count + (commitJob(job, []) ? 1 : 0),
     0,
@@ -307,15 +339,27 @@ export function drainTemporalEmbeddingQueueOnce(): Promise<number> {
   if (activeDrain) return activeDrain;
   const abort = new AbortController();
   activeDrainAbort = abort;
-  const timer = setTimeout(
-    () =>
-      abort.abort(new Error("temporal embedding request deadline exceeded")),
-    requestTimeoutMs,
-  );
+  const diagnostics: DrainDiagnostics = {
+    stage: "read",
+    startedAt: performance.now(),
+    messages: 0,
+    inputBytes: 0,
+    units: 0,
+    providerUnavailable: false,
+  };
+  activeDiagnostics = diagnostics;
+  const timer = setTimeout(() => {
+    if (abort.signal.aborted) return;
+    diagnostics.abortReason = "deadline";
+    abort.abort(new Error("temporal embedding request deadline exceeded"));
+  }, requestTimeoutMs);
   timer.unref?.();
-  activeDrain = drainOnce(abort.signal).finally(() => {
+  activeDrain = drainOnce(abort.signal, diagnostics).finally(() => {
     clearTimeout(timer);
-    if (activeDrainAbort === abort) activeDrainAbort = undefined;
+    if (activeDrainAbort === abort) {
+      activeDrainAbort = undefined;
+      activeDiagnostics = undefined;
+    }
     activeDrain = undefined;
     const settlers = [...drainSettlers];
     drainSettlers.clear();
@@ -324,25 +368,88 @@ export function drainTemporalEmbeddingQueueOnce(): Promise<number> {
   return activeDrain;
 }
 
-function scheduleDrain(delayMs: number): void {
-  if (!schedulerStarted || schedulerTimer) return;
+/** Never inspect or stringify arbitrary exception properties, including causes. */
+function failureReason(error: unknown, diagnostics: DrainDiagnostics): string {
+  if (diagnostics.abortReason === "deadline") return "deadline";
+  // Even instanceof can throw for an untrusted Proxy rejection value.
+  try {
+    if (error instanceof embedding.LocalProviderUnavailableError) {
+      return "provider-unavailable";
+    }
+    if (error instanceof embedding.EmbeddingRequestAbortedError) {
+      return "request-aborted";
+    }
+  } catch {
+    // Fall through to an owned, content-free classification.
+  }
+  return diagnostics.stage === "validate"
+    ? "invalid-output"
+    : "operation-failed";
+}
+
+function schedulerIsCurrent(generation: number): boolean {
+  return schedulerStarted && schedulerGeneration === generation;
+}
+
+function scheduleDrain(
+  delayMs: number,
+  generation = schedulerGeneration,
+): void {
+  if (!schedulerIsCurrent(generation) || schedulerTimer) return;
   schedulerTimer = setTimeout(() => {
     schedulerTimer = undefined;
-    if (!schedulerStarted) return;
-    void drainTemporalEmbeddingQueueOnce()
-      .catch(() => {
-        log.error("temporal embedding scheduler drain failed");
-        return 0;
-      })
-      .then((processed) => {
+    if (!schedulerIsCurrent(generation)) return;
+    const drain = drainTemporalEmbeddingQueueOnce();
+    // Capture this drain's context before its finally releases the shared slot.
+    const diagnostics = activeDiagnostics!;
+    void drain.then(
+      (processed) => {
+        if (!schedulerIsCurrent(generation)) return;
+        if (processed > 0 && consecutiveFailures > 0) {
+          log.info(
+            `temporal embedding scheduler recovered: failures=${consecutiveFailures} committed=${processed}`,
+          );
+          consecutiveFailures = 0;
+          failureRetryMs = 0;
+        }
         scheduleDrain(
           processed > 0
             ? 0
-            : embedding.isAvailable()
-              ? IDLE_DRAIN_INTERVAL_MS
-              : UNAVAILABLE_DRAIN_INTERVAL_MS,
+            : diagnostics.providerUnavailable
+              ? UNAVAILABLE_DRAIN_INTERVAL_MS
+              : Math.max(IDLE_DRAIN_INTERVAL_MS, failureRetryMs),
+          generation,
         );
-      });
+      },
+      (error: unknown) => {
+        if (!schedulerIsCurrent(generation)) return;
+        if (diagnostics.abortReason === "shutdown") {
+          // A restarted scheduler can share the old, cancelled provider call.
+          scheduleDrain(0, generation);
+          return;
+        }
+        consecutiveFailures = Math.min(
+          consecutiveFailures + 1,
+          Number.MAX_SAFE_INTEGER,
+        );
+        const reason = failureReason(error, diagnostics);
+        failureRetryMs = Math.min(
+          FAILURE_RETRY_BASE_MS * 2 ** Math.min(consecutiveFailures - 1, 5),
+          FAILURE_RETRY_MAX_MS,
+        );
+        let unavailable = reason === "provider-unavailable";
+        try {
+          unavailable ||= !embedding.isAvailable();
+        } catch {
+          // Availability probing must not replace the original failure or stop retries.
+        }
+        if (unavailable) failureRetryMs = UNAVAILABLE_DRAIN_INTERVAL_MS;
+        log.error(
+          `temporal embedding scheduler drain failed: reason=${reason} stage=${diagnostics.stage} elapsed_ms=${Math.round(performance.now() - diagnostics.startedAt)} messages=${diagnostics.messages} input_bytes=${diagnostics.inputBytes} units=${diagnostics.units} failures=${consecutiveFailures} retry_ms=${failureRetryMs}`,
+        );
+        scheduleDrain(failureRetryMs, generation);
+      },
+    );
   }, delayMs);
   schedulerTimer.unref?.();
 }
@@ -351,15 +458,20 @@ function scheduleDrain(delayMs: number): void {
 export function startTemporalEmbeddingScheduler(): void {
   if (schedulerStarted) return;
   schedulerStarted = true;
+  schedulerGeneration++;
   scheduleDrain(0);
 }
 
 /** Stop admission of new scheduler drains. Any active provider call keeps its slot. */
 export function stopTemporalEmbeddingScheduler(): void {
   schedulerStarted = false;
+  schedulerGeneration++;
   if (schedulerTimer) clearTimeout(schedulerTimer);
   schedulerTimer = undefined;
-  activeDrainAbort?.abort(new Error("temporal embedding scheduler stopped"));
+  if (activeDrainAbort && !activeDrainAbort.signal.aborted) {
+    if (activeDiagnostics) activeDiagnostics.abortReason = "shutdown";
+    activeDrainAbort.abort(new Error("temporal embedding scheduler stopped"));
+  }
 }
 
 /**
@@ -394,6 +506,8 @@ export function _resetTemporalEmbeddingSchedulerForTest(): void {
   stopTemporalEmbeddingScheduler();
   drainSettlers.clear();
   requestTimeoutMs = DEFAULT_REQUEST_TIMEOUT_MS;
+  consecutiveFailures = 0;
+  failureRetryMs = 0;
 }
 
 /** Test-only request deadline override. Null restores the production default. */

--- a/packages/core/test/temporal-embedding-queue.test.ts
+++ b/packages/core/test/temporal-embedding-queue.test.ts
@@ -297,7 +297,12 @@ describe("durable temporal embedding scheduler", () => {
         /^temporal embedding scheduler drain failed: reason=operation-failed stage=embed elapsed_ms=\d+ messages=1 input_bytes=\d+ units=1 failures=1 retry_ms=1000$/,
       ),
     );
-    const rendered = JSON.stringify(error.mock.calls);
+    expect(error).toHaveBeenCalledOnce();
+    expect(
+      error.mock.calls.flat().every((argument) => typeof argument === "string"),
+    ).toBe(true);
+    // Match the logger's coercion: JSON.stringify(Error) would hide its message.
+    const rendered = error.mock.calls.flat().map(String).join("\n");
     expect(rendered).not.toContain(content);
     expect(rendered).not.toContain(id);
     expect(rendered).not.toContain("private provider diagnostic");

--- a/packages/core/test/temporal-embedding-queue.test.ts
+++ b/packages/core/test/temporal-embedding-queue.test.ts
@@ -11,6 +11,7 @@ import {
 import {
   _restoreProvider,
   _saveAndClearProvider,
+  LocalProviderUnavailableError,
   type EmbeddingProvider,
 } from "../src/embedding";
 import {
@@ -25,6 +26,7 @@ import {
 } from "../src/temporal-embedding-queue";
 import { MAX_TEMPORAL_CHUNKS_PER_MESSAGE } from "../src/embedding-units";
 import * as log from "../src/log";
+import * as embedding from "../src/embedding";
 
 interface Deferred<T> {
   promise: Promise<T>;
@@ -96,6 +98,7 @@ beforeEach(() => {
 afterEach(async () => {
   stopTemporalEmbeddingScheduler();
   await settleTemporalEmbeddingScheduler();
+  vi.useRealTimers();
   _restoreProvider(savedProvider);
   log.registerSink(passthroughSink);
   vi.restoreAllMocks();
@@ -269,7 +272,7 @@ describe("durable temporal embedding scheduler", () => {
     expect(row.embedding).toBeNull();
   });
 
-  test("scheduler failures emit only a fixed content-free message", async () => {
+  test("scheduler failures identify the stage without exposing private diagnostics", async () => {
     const logged = deferred<void>();
     const error = vi.spyOn(log, "error").mockImplementation(() => {
       logged.resolve();
@@ -290,13 +293,333 @@ describe("durable temporal embedding scheduler", () => {
     await settleTemporalEmbeddingScheduler();
 
     expect(error).toHaveBeenCalledWith(
-      "temporal embedding scheduler drain failed",
+      expect.stringMatching(
+        /^temporal embedding scheduler drain failed: reason=operation-failed stage=embed elapsed_ms=\d+ messages=1 input_bytes=\d+ units=1 failures=1 retry_ms=1000$/,
+      ),
     );
     const rendered = JSON.stringify(error.mock.calls);
     expect(rendered).not.toContain(content);
     expect(rendered).not.toContain(id);
     expect(rendered).not.toContain("private provider diagnostic");
     expect(queueRow(id)).not.toBeNull();
+  });
+
+  test("persistent failures back off exponentially, cap retries, and recover once after durable progress", async () => {
+    vi.useFakeTimers();
+    const error = vi.spyOn(log, "error").mockImplementation(() => {});
+    const info = vi.spyOn(log, "info").mockImplementation(() => {});
+    let failing = true;
+    const embed = vi.fn(async (texts: string[]) => {
+      if (failing) throw new Error("private retry diagnostic");
+      return texts.map(() => vector());
+    });
+    installProvider({ maxBatchSize: 8, embed });
+    const id = insertMessage(
+      "durable retries must survive each failed provider attempt",
+    );
+    startTemporalEmbeddingScheduler();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(embed).toHaveBeenCalledTimes(1);
+    for (const [index, delay] of [
+      1000, 2000, 4000, 8000, 16000, 30000, 30000,
+    ].entries()) {
+      expect(error.mock.calls.at(-1)?.[0]).toContain(`retry_ms=${delay}`);
+      await vi.advanceTimersByTimeAsync(delay - 1);
+      expect(embed).toHaveBeenCalledTimes(index + 1);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(embed).toHaveBeenCalledTimes(index + 2);
+      expect(queueRow(id)).not.toBeNull();
+    }
+    failing = false;
+    await vi.advanceTimersByTimeAsync(30000);
+    expect(queueRow(id)).toBeNull();
+    const recoveries = () =>
+      info.mock.calls.filter(([message]) =>
+        String(message).startsWith("temporal embedding scheduler recovered:"),
+      );
+    expect(recoveries()).toHaveLength(1);
+    expect(recoveries()[0]?.[0]).toContain("failures=8");
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(recoveries()).toHaveLength(1);
+    failing = true;
+    insertMessage(
+      "new work starts a fresh failure streak after a real recovery",
+    );
+    await vi.advanceTimersByTimeAsync(250);
+    expect(error.mock.calls.at(-1)?.[0]).toContain("failures=1 retry_ms=1000");
+  });
+
+  test("an empty poll does not claim recovery or reset the failure streak", async () => {
+    vi.useFakeTimers();
+    const info = vi.spyOn(log, "info").mockImplementation(() => {});
+    const error = vi.spyOn(log, "error").mockImplementation(() => {});
+    installProvider({
+      maxBatchSize: 8,
+      async embed() {
+        throw new Error("private");
+      },
+    });
+    const id = insertMessage(
+      "another connection may remove failed work before the retry",
+    );
+    startTemporalEmbeddingScheduler();
+    await vi.advanceTimersByTimeAsync(0);
+    db()
+      .query("DELETE FROM temporal_embedding_queue WHERE message_id = ?")
+      .run(id);
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(
+      info.mock.calls.some(([message]) =>
+        String(message).includes("scheduler recovered"),
+      ),
+    ).toBe(false);
+    insertMessage(
+      "later work still inherits the provider failure backoff streak",
+    );
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(error.mock.calls.at(-1)?.[0]).toContain("failures=2 retry_ms=2000");
+  });
+
+  test("deadline failures identify the scheduler deadline, not the provider's private abort error", async () => {
+    vi.useFakeTimers();
+    const error = vi.spyOn(log, "error").mockImplementation(() => {});
+    installProvider({
+      maxBatchSize: 8,
+      embed(_texts, _inputType, signal) {
+        return new Promise((_, reject) =>
+          signal?.addEventListener(
+            "abort",
+            () => reject(new Error("private deadline payload")),
+            { once: true },
+          ),
+        );
+      },
+    });
+    const id = insertMessage(
+      "a timed out provider request must not lose its durable job",
+    );
+    _setTemporalEmbeddingRequestTimeoutForTest(10);
+    startTemporalEmbeddingScheduler();
+    await vi.advanceTimersByTimeAsync(10);
+    expect(error).toHaveBeenCalledOnce();
+    expect(error.mock.calls[0]?.[0]).toContain(
+      "reason=deadline stage=embed elapsed_ms=10",
+    );
+    expect(JSON.stringify(error.mock.calls)).not.toContain(
+      "private deadline payload",
+    );
+    expect(queueRow(id)).not.toBeNull();
+  });
+
+  test("provider unavailability preserves the slow retry cadence without logging its cause", async () => {
+    vi.useFakeTimers();
+    const error = vi.spyOn(log, "error").mockImplementation(() => {});
+    const embed = vi.fn(async () => {
+      throw new LocalProviderUnavailableError(new Error("secret model path"));
+    });
+    installProvider({ maxBatchSize: 8, embed });
+    insertMessage(
+      "provider availability errors must use the slower polling cadence",
+    );
+    startTemporalEmbeddingScheduler();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(error.mock.calls[0]?.[0]).toContain(
+      "reason=provider-unavailable stage=embed",
+    );
+    expect(error.mock.calls[0]?.[0]).toContain("retry_ms=30000");
+    await vi.advanceTimersByTimeAsync(29999);
+    expect(embed).toHaveBeenCalledOnce();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(embed).toHaveBeenCalledTimes(2);
+    expect(JSON.stringify(error.mock.calls)).not.toContain("secret model path");
+  });
+
+  test("shutdown cancellation stays quiet and restart waits for the old provider slot", async () => {
+    vi.useFakeTimers();
+    const error = vi.spyOn(log, "error").mockImplementation(() => {});
+    const gate = deferred<Float32Array[]>();
+    const fresh = deferred<Float32Array[]>();
+    const embed = vi
+      .fn()
+      .mockImplementationOnce(() => gate.promise)
+      .mockImplementation(() => fresh.promise);
+    installProvider({ maxBatchSize: 8, embed });
+    const id = insertMessage(
+      "a restarted scheduler must wait for abort-ignoring inference to settle",
+    );
+    try {
+      startTemporalEmbeddingScheduler();
+      await vi.advanceTimersByTimeAsync(0);
+      stopTemporalEmbeddingScheduler();
+      startTemporalEmbeddingScheduler();
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(embed).toHaveBeenCalledOnce();
+      gate.resolve([vector()]);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(error).not.toHaveBeenCalled();
+      expect(queueRow(id)).not.toBeNull();
+      expect(embed).toHaveBeenCalledTimes(2);
+      fresh.resolve([vector(2)]);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(queueRow(id)).toBeNull();
+    } finally {
+      gate.resolve([vector()]);
+      fresh.resolve([vector(2)]);
+    }
+  });
+
+  test("settlement after stop never probes or recreates the provider", async () => {
+    vi.useFakeTimers();
+    const error = vi.spyOn(log, "error").mockImplementation(() => {});
+    const available = vi.spyOn(embedding, "isAvailable");
+    installProvider({
+      maxBatchSize: 8,
+      embed(_texts, _inputType, signal) {
+        return new Promise((_, reject) =>
+          signal?.addEventListener(
+            "abort",
+            () => reject(new Error("private shutdown")),
+            { once: true },
+          ),
+        );
+      },
+    });
+    insertMessage(
+      "shutdown must not call the provider after releasing runtime ownership",
+    );
+    startTemporalEmbeddingScheduler();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(available).toHaveBeenCalledOnce();
+    stopTemporalEmbeddingScheduler();
+    await vi.advanceTimersByTimeAsync(60000);
+    expect(available).toHaveBeenCalledOnce();
+    expect(error).not.toHaveBeenCalled();
+  });
+
+  test("a deadline preceding stop and restart is reported once by the current scheduler", async () => {
+    vi.useFakeTimers();
+    const error = vi.spyOn(log, "error").mockImplementation(() => {});
+    const gate = deferred<Float32Array[]>();
+    const embed = vi
+      .fn()
+      .mockImplementationOnce(() => gate.promise)
+      .mockImplementation(async (texts: string[]) =>
+        texts.map(() => vector(2)),
+      );
+    installProvider({ maxBatchSize: 8, embed });
+    const id = insertMessage(
+      "deadline ownership must survive restarting while old inference is pending",
+    );
+    _setTemporalEmbeddingRequestTimeoutForTest(10);
+    try {
+      startTemporalEmbeddingScheduler();
+      await vi.advanceTimersByTimeAsync(10);
+      stopTemporalEmbeddingScheduler();
+      startTemporalEmbeddingScheduler();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(embed).toHaveBeenCalledOnce();
+      gate.resolve([vector()]);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(queueRow(id)).not.toBeNull();
+      expect(error).toHaveBeenCalledOnce();
+      expect(error.mock.calls[0]?.[0]).toContain("reason=deadline stage=embed");
+      expect(error.mock.calls[0]?.[0]).toContain("failures=1 retry_ms=1000");
+      await vi.advanceTimersByTimeAsync(999);
+      expect(embed).toHaveBeenCalledOnce();
+      await vi.advanceTimersByTimeAsync(1);
+      expect(embed).toHaveBeenCalledTimes(2);
+      expect(queueRow(id)).toBeNull();
+    } finally {
+      gate.resolve([vector()]);
+    }
+  });
+
+  test("malformed vectors identify validation failures and preserve queued work", async () => {
+    vi.useFakeTimers();
+    const error = vi.spyOn(log, "error").mockImplementation(() => {});
+    installProvider({
+      maxBatchSize: 8,
+      async embed() {
+        return [new Float32Array(1)];
+      },
+    });
+    const id = insertMessage(
+      "the scheduler must reject incomplete vectors before any commit",
+    );
+    startTemporalEmbeddingScheduler();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(error.mock.calls[0]?.[0]).toContain(
+      "reason=invalid-output stage=validate",
+    );
+    expect(queueRow(id)).not.toBeNull();
+  });
+
+  test("commit failures roll back vectors and classify storage without exposing its exception", async () => {
+    vi.useFakeTimers();
+    const error = vi.spyOn(log, "error").mockImplementation(() => {});
+    installProvider({
+      maxBatchSize: 8,
+      async embed(texts) {
+        return texts.map(() => vector());
+      },
+    });
+    const id = insertMessage(
+      "queue deletion must commit atomically with its generated embedding",
+    );
+    db().exec(
+      "CREATE TEMP TRIGGER fail_temporal_queue_delete BEFORE DELETE ON temporal_embedding_queue BEGIN SELECT RAISE(ABORT, 'private storage payload'); END",
+    );
+    try {
+      startTemporalEmbeddingScheduler();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(error.mock.calls[0]?.[0]).toContain(
+        "reason=operation-failed stage=commit",
+      );
+      expect(queueRow(id)).not.toBeNull();
+      expect(
+        db()
+          .query("SELECT embedding FROM temporal_messages WHERE id = ?")
+          .get(id),
+      ).toEqual({ embedding: null });
+      expect(JSON.stringify(error.mock.calls)).not.toContain(
+        "private storage payload",
+      );
+    } finally {
+      db().exec("DROP TRIGGER fail_temporal_queue_delete");
+    }
+  });
+
+  test("hostile thrown values cannot inject diagnostics or prevent subsequent retries", async () => {
+    vi.useFakeTimers();
+    const error = vi.spyOn(log, "error").mockImplementation(() => {});
+    const hostile = new Proxy(
+      {},
+      {
+        get() {
+          throw new Error("private getter");
+        },
+        getPrototypeOf() {
+          throw new Error("private prototype");
+        },
+      },
+    );
+    const embed = vi.fn(async () => {
+      throw hostile;
+    });
+    installProvider({ maxBatchSize: 8, embed });
+    insertMessage(
+      "untrusted failures must not break the retry reporting machinery",
+    );
+    startTemporalEmbeddingScheduler();
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(embed).toHaveBeenCalledTimes(2);
+    expect(error).toHaveBeenCalledTimes(2);
+    expect(JSON.stringify(error.mock.calls)).not.toMatch(
+      /private|prototype|getter/,
+    );
+    expect(error.mock.calls[0]?.[0]).toContain(
+      "reason=operation-failed stage=embed",
+    );
   });
 
   test("refreshes stale admission metadata without sending stale content", async () => {


### PR DESCRIPTION
Recurring temporal embedding drain errors currently hide the failing stage and can retry a persistent failure every 250 ms. Production logs showed repeated errors while normal turns and distillation continued, so the scheduler needs useful diagnostics and a bounded retry cadence.

This change:
- Reports fixed failure categories, stage, elapsed time, bounded message/input/unit counts, failure streak, and retry delay in one readable log line. Exception text, causes, IDs, content, provider responses, and configuration values are excluded.
- Backs off failed drains from 1 second to a 30-second cap, retains the slower provider-unavailable cadence, and reports recovery once after work commits.
- Treats shutdown cancellation separately and uses scheduler generations to prevent stopped callbacks from reinitializing providers or counting a shared deadline failure twice after restart.
- Preserves durable queue rows, atomic vector commits, request deadlines, and the active inference slot until the real provider call settles.

This does not establish which provider failure produced the original logs or repair an unknown local model initialization failure. The classified diagnostics will distinguish that next. The broader O(delta) work in #1710 remains separate.

Validation:
- 36 focused scheduler tests pass.
- Eight regressions failed against the original scheduler before implementation; independent base-source verification subsequently reproduced all ten selected failures. Review strengthened the deadline-first restart and real logger-coercion tests. Generation, backoff, deadline, raw-error logging, hostile-Proxy, abort, and rollback mutants are rejected.
- Final typecheck, lint, formatting, and gateway bundle pass. Both independent reviews are COMPLETE with no unresolved finding: [correctness](https://github.com/BYK/loreai/pull/1724#pullrequestreview-5139441614), [security](https://github.com/BYK/loreai/pull/1724#pullrequestreview-5139456336). Each reviewer passed ten sync property runs.
- Each independent full run on the initial candidate finished with **9,886 passed, 7 known base/environment failures, 229 skipped** (exit 1). All seven failures were reproduced afresh on the unchanged base. Subsequent changes only strengthened tests; the final tree separately passes all 36 scheduler tests and all static gates. The full test phase followed a successful `node --import tsx` bundle because this local environment blocks the standard tsx CLI IPC pretest.
- Final-head [hosted CI](https://github.com/BYK/loreai/actions/runs/34205303310) passed tests, typecheck, lint, formatting, npm bundle and smoke, Linux x64 standalone build and smoke, and Linux ARM64 / Windows x64 / macOS ARM64 binary smoke jobs. CI Status is green. Seer passed with no issues (reference 16559810); semantic lint, docs checks, preview, and Postgres integration also passed. The earlier ONNX dependency download failure was setup-only and did not recur on the final head.
- Copilot could not review because its quota was exhausted. The user authorized proceeding with the completed independent correctness and security reviews and the green Seer review.
- Final head: `65b86acaaa5e3947ec7e592643833e97131dedbb`, tree `930c29996ea360e914f6285dbb730b6dce72003f` (identical to the final reviewed local tree).

Fixes #1723