### PR TITLE
fix(perf): resume semantic preparation from durable source windows

### DIFF
--- a/packages/core/src/data.ts
+++ b/packages/core/src/data.ts
@@ -655,6 +655,7 @@ export function clearProject(projectPath: string): ClearResult {
   database.exec("BEGIN IMMEDIATE");
   try {
     // Preparation may publish derived counts before any temporal row exists.
+    database.query("DELETE FROM source_windows WHERE project_id = ?").run(pid);
     database
       .query("DELETE FROM semantic_token_cache WHERE project_id = ?")
       .run(pid);

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -1,3 +1,4 @@
+import { SOURCE_WINDOW_SCHEMA } from "./source-window-schema";
 import { Database, registerScalarFunction } from "#db/driver";
 import { isVecAvailable, loadVecExtension, resetVecState } from "./db/vec";
 import {
@@ -2070,6 +2071,8 @@ export const MIGRATIONS: readonly string[] = Object.freeze([
   CREATE INDEX IF NOT EXISTS idx_semantic_token_cache_updated
     ON semantic_token_cache(updated_at);
   `,
+  // Version 87: bounded, local accepted-source transcript windows.
+  SOURCE_WINDOW_SCHEMA,
 ]);
 
 // Index of the migration whose work is performed by a column-presence-aware JS
@@ -4140,6 +4143,7 @@ function recoverMissingObjects(database: Database) {
     CREATE INDEX IF NOT EXISTS idx_semantic_token_cache_updated
       ON semantic_token_cache(updated_at);
   `);
+  database.exec(SOURCE_WINDOW_SCHEMA);
   // Version 54: knowledge_session_injections.verdict (outcome impact, #497).
   // The verdict-keyed index MUST be created here, AFTER the column is ensured —
   // never in the big exec above, which runs before this ALTER and would throw
@@ -4261,6 +4265,7 @@ export const PROJECT_MERGE_TABLES = Object.freeze([
   "project_id_aliases",
   "project_path_aliases",
   "session_prompt_deltas",
+  "source_windows", // Disposable; source-project deletion cascades it away.
   "semantic_token_cache", // Disposable; source-project deletion cascades it away.
   "session_rollup",
   "temporal_messages",

--- a/packages/core/src/gradient.ts
+++ b/packages/core/src/gradient.ts
@@ -22,6 +22,28 @@ import { estimateTokens } from "./tokenize";
 
 type MessageWithParts = LoreMessageWithParts;
 
+/** Exact aggregates for source messages preceding a bounded raw window. */
+export interface SourceWindow {
+  offset: number;
+  omittedTokens: number;
+  /** Cumulative resolved tokens at absolute source indexes, starting with zero. */
+  prefixTokens: number[];
+  /** Prior transformed IDs certify that no prior raw window lies in the omitted prefix. */
+  previousWindowIDs: string[];
+}
+
+export class FullSourceRequired extends Error {
+  constructor(
+    readonly reason:
+      | "window_exhausted"
+      | "tool_chain"
+      | "calibration"
+      | "passthrough",
+  ) {
+    super(`Full source required: ${reason}`);
+  }
+}
+
 // Token estimate using the shared ai-tokenizer-backed helper (cl100k_base by
 // default — gradient.ts intentionally does NOT thread the active provider/model
 // through all 21 internal call sites; per-encoding selection would balloon the
@@ -3063,6 +3085,7 @@ export function resetRawWindowCache(sessionID?: string) {
  * updates the cache.
  */
 function tryFitStable(input: {
+  sourceWindow?: SourceWindow;
   messages: MessageWithParts[];
   prefix: MessageWithParts[];
   prefixTokens: number;
@@ -3090,9 +3113,13 @@ function tryFitStable(input: {
     // old messages) because the offset is relative to the tail.
     const newMessages = Math.max(
       0,
-      input.messages.length - rawWindowCache.pinnedTotalCount,
+      input.messages.length +
+        (input.sourceWindow?.offset ?? 0) -
+        rawWindowCache.pinnedTotalCount,
     );
     const windowSize = rawWindowCache.pinnedRawCount + newMessages;
+    if (input.sourceWindow?.offset && windowSize > input.messages.length)
+      throw new FullSourceRequired("window_exhausted");
     const pinnedIdx = Math.max(0, input.messages.length - windowSize);
 
     // Ensure the pinned window starts with a user message when a prefix is
@@ -3135,7 +3162,8 @@ function tryFitStable(input: {
         input.sessState.rawWindowCache = {
           ...rawWindowCache,
           pinnedRawCount: pinnedWindow.length,
-          pinnedTotalCount: input.messages.length,
+          pinnedTotalCount:
+            input.messages.length + (input.sourceWindow?.offset ?? 0),
           pinnedBudget: input.rawBudget,
         };
       }
@@ -3175,6 +3203,7 @@ function tryFitStable(input: {
   // also degraded, just at the 100% boundary); higher layers (tool stripping)
   // take over when even the current turn doesn't fit the full rawBudget.
   const result = tryFit({
+    sourceWindow: input.sourceWindow,
     messages: input.messages,
     prefix: input.prefix,
     prefixTokens: input.prefixTokens,
@@ -3195,7 +3224,8 @@ function tryFitStable(input: {
       input.sessState.rawWindowCache = {
         sessionID: input.sessionID,
         pinnedRawCount: rawMessageCount,
-        pinnedTotalCount: input.messages.length,
+        pinnedTotalCount:
+          input.messages.length + (input.sourceWindow?.offset ?? 0),
         pinnedBudget: input.rawBudget,
       };
     }
@@ -3346,6 +3376,7 @@ function layer0Bounds(
  * tested here — no decision-vs-compression drift band. (#796)
  */
 export function isLargeColdStart(input: {
+  sourceWindow?: SourceWindow;
   messages: MessageWithParts[];
   sessionID?: string;
   /** Override the session's in-flight LTM token count (see docstring). */
@@ -3369,7 +3400,10 @@ export function isLargeColdStart(input: {
   const sessLtmTokens =
     input.ltmTokens ?? (sid ? sessState.ltmTokens : ltmTokensFallback);
   const expectedInput =
-    estimateMessages(input.messages) + overhead + sessLtmTokens;
+    estimateMessages(input.messages) +
+    (input.sourceWindow?.omittedTokens ?? 0) +
+    overhead +
+    sessLtmTokens;
   const { layer0Input, layer0Ceiling, maxInput } = layer0Bounds(
     expectedInput,
     false,
@@ -3382,6 +3416,7 @@ export function isLargeColdStart(input: {
 }
 
 function transformInner(input: {
+  sourceWindow?: SourceWindow;
   messages: MessageWithParts[];
   projectPath: string;
   sessionID?: string;
@@ -3478,7 +3513,8 @@ function transformInner(input: {
   // One-shot: consumed here and reset to 0 (both in-memory and on disk).
   let effectiveMinLayer = sessState.forceMinLayer;
   sessState.forceMinLayer = 0;
-  if (sid && effectiveMinLayer > 0) saveForceMinLayer(sid, 0);
+  if (sid && effectiveMinLayer > 0 && !input.sourceWindow?.offset)
+    saveForceMinLayer(sid, 0);
 
   // --- Approach A: Cache-preserving passthrough ---
   // Use exact token count from the previous API response when available.
@@ -3594,21 +3630,38 @@ function transformInner(input: {
     // 1.3 covers this without triggering unnecessary compression.
     const CALIBRATED_DELTA_SAFETY = 1.3;
 
-    const newMessages =
-      sessState.lastWindowMessageIDs.size > 0
-        ? input.messages.filter(
-            (m) => !sessState.lastWindowMessageIDs.has(m.info.id),
-          )
-        : input.messages.slice(
-            -Math.max(
-              0,
-              input.messages.length - sessState.lastKnownMessageCount,
-            ),
-          );
-    const rawNewMsgTokens = newMessages.reduce(
-      (s, m) => s + estimateMessage(m),
-      0,
-    );
+    let newMessages: MessageWithParts[];
+    let omittedNewTokens = input.sourceWindow?.omittedTokens ?? 0;
+    if (sessState.lastWindowMessageIDs.size > 0) {
+      if (input.sourceWindow?.offset) {
+        const prior = new Set(input.sourceWindow.previousWindowIDs);
+        for (const id of sessState.lastWindowMessageIDs)
+          if (!prior.has(id)) throw new FullSourceRequired("calibration");
+      }
+      newMessages = input.messages.filter(
+        (m) => !sessState.lastWindowMessageIDs.has(m.info.id),
+      );
+    } else if (input.sourceWindow?.offset) {
+      const sourceCount = input.sourceWindow.offset + input.messages.length;
+      const start =
+        sourceCount > sessState.lastKnownMessageCount
+          ? sessState.lastKnownMessageCount
+          : 0;
+      const omittedStart = Math.min(start, input.sourceWindow.offset);
+      const skipped = input.sourceWindow.prefixTokens[omittedStart];
+      if (skipped === undefined) throw new FullSourceRequired("calibration");
+      omittedNewTokens -= skipped;
+      newMessages = input.messages.slice(
+        Math.max(0, start - input.sourceWindow.offset),
+      );
+    } else {
+      newMessages = input.messages.slice(
+        -Math.max(0, input.messages.length - sessState.lastKnownMessageCount),
+      );
+    }
+    const rawNewMsgTokens =
+      omittedNewTokens +
+      newMessages.reduce((s, m) => s + estimateMessage(m), 0);
     const newMsgTokens = Math.ceil(rawNewMsgTokens * CALIBRATED_DELTA_SAFETY);
     const ltmDelta = sessLtmTokens - sessState.lastKnownLtm;
     expectedInput = sessState.lastKnownInput + newMsgTokens + ltmDelta;
@@ -3616,7 +3669,7 @@ function transformInner(input: {
     // First turn or session change: fall back to chars/3 estimate + overhead.
     const messageTokens = input.messages.reduce(
       (s, m) => s + estimateMessage(m),
-      0,
+      input.sourceWindow?.omittedTokens ?? 0,
     );
     expectedInput = messageTokens + overhead + sessLtmTokens;
   }
@@ -3668,6 +3721,7 @@ function transformInner(input: {
     effectiveMinLayer === 0 &&
     layer0Passes(layer0Input, layer0Ceiling, maxInput)
   ) {
+    if (input.sourceWindow?.offset) throw new FullSourceRequired("passthrough");
     // All messages fit — return unmodified to preserve append-only prompt-cache pattern.
     // Raw messages are strictly better context than lossy distilled summaries.
     // The quality-hard-ceiling clause (fill > QUALITY_HARD_CEILING_FRACTION of
@@ -3749,6 +3803,8 @@ function transformInner(input: {
         freeWrite,
       })
     ) {
+      if (input.sourceWindow?.offset)
+        throw new FullSourceRequired("passthrough");
       const messageTokens = calibrated
         ? expectedInput - (sessLtmTokens - sessState.lastKnownLtm)
         : expectedInput - overhead - sessLtmTokens;
@@ -3779,6 +3835,8 @@ function transformInner(input: {
   // ones with compact annotations. This can save thousands of tokens for sessions
   // with repeated file reads, potentially avoiding escalation to higher layers.
   const turnStart = currentTurnStart(input.messages);
+  if (input.sourceWindow?.offset && turnStart === 0)
+    throw new FullSourceRequired("tool_chain");
   // Pass the per-session decision memo so dedup stays byte-stable across turns
   // (an already-sent output keeps its full/collapsed form). Only when we have a
   // session to scope the memo to.
@@ -3930,6 +3988,7 @@ function transformInner(input: {
       // prefix the trim gate kept — otherwise tryFitStable's own
       // `prefixTokens > distilledBudget` guard would reject it and escalate.
       result = tryFitStable({
+        sourceWindow: input.sourceWindow,
         messages: dedupMessages,
         prefix: stagePrefix,
         prefixTokens: stagePrefixTokens,
@@ -3947,6 +4006,7 @@ function transformInner(input: {
       sessState.rawWindowCache = null;
       sessState.distilledBudgetHighWater = 0;
       result = tryFit({
+        sourceWindow: input.sourceWindow,
         messages: dedupMessages,
         prefix: stagePrefix,
         prefixTokens: stagePrefixTokens,
@@ -4022,6 +4082,8 @@ function transformInner(input: {
   // Current turn is always included (non-negotiable — dropping it causes
   // the infinite tool-call loop). Clean parts but never strip tool outputs.
   const nuclearTurnStart = currentTurnStart(input.messages);
+  if (input.sourceWindow?.offset && nuclearTurnStart === 0)
+    throw new FullSourceRequired("tool_chain");
   const currentTurn = input.messages.slice(nuclearTurnStart).map((m) => ({
     info: m.info,
     parts: cleanParts(m.parts),
@@ -4047,6 +4109,13 @@ function transformInner(input: {
     });
     olderTokens += est;
   }
+
+  if (
+    input.sourceWindow?.offset &&
+    olderMessages.length === nuclearTurnStart &&
+    olderTokens < remaining
+  )
+    throw new FullSourceRequired("window_exhausted");
 
   // Ensure role alternation at the prefix/raw boundary: drop leading assistant
   // messages from the older tail so the raw window starts with user (#424).
@@ -4088,6 +4157,7 @@ function transformInner(input: {
 // count but the "new messages" delta is computed against the full DB count,
 // making newMsgCount ≈ 0 and causing layer 0 passthrough on an overflowing session.
 export function transform(input: {
+  sourceWindow?: SourceWindow;
   messages: MessageWithParts[];
   projectPath: string;
   sessionID?: string;
@@ -4103,6 +4173,26 @@ export function transform(input: {
   // other request can clobber the globals between here and the transform.
   if (input.budget) applyModelBudget(input.budget);
 
+  const attemptSid = input.sessionID ?? input.messages[0]?.info.sessionID;
+  const original =
+    input.sourceWindow?.offset && attemptSid
+      ? getSessionState(attemptSid)
+      : undefined;
+  const originalUrgent = attemptSid
+    ? urgentDistillationMap.get(attemptSid)
+    : undefined;
+  if (original && attemptSid) {
+    const decisions = new Map<string, boolean>();
+    for (const message of input.messages)
+      for (const part of message.parts) {
+        if (!isToolPart(part)) continue;
+        const key = `${message.info.id}:${part.id ?? ""}`;
+        const value = original.dedupDecisions.get(key);
+        if (value !== undefined) decisions.set(key, value);
+      }
+    sessionStates.set(attemptSid, { ...original, dedupDecisions: decisions });
+  }
+
   // #797: count this transform for the cold-start grace window. Incremented
   // BEFORE transformInner so the very first turn observes transformCount === 1,
   // making the grace cover exactly the first COLD_START_GRACE_TURNS turns of a
@@ -4112,7 +4202,25 @@ export function transform(input: {
   const coldStartSid = input.sessionID ?? input.messages[0]?.info.sessionID;
   if (coldStartSid) getSessionState(coldStartSid).transformCount++;
 
-  const result = transformInner(input);
+  let result: TransformResult;
+  try {
+    result = transformInner(input);
+  } catch (error) {
+    if (original && attemptSid) {
+      sessionStates.set(attemptSid, original);
+      if (originalUrgent === undefined)
+        urgentDistillationMap.delete(attemptSid);
+      else urgentDistillationMap.set(attemptSid, originalUrgent);
+    }
+    throw error;
+  }
+  if (original && attemptSid) {
+    const accepted = getSessionState(attemptSid);
+    for (const [key, value] of accepted.dedupDecisions)
+      original.dedupDecisions.set(key, value);
+    accepted.dedupDecisions = original.dedupDecisions;
+    if (original.forceMinLayer > 0) saveForceMinLayer(attemptSid, 0);
+  }
 
   // Sanitize non-terminal tool parts before the window reaches the SDK.
   // Must run after transformInner (covers all layers 0-4) and before the
@@ -4248,6 +4356,7 @@ function currentTurnStart(messages: MessageWithParts[]): number {
 }
 
 function tryFit(input: {
+  sourceWindow?: SourceWindow;
   messages: MessageWithParts[];
   prefix: MessageWithParts[];
   prefixTokens: number;
@@ -4277,6 +4386,8 @@ function tryFit(input: {
   // These are always included — they must never be evicted. If they alone exceed the
   // raw budget, escalate to the next layer (which strips tool outputs to reduce size).
   const turnStart = currentTurnStart(input.messages);
+  if (input.sourceWindow?.offset && turnStart === 0)
+    throw new FullSourceRequired("tool_chain");
   const currentTurn = input.messages.slice(turnStart);
   const currentTurnTokens = currentTurn.reduce(
     (s, m) => s + estimateMessage(m),
@@ -4312,6 +4423,9 @@ function tryFit(input: {
     olderTokens += tokens;
     if (i === 0) cutoff = 0;
   }
+
+  if (input.sourceWindow?.offset && cutoff === 0)
+    throw new FullSourceRequired("window_exhausted");
 
   // Ensure role alternation at the prefix/raw boundary: the distilled prefix
   // ends with an assistant message, so the raw window must start with a user.

--- a/packages/core/src/gradient.ts
+++ b/packages/core/src/gradient.ts
@@ -3513,6 +3513,9 @@ function transformInner(input: {
   // One-shot: consumed here and reset to 0 (both in-memory and on disk).
   let effectiveMinLayer = sessState.forceMinLayer;
   sessState.forceMinLayer = 0;
+  // Complete source (including offset zero) consumes escalation normally.
+  // Only an omitted-prefix attempt can need full-source replay and must defer
+  // durable consumption until the speculative transform succeeds.
   if (sid && effectiveMinLayer > 0 && !input.sourceWindow?.offset)
     saveForceMinLayer(sid, 0);
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -218,6 +218,9 @@ export {
 } from "./hosted";
 export {
   transform,
+  estimateMessages,
+  FullSourceRequired,
+  type SourceWindow,
   prewarmDistillationSnapshot,
   setModelLimits,
   setMaxLayer0Tokens,
@@ -342,7 +345,11 @@ export {
   _resetVecReadLatencyForTest,
 } from "./vec-latency";
 export { distillLimiter, curatorLimiter } from "./session-limiter";
-export { estimateTokens, encodingForModel } from "./tokenize";
+export {
+  estimateTokens,
+  encodingForModel,
+  TOKEN_ESTIMATE_CACHE_VERSION,
+} from "./tokenize";
 export { SemanticTokenCache } from "./semantic-token-cache";
 export {
   installFetchInterceptor,
@@ -387,3 +394,9 @@ export type {
   CacheEconomicsInput,
   CacheEconomicsResult,
 } from "./cache-economics";
+
+export {
+  SourceWindowStore,
+  SOURCE_WINDOW_MAX_BYTES,
+  SOURCE_WINDOW_MAX_SESSIONS,
+} from "./source-window-store";

--- a/packages/core/src/semantic-token-cache.ts
+++ b/packages/core/src/semantic-token-cache.ts
@@ -36,6 +36,7 @@ export class SemanticTokenCache {
       projectPath: string;
       sessionID: string;
       noStore: boolean;
+      retainUnused?: boolean;
     },
   ) {
     if (scope.noStore) return;
@@ -131,7 +132,14 @@ export class SemanticTokenCache {
         currentTenantId() !== this.tenant
       )
         return;
-      const data = [...this.used];
+      const retained = this.scope.retainUnused
+        ? new Map(this.entries)
+        : new Map<string, number>();
+      for (const [key, value] of this.used) {
+        retained.delete(key);
+        retained.set(key, value);
+      }
+      const data = [...retained].slice(-SEMANTIC_TOKEN_CACHE_MAX_ENTRIES);
       const payload = JSON.stringify([
         VERSION,
         data,

--- a/packages/core/src/source-window-schema.ts
+++ b/packages/core/src/source-window-schema.ts
@@ -1,0 +1,40 @@
+/** Local, disposable transcript checkpoints. Never included in sync. */
+export const SOURCE_WINDOW_SCHEMA = `
+  CREATE TABLE IF NOT EXISTS source_windows (
+    project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    session_id TEXT NOT NULL REFERENCES session_state(session_id) ON DELETE CASCADE,
+    generation TEXT NOT NULL DEFAULT (lower(hex(randomblob(16)))),
+    revision INTEGER NOT NULL DEFAULT 0,
+    payload BLOB CHECK(length(payload) <= 4000000),
+    checksum TEXT,
+    updated_at INTEGER NOT NULL,
+    PRIMARY KEY(project_id, session_id)
+  );
+  CREATE INDEX IF NOT EXISTS idx_source_windows_updated ON source_windows(updated_at);
+  CREATE TRIGGER IF NOT EXISTS source_windows_temporal_insert
+  AFTER INSERT ON temporal_messages BEGIN
+    UPDATE source_windows SET revision = revision + 1, payload = NULL, checksum = NULL
+      WHERE project_id = NEW.project_id AND session_id = NEW.session_id;
+  END;
+  CREATE TRIGGER IF NOT EXISTS source_windows_temporal_delete
+  AFTER DELETE ON temporal_messages BEGIN
+    UPDATE source_windows SET revision = revision + 1, payload = NULL, checksum = NULL
+      WHERE project_id = OLD.project_id AND session_id = OLD.session_id;
+  END;
+  CREATE TRIGGER IF NOT EXISTS source_windows_temporal_update
+  AFTER UPDATE OF id, source_id, project_id, session_id, content, metadata ON temporal_messages BEGIN
+    UPDATE source_windows SET revision = revision + 1, payload = NULL, checksum = NULL
+      WHERE (project_id = OLD.project_id AND session_id = OLD.session_id)
+         OR (project_id = NEW.project_id AND session_id = NEW.session_id);
+  END;
+  CREATE TRIGGER IF NOT EXISTS source_windows_session_rebind
+  AFTER UPDATE OF project_path, credential_fingerprint ON session_state
+  WHEN OLD.project_path IS NOT NEW.project_path
+    OR OLD.credential_fingerprint IS NOT NEW.credential_fingerprint BEGIN
+    DELETE FROM source_windows WHERE session_id = NEW.session_id;
+  END;
+  CREATE TRIGGER IF NOT EXISTS source_windows_amnesia
+  AFTER UPDATE OF amnesia ON session_state WHEN NEW.amnesia != 0 BEGIN
+    DELETE FROM source_windows WHERE session_id = NEW.session_id;
+  END;
+`;

--- a/packages/core/src/source-window-store.ts
+++ b/packages/core/src/source-window-store.ts
@@ -1,0 +1,187 @@
+import { createHash } from "node:crypto";
+import { deflateSync, inflateSync } from "node:zlib";
+import { db, databaseInTransaction, isCurrentDatabase, projectId } from "./db";
+import { currentTenantId } from "./tenant";
+
+export const SOURCE_WINDOW_MAX_BYTES = 16_000_000;
+export const SOURCE_WINDOW_MAX_SESSIONS = 32;
+// A session may use the canonical path or a tenant-scoped worktree alias.
+// Apply this inside both SQL statements so a concurrent rebind cannot race a
+// separate ownership precheck. Unbound sessions are bound by the pipeline later.
+const SESSION_PROJECT_MATCH = `(s.project_path IS NULL OR s.project_path = ''
+  OR s.project_path = ? OR s.project_path = p.path
+  OR EXISTS (SELECT 1 FROM project_path_aliases a
+    WHERE a.project_id = p.id AND a.tenant_id = p.tenant_id AND a.path = s.project_path))`;
+const digest = (value: Uint8Array) =>
+  createHash("sha256").update(value).digest("hex");
+
+/**
+ * A lease on one accepted-request checkpoint, not an observation watermark.
+ * The source count never claims that historical messages were distilled/stored.
+ * claim/publish run inside the caller's temporal savepoint: failures roll back
+ * both response storage and frontier advancement. A stale request cannot
+ * resurrect a deleted owner or replace a newer request's checkpoint.
+ */
+export class SourceWindowStore {
+  private readonly tenant = currentTenantId();
+  private connection?: ReturnType<typeof db>;
+  private pid?: string;
+  private generation?: string;
+  private revision?: number;
+  private payload?: Uint8Array;
+  private checksum?: string;
+  private claimed = false;
+
+  private readonly scope: {
+    projectPath: string;
+    sessionID: string;
+    noStore: boolean;
+  };
+  constructor(scope: {
+    projectPath: string;
+    sessionID: string;
+    noStore: boolean;
+  }) {
+    // Do not retain extra properties (notably a caller's full request transcript).
+    this.scope = {
+      projectPath: scope.projectPath,
+      sessionID: scope.sessionID,
+      noStore: scope.noStore,
+    };
+    if (scope.noStore) return;
+    try {
+      const connection = (this.connection = db());
+      const pid = (this.pid = projectId(scope.projectPath));
+      if (!pid) return;
+      const read = () =>
+        connection
+          .query(`SELECT w.generation, w.revision, w.payload, w.checksum FROM source_windows w
+        JOIN projects p ON p.id = w.project_id
+        JOIN session_state s ON s.session_id = w.session_id
+        WHERE w.project_id = ? AND w.session_id = ? AND p.tenant_id = ? AND s.amnesia = 0
+          AND ${SESSION_PROJECT_MATCH} AND (w.payload IS NULL OR length(w.payload) <= 4000000)`)
+          .get(pid, scope.sessionID, this.tenant, scope.projectPath) as {
+          generation: string;
+          revision: number;
+          payload: Uint8Array | null;
+          checksum: string | null;
+        } | null;
+      let row = read();
+      if (!row) {
+        // The common hit is read-only. Cache creation must never wait on a
+        // background writer and stall the foreground event loop.
+        const { timeout } = connection.query("PRAGMA busy_timeout").get() as {
+          timeout: number;
+        };
+        connection.exec("PRAGMA busy_timeout = 0");
+        try {
+          const inserted = connection
+            .query(`INSERT OR IGNORE INTO source_windows(project_id, session_id, updated_at)
+            SELECT p.id, s.session_id, ? FROM projects p, session_state s
+            WHERE p.id = ? AND p.tenant_id = ? AND s.session_id = ? AND s.amnesia = 0
+              AND ${SESSION_PROJECT_MATCH}`)
+            .run(
+              Date.now(),
+              pid,
+              this.tenant,
+              scope.sessionID,
+              scope.projectPath,
+            );
+          if (inserted.changes)
+            connection
+              .query(`DELETE FROM source_windows WHERE rowid IN
+            (SELECT rowid FROM source_windows ORDER BY updated_at DESC, rowid DESC LIMIT -1 OFFSET ?)`)
+              .run(SOURCE_WINDOW_MAX_SESSIONS);
+          row = read();
+        } finally {
+          connection.exec(`PRAGMA busy_timeout = ${timeout}`);
+        }
+      }
+      if (!row) return;
+      this.generation = row.generation;
+      this.revision = row.revision;
+      this.payload = row.payload ?? undefined;
+      this.checksum = row.checksum ?? undefined;
+    } catch {
+      this.connection = undefined;
+    }
+  }
+
+  load(): unknown {
+    if (!this.payload || !this.checksum) return;
+    try {
+      if (digest(this.payload) !== this.checksum) return;
+      return JSON.parse(
+        inflateSync(this.payload, {
+          maxOutputLength: SOURCE_WINDOW_MAX_BYTES,
+        }).toString("utf8"),
+      );
+    } catch {
+      return;
+    }
+  }
+
+  /** Acquire the writer lock before checking the lease, inside the response savepoint. */
+  claim(): boolean {
+    this.claimed = false;
+    if (
+      !this.connection ||
+      !this.generation ||
+      this.revision === undefined ||
+      !isCurrentDatabase(this.connection) ||
+      currentTenantId() !== this.tenant ||
+      !databaseInTransaction(this.connection)
+    )
+      return false;
+    try {
+      return (this.claimed =
+        this.connection
+          .query(`UPDATE source_windows SET revision = revision
+        WHERE project_id = ? AND session_id = ? AND generation = ? AND revision = ?`)
+          .run(this.pid!, this.scope.sessionID, this.generation, this.revision)
+          .changes === 1);
+    } catch {
+      return false;
+    }
+  }
+
+  /** Caller must have claimed this lease before its own temporal writes. */
+  publish(value: unknown): boolean {
+    if (
+      !this.claimed ||
+      !this.connection ||
+      !this.generation ||
+      !isCurrentDatabase(this.connection) ||
+      currentTenantId() !== this.tenant ||
+      !databaseInTransaction(this.connection)
+    )
+      return false;
+    this.claimed = false;
+    try {
+      const json = JSON.stringify(value);
+      if (Buffer.byteLength(json) > SOURCE_WINDOW_MAX_BYTES) return false;
+      const payload = deflateSync(json, { level: 1 });
+      if (payload.length > 4_000_000) return false;
+      const result = this.connection
+        .query(`UPDATE source_windows SET payload = ?, checksum = ?,
+          revision = revision + 1, updated_at = ?
+        WHERE project_id = ? AND session_id = ? AND generation = ?`)
+        .run(
+          payload,
+          digest(payload),
+          Date.now(),
+          this.pid!,
+          this.scope.sessionID,
+          this.generation,
+        );
+      if (!result.changes) return false;
+      this.connection
+        .query(`DELETE FROM source_windows WHERE rowid IN
+        (SELECT rowid FROM source_windows ORDER BY updated_at DESC, rowid DESC LIMIT -1 OFFSET ?)`)
+        .run(SOURCE_WINDOW_MAX_SESSIONS);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}

--- a/packages/core/test/gradient-source-parity.test.ts
+++ b/packages/core/test/gradient-source-parity.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, expect, it, vi } from "vitest";
+import { ensureProject } from "../src/db";
+import {
+  calibrate,
+  estimateMessages,
+  FullSourceRequired,
+  getCacheSizeSnapshot,
+  resetCalibration,
+  setForceMinLayer,
+  setMaxLayer0Tokens,
+  setModelLimits,
+  transform,
+} from "../src/gradient";
+import type { LoreMessageWithParts } from "../src/types";
+
+afterEach(() => vi.useRealTimers());
+
+it("matches full-source windows across mixed tools, calibration, and budget changes", () => {
+  vi.useFakeTimers({ toFake: ["Date"] });
+  vi.setSystemTime(12345);
+  const projectPath = "/test/source-parity";
+  ensureProject(projectPath);
+  let hits = 0;
+  for (let scenario = 0; scenario < 40; scenario++) {
+    const sessionID = `source-parity-${scenario}`;
+    const messages = Array.from({ length: 700 }, (_, index) => ({
+      info: {
+        id: `message-${index}`,
+        sessionID,
+        role: index % 2 ? "assistant" : "user",
+        time: { created: 0 },
+      },
+      hiddenInputTokens: index % 13 === 0 ? scenario * 3 : 0,
+      parts: [
+        index % 6 === 1
+          ? {
+              id: `part-${index}`,
+              type: "tool",
+              tool: "read",
+              callID: `call-${index}`,
+              state: {
+                status: "completed",
+                input: { path: `file-${index % 17}` },
+                output:
+                  `file-${index % 17}: ` +
+                  "return value ".repeat(15 + (scenario % 20)),
+                time: { start: 0, end: 0 },
+              },
+            }
+          : {
+              id: `part-${index}`,
+              type: "text",
+              text:
+                `line-${index} ` +
+                "ordinary prose ".repeat(3 + (scenario % 10)),
+            },
+      ],
+    })) as LoreMessageWithParts[];
+    const seedState = () => {
+      // Calibration also changes the global first-turn overhead fallback.
+      // Reset both copies so the comparison starts from identical state.
+      resetCalibration(sessionID);
+      calibrate(0, sessionID);
+      setModelLimits({ context: 8000 + (scenario % 3) * 4000, output: 1000 });
+      setMaxLayer0Tokens(4000);
+      const previous = transform({
+        messages: structuredClone(messages.slice(0, 690)),
+        projectPath,
+        sessionID,
+      });
+      if (scenario % 2)
+        calibrate(
+          previous.totalTokens + 500,
+          sessionID,
+          previous.messages.length,
+        );
+      if (scenario % 7 === 0) setForceMinLayer(4, sessionID);
+      setModelLimits({ context: 8000 + (scenario % 5) * 4000, output: 1000 });
+      return previous;
+    };
+    const previous = seedState();
+    const expected = transform({
+      messages: structuredClone(messages),
+      projectPath,
+      sessionID,
+    });
+    const expectedSizes = getCacheSizeSnapshot(sessionID);
+    seedState();
+    const offset = 400;
+    const prefixTokens = [0];
+    for (const message of messages.slice(0, offset))
+      prefixTokens.push(prefixTokens.at(-1)! + estimateMessages([message]));
+    let actual;
+    try {
+      actual = transform({
+        messages: structuredClone(messages.slice(offset)),
+        sourceWindow: {
+          offset,
+          omittedTokens: prefixTokens[offset],
+          prefixTokens,
+          previousWindowIDs: previous.messages.map(
+            (message) => message.info.id,
+          ),
+        },
+        projectPath,
+        sessionID,
+      });
+    } catch (error) {
+      if (error instanceof FullSourceRequired) continue;
+      throw error;
+    }
+    expect(actual, `scenario ${scenario}`).toEqual(expected);
+    expect(getCacheSizeSnapshot(sessionID)).toEqual(expectedSizes);
+    hits++;
+  }
+  // A battery that always falls back would prove nothing about the fast path.
+  expect(hits).toBeGreaterThan(10);
+});

--- a/packages/core/test/gradient-source-window.test.ts
+++ b/packages/core/test/gradient-source-window.test.ts
@@ -1,0 +1,126 @@
+import { beforeEach, expect, it } from "vitest";
+import { ensureProject, loadForceMinLayer } from "../src/db";
+import {
+  transform,
+  estimateMessages,
+  setModelLimits,
+  setMaxLayer0Tokens,
+  evictSession,
+  FullSourceRequired,
+  inspectSessionState,
+  setForceMinLayer,
+  needsUrgentDistillation,
+} from "../src/gradient";
+import type { LoreMessageWithParts } from "../src/types";
+
+const projectPath = "/test/gradient-source-window";
+const sid = "gradient-source-window";
+const messages: LoreMessageWithParts[] = Array.from(
+  { length: 600 },
+  (_, i) => ({
+    info: {
+      id: `source-${i}`,
+      sessionID: sid,
+      role: i % 2 ? "assistant" : "user",
+      time: { created: i },
+    },
+    parts: [
+      {
+        type: "text",
+        id: `part-${i}`,
+        sessionID: sid,
+        messageID: `source-${i}`,
+        text: `message ${i}: ` + "useful context ".repeat(25),
+      },
+    ],
+  }),
+) as LoreMessageWithParts[];
+beforeEach(() => {
+  ensureProject(projectPath);
+  evictSession(sid);
+  setModelLimits({ context: 16_000, output: 2_000 });
+  setMaxLayer0Tokens(8_000);
+});
+const metadata = (offset: number) => ({
+  offset,
+  omittedTokens: estimateMessages(messages.slice(0, offset)),
+  prefixTokens: Array.from({ length: offset + 1 }, (_, n) =>
+    estimateMessages(messages.slice(0, n)),
+  ),
+  previousWindowIDs: [] as string[],
+});
+it("selects exactly the full path's window using omitted source aggregates", () => {
+  const expected = transform({
+    messages: structuredClone(messages),
+    sessionID: sid,
+    projectPath,
+  });
+  evictSession(sid);
+  const actual = transform({
+    messages: structuredClone(messages.slice(300)),
+    sessionID: sid,
+    projectPath,
+    sourceWindow: metadata(300),
+  });
+  expect(actual).toEqual(expected);
+});
+it("requires full source on budget expansion without consuming gradient state", () => {
+  transform({
+    messages: structuredClone(messages),
+    sessionID: sid,
+    projectPath,
+  });
+  const before = inspectSessionState(sid);
+  expect(() =>
+    transform({
+      messages: structuredClone(messages.slice(-3)),
+      sessionID: sid,
+      projectPath,
+      sourceWindow: {
+        ...metadata(597),
+        previousWindowIDs: messages.map((m) => m.info.id),
+      },
+    }),
+  ).toThrow("Full source required: window_exhausted");
+  expect(inspectSessionState(sid)).toEqual(before);
+});
+
+it.each([2, 4] as const)(
+  "retries an exhausted layer %s scan without consuming one-shot escalation",
+  (layer) => {
+    transform({
+      messages: structuredClone(messages),
+      sessionID: sid,
+      projectPath,
+    });
+    needsUrgentDistillation(sid);
+    setForceMinLayer(layer, sid);
+    const before = inspectSessionState(sid);
+    expect(() =>
+      transform({
+        messages: structuredClone(messages.slice(-3)),
+        sessionID: sid,
+        projectPath,
+        sourceWindow: {
+          ...metadata(597),
+          previousWindowIDs: messages.map((m) => m.info.id),
+        },
+      }),
+    ).toThrow("Full source required: window_exhausted");
+    expect(loadForceMinLayer(sid)).toBe(layer);
+    expect(inspectSessionState(sid)).toEqual(before);
+    expect(needsUrgentDistillation(sid)).toBe(false);
+  },
+);
+
+it("requires the full source for an uninterrupted tool chain", () => {
+  const partial = structuredClone(messages.slice(-2));
+  expect(() =>
+    transform({
+      messages: partial,
+      sessionID: sid,
+      projectPath,
+      sourceWindow: metadata(598),
+    }),
+  ).toThrow(FullSourceRequired);
+});

--- a/packages/core/test/gradient-source-window.test.ts
+++ b/packages/core/test/gradient-source-window.test.ts
@@ -134,3 +134,21 @@ it("requires the full source for an uninterrupted tool chain", () => {
     }),
   ).toThrow(FullSourceRequired);
 });
+
+it.each([2, 4] as const)(
+  "consumes forced layer %s durably when the source offset is zero",
+  (layer) => {
+    setForceMinLayer(layer, sid);
+    expect(loadForceMinLayer(sid)).toBe(layer);
+    const result = transform({
+      messages: structuredClone(messages),
+      sessionID: sid,
+      projectPath,
+      sourceWindow: metadata(0),
+    });
+    expect(result.layer).toBeGreaterThanOrEqual(layer);
+    expect(loadForceMinLayer(sid)).toBe(0);
+    evictSession(sid);
+    expect(loadForceMinLayer(sid)).toBe(0);
+  },
+);

--- a/packages/core/test/gradient-source-window.test.ts
+++ b/packages/core/test/gradient-source-window.test.ts
@@ -10,6 +10,8 @@ import {
   inspectSessionState,
   setForceMinLayer,
   needsUrgentDistillation,
+  calibrate,
+  resetCalibration,
 } from "../src/gradient";
 import type { LoreMessageWithParts } from "../src/types";
 
@@ -37,7 +39,10 @@ const messages: LoreMessageWithParts[] = Array.from(
 ) as LoreMessageWithParts[];
 beforeEach(() => {
   ensureProject(projectPath);
-  evictSession(sid);
+  resetCalibration(sid);
+  // The default first-turn overhead exceeds this deliberately small model.
+  // Seed measured zero overhead so pin/plain-stage tests actually reach them.
+  calibrate(0, sid);
   setModelLimits({ context: 16_000, output: 2_000 });
   setMaxLayer0Tokens(8_000);
 });
@@ -65,12 +70,15 @@ it("selects exactly the full path's window using omitted source aggregates", () 
   expect(actual).toEqual(expected);
 });
 it("requires full source on budget expansion without consuming gradient state", () => {
-  transform({
+  const seeded = transform({
     messages: structuredClone(messages),
     sessionID: sid,
     projectPath,
   });
+  expect(seeded.layer).toBe(1);
+  expect(seeded.usable).toBeGreaterThan(0);
   const before = inspectSessionState(sid);
+  expect(before?.hasRawWindowCache).toBe(true);
   expect(() =>
     transform({
       messages: structuredClone(messages.slice(-3)),
@@ -88,11 +96,13 @@ it("requires full source on budget expansion without consuming gradient state", 
 it.each([2, 4] as const)(
   "retries an exhausted layer %s scan without consuming one-shot escalation",
   (layer) => {
-    transform({
+    const seeded = transform({
       messages: structuredClone(messages),
       sessionID: sid,
       projectPath,
     });
+    expect(seeded.layer).toBe(1);
+    expect(seeded.usable).toBeGreaterThan(0);
     needsUrgentDistillation(sid);
     setForceMinLayer(layer, sid);
     const before = inspectSessionState(sid);

--- a/packages/core/test/source-window-binding.test.ts
+++ b/packages/core/test/source-window-binding.test.ts
@@ -1,0 +1,44 @@
+import { expect, it } from "vitest";
+import {
+  db,
+  ensureProject,
+  saveSessionTracking,
+  withSavepoint,
+} from "../src/db";
+import { moveSessions } from "../src/data";
+import { SourceWindowStore } from "../src/source-window-store";
+
+it("rejects an existing private checkpoint moved under the old trigger set", () => {
+  const scope = {
+    projectPath: "/test/read-binding-source",
+    sessionID: "read-binding-probe",
+    noStore: false,
+  };
+  const pid = ensureProject(scope.projectPath);
+  saveSessionTracking(scope.sessionID, { projectPath: scope.projectPath });
+  const store = new SourceWindowStore(scope);
+  withSavepoint("save_before_move", () => {
+    expect(store.claim()).toBe(true);
+    expect(store.publish({ private: "old project" })).toBe(true);
+  });
+  // Reproduce the prior source-only move defect through the real move API.
+  const row = db()
+    .query(
+      "SELECT sql FROM sqlite_master WHERE name = 'source_windows_session_rebind'",
+    )
+    .get() as { sql: string };
+  db().exec("DROP TRIGGER source_windows_session_rebind");
+  try {
+    moveSessions([scope.sessionID], pid, "/test/read-binding-destination");
+  } finally {
+    db().exec(row.sql);
+  }
+  expect(
+    db()
+      .query(
+        "SELECT payload IS NOT NULL AS present FROM source_windows WHERE project_id = ? AND session_id = ?",
+      )
+      .get(pid, scope.sessionID),
+  ).toEqual({ present: 1 });
+  expect(new SourceWindowStore(scope).load()).toBeUndefined();
+});

--- a/packages/core/test/source-window-security.test.ts
+++ b/packages/core/test/source-window-security.test.ts
@@ -1,0 +1,210 @@
+import { beforeEach, expect, it } from "vitest";
+import { DatabaseSync } from "node:sqlite";
+import { createHash } from "node:crypto";
+import { deflateSync } from "node:zlib";
+import {
+  db,
+  ensureProject,
+  saveSessionTracking,
+  withSavepoint,
+  mergeProjectInternal,
+} from "../src/db";
+import { withTenant } from "../src/tenant";
+import {
+  SourceWindowStore,
+  SOURCE_WINDOW_MAX_BYTES,
+} from "../src/source-window-store";
+import { moveSessions } from "../src/data";
+
+const scope = {
+  projectPath: "/test/security-window",
+  sessionID: "security-window",
+  noStore: false,
+};
+beforeEach(() => {
+  db().exec("DELETE FROM source_windows");
+  db()
+    .query("DELETE FROM temporal_messages WHERE session_id = ?")
+    .run(scope.sessionID);
+  ensureProject(scope.projectPath);
+  saveSessionTracking(scope.sessionID, {
+    amnesia: false,
+    projectPath: scope.projectPath,
+    projectPathProvisional: false,
+  });
+});
+const commit = (store: SourceWindowStore, value: unknown) =>
+  withSavepoint("probe_commit", () => store.claim() && store.publish(value));
+
+it("rejects a small compressed decompression bomb and checksum corruption", () => {
+  const owner = new SourceWindowStore(scope);
+  expect(commit(owner, { private: "checkpoint" })).toBe(true);
+  const bytes = deflateSync(
+    JSON.stringify({ bomb: "x".repeat(SOURCE_WINDOW_MAX_BYTES + 1) }),
+  );
+  expect(bytes.length).toBeLessThan(4000000);
+  db()
+    .query("UPDATE source_windows SET payload = ?, checksum = ?")
+    .run(bytes, createHash("sha256").update(bytes).digest("hex"));
+  expect(new SourceWindowStore(scope).load()).toBeUndefined();
+  db().query("UPDATE source_windows SET checksum = 'wrong'").run();
+  expect(new SourceWindowStore(scope).load()).toBeUndefined();
+});
+
+it("rejects external delete and recreate before a stale request commits", () => {
+  const stale = new SourceWindowStore(scope);
+  const other = new DatabaseSync(process.env.LORE_DB_PATH!);
+  try {
+    other.exec("PRAGMA foreign_keys = ON; BEGIN IMMEDIATE");
+    other
+      .prepare("DELETE FROM session_state WHERE session_id = ?")
+      .run(scope.sessionID);
+    other
+      .prepare(
+        "INSERT INTO session_state(session_id, updated_at) VALUES (?, ?)",
+      )
+      .run(scope.sessionID, Date.now());
+    other.exec("COMMIT");
+  } finally {
+    other.close();
+  }
+  const current = new SourceWindowStore(scope);
+  // Both old and new leases are revision zero. Only the generation protects
+  // against deleted-and-recreated identity here.
+  expect(commit(stale, { private: "old owner" })).toBe(false);
+  expect(commit(current, { private: "new owner" })).toBe(true);
+  expect(new SourceWindowStore(scope).load()).toEqual({ private: "new owner" });
+});
+
+it("rejects a captured lease after changing tenant context", () => {
+  const stale = new SourceWindowStore(scope);
+  withTenant("foreign-tenant", () => {
+    expect(commit(stale, { private: "foreign publication" })).toBe(false);
+    ensureProject(scope.projectPath);
+    expect(new SourceWindowStore(scope).load()).toBeUndefined();
+  });
+  expect(new SourceWindowStore(scope).load()).toBeUndefined();
+});
+
+it("invalidates a checkpoint when another connection edits a temporal source", () => {
+  const pid = ensureProject(scope.projectPath);
+  db()
+    .query(
+      "INSERT INTO temporal_messages(id, project_id, session_id, role, content, tokens, distilled, created_at) VALUES ('external-source', ?, ?, 'user', 'before', 1, 0, 1)",
+    )
+    .run(pid, scope.sessionID);
+  expect(commit(new SourceWindowStore(scope), { private: "before" })).toBe(
+    true,
+  );
+  const stale = new SourceWindowStore(scope);
+  const other = new DatabaseSync(process.env.LORE_DB_PATH!);
+  try {
+    other
+      .prepare(
+        "UPDATE temporal_messages SET content = 'after' WHERE id = 'external-source'",
+      )
+      .run();
+  } finally {
+    other.close();
+  }
+  expect(new SourceWindowStore(scope).load()).toBeUndefined();
+  expect(commit(stale, { private: "before" })).toBe(false);
+});
+
+it("invalidates source-owner checkpoints on project merge", () => {
+  const source = ensureProject(scope.projectPath);
+  const target = ensureProject("/test/security-window-target");
+  const stale = new SourceWindowStore(scope);
+  expect(commit(new SourceWindowStore(scope), { private: "source" })).toBe(
+    true,
+  );
+  mergeProjectInternal(source, target);
+  expect(
+    db()
+      .query("SELECT payload FROM source_windows WHERE project_id = ?")
+      .get(source),
+  ).toBeNull();
+  expect(commit(stale, { private: "resurrection" })).toBe(false);
+});
+
+it("does not claim or publish outside a temporal transaction", () => {
+  const store = new SourceWindowStore(scope);
+  expect(store.claim()).toBe(false);
+  expect(store.publish({ data: "uncommitted" })).toBe(false);
+  withSavepoint("claim_only", () => expect(store.claim()).toBe(true));
+  expect(store.publish({ data: "after transaction" })).toBe(false);
+  expect(new SourceWindowStore(scope).load()).toBeUndefined();
+});
+
+it("bounds payload publication and treats hostile IDs as data", () => {
+  const hostile = { ...scope, sessionID: "'; DROP TABLE source_windows; --" };
+  saveSessionTracking(hostile.sessionID, {});
+  expect(commit(new SourceWindowStore(hostile), { text: "private" })).toBe(
+    true,
+  );
+  expect(new SourceWindowStore(hostile).load()).toEqual({ text: "private" });
+  expect(
+    commit(new SourceWindowStore(scope), {
+      tooLarge: "x".repeat(SOURCE_WINDOW_MAX_BYTES),
+    }),
+  ).toBe(false);
+  expect(new SourceWindowStore(scope).load()).toBeUndefined();
+});
+
+it("rejects publication into the old project when a source-only session is moved before its first response", () => {
+  const source = ensureProject(scope.projectPath);
+  saveSessionTracking(scope.sessionID, { projectPath: scope.projectPath });
+  // Preparation creates the lease before the first response's temporal rows.
+  const stale = new SourceWindowStore(scope);
+  expect(
+    db()
+      .query("SELECT COUNT(*) AS n FROM temporal_messages WHERE session_id = ?")
+      .get(scope.sessionID),
+  ).toEqual({ n: 0 });
+  moveSessions([scope.sessionID], source, "/test/security-moved-project");
+  expect(commit(stale, { private: "obsolete project data" })).toBe(false);
+});
+
+it("does not create a new lease for an already mismatched confirmed project", () => {
+  saveSessionTracking(scope.sessionID, {
+    projectPath: "/test/security-moved-project",
+    projectPathProvisional: false,
+  });
+  ensureProject("/test/security-moved-project");
+  const wrongScope = new SourceWindowStore(scope);
+  expect(commit(wrongScope, { private: "wrong project" })).toBe(false);
+  expect(
+    db()
+      .query("SELECT COUNT(*) AS n FROM source_windows WHERE session_id = ?")
+      .get(scope.sessionID),
+  ).toEqual({ n: 0 });
+});
+
+it("invalidates both a saved checkpoint and an outstanding lease on credential rebind", () => {
+  expect(
+    commit(new SourceWindowStore(scope), { private: "old credentials" }),
+  ).toBe(true);
+  const stale = new SourceWindowStore(scope);
+  saveSessionTracking(scope.sessionID, {
+    credentialFingerprint: "new-credentials",
+  });
+  expect(commit(stale, { private: "old credentials" })).toBe(false);
+  expect(new SourceWindowStore(scope).load()).toBeUndefined();
+});
+
+it("accepts canonical and tenant-scoped alias paths for the same project", () => {
+  const pid = ensureProject(scope.projectPath);
+  const alias = "/test/security-window-alias";
+  db()
+    .query(
+      "INSERT OR REPLACE INTO project_path_aliases(tenant_id, path, project_id) VALUES ('', ?, ?)",
+    )
+    .run(alias, pid);
+  saveSessionTracking(scope.sessionID, { projectPath: alias });
+  expect(commit(new SourceWindowStore(scope), { private: "same owner" })).toBe(
+    true,
+  );
+  expect(
+    new SourceWindowStore({ ...scope, projectPath: alias }).load(),
+  ).toEqual({ private: "same owner" });
+});

--- a/packages/core/test/source-window-store.test.ts
+++ b/packages/core/test/source-window-store.test.ts
@@ -1,0 +1,151 @@
+import { beforeEach, expect, it } from "vitest";
+import {
+  close,
+  db,
+  ensureProject,
+  saveSessionTracking,
+  withSavepoint,
+  MIGRATIONS,
+} from "../src/db";
+import { withTenant } from "../src/tenant";
+import {
+  SourceWindowStore,
+  SOURCE_WINDOW_MAX_SESSIONS,
+} from "../src/source-window-store";
+import { clearProject } from "../src/data";
+
+const scope = {
+  projectPath: "/test/source-window",
+  sessionID: "source-window",
+  noStore: false,
+};
+beforeEach(() => {
+  db().exec("DELETE FROM session_state WHERE session_id = 'source-window'");
+  ensureProject(scope.projectPath);
+  saveSessionTracking(scope.sessionID, {});
+});
+function commit(store: SourceWindowStore, value: unknown) {
+  return withSavepoint("accepted_turn", () => {
+    if (!store.claim()) return false;
+    return store.publish(value);
+  });
+}
+it("rehydrates an accepted checkpoint after closing the database", () => {
+  const store = new SourceWindowStore(scope);
+  expect(commit(store, { count: 5580, encrypted: "opaque payload" })).toBe(
+    true,
+  );
+  close();
+  expect(new SourceWindowStore(scope).load()).toEqual({
+    count: 5580,
+    encrypted: "opaque payload",
+  });
+});
+it("rolls back the source frontier with a failed temporal transaction", () => {
+  const store = new SourceWindowStore(scope);
+  expect(() =>
+    withSavepoint("failed_turn", () => {
+      expect(store.claim()).toBe(true);
+      expect(store.publish({ count: 5582 })).toBe(true);
+      throw new Error("disk failure");
+    }),
+  ).toThrow("disk failure");
+  expect(new SourceWindowStore(scope).load()).toBeUndefined();
+  expect(commit(store, { count: 5582 })).toBe(true);
+});
+it("rejects stale completion after deletion and same-session recreation", () => {
+  const stale = new SourceWindowStore(scope);
+  db()
+    .query("DELETE FROM session_state WHERE session_id = ?")
+    .run(scope.sessionID);
+  saveSessionTracking(scope.sessionID, {});
+  const live = new SourceWindowStore(scope);
+  expect(commit(live, { count: 2 })).toBe(true);
+  expect(commit(stale, { count: 9000 })).toBe(false);
+  expect(new SourceWindowStore(scope).load()).toEqual({ count: 2 });
+});
+it("invalidates on temporal edits while allowing the owning transaction's inserts", () => {
+  const pid = ensureProject(scope.projectPath);
+  const store = new SourceWindowStore(scope);
+  withSavepoint("accepted_turn", () => {
+    expect(store.claim()).toBe(true);
+    db()
+      .query(
+        `INSERT INTO temporal_messages (id, project_id, session_id, role, content, tokens, distilled, created_at) VALUES ('window-msg', ?, ?, 'user', 'original', 1, 0, 1)`,
+      )
+      .run(pid, scope.sessionID);
+    expect(store.publish({ count: 1 })).toBe(true);
+  });
+  const stale = new SourceWindowStore(scope);
+  db()
+    .query(
+      "UPDATE temporal_messages SET content = 'changed' WHERE id = 'window-msg'",
+    )
+    .run();
+  expect(new SourceWindowStore(scope).load()).toBeUndefined();
+  expect(commit(stale, { count: 2 })).toBe(false);
+  db().query("DELETE FROM temporal_messages WHERE id = 'window-msg'").run();
+});
+it("does not read or publish checkpoints in no-store or a different tenant", () => {
+  expect(commit(new SourceWindowStore(scope), { private: "data" })).toBe(true);
+  const disabled = new SourceWindowStore({ ...scope, noStore: true });
+  expect(disabled.load()).toBeUndefined();
+  expect(commit(disabled, { private: "replacement" })).toBe(false);
+  withTenant("another-tenant", () => {
+    const other = new SourceWindowStore(scope);
+    expect(other.load()).toBeUndefined();
+    expect(commit(other, { stolen: true })).toBe(false);
+  });
+  expect(new SourceWindowStore(scope).load()).toEqual({ private: "data" });
+});
+
+it("rejects a competing older completion", () => {
+  const first = new SourceWindowStore(scope);
+  const older = new SourceWindowStore(scope);
+  expect(commit(first, { count: 5582 })).toBe(true);
+  expect(commit(older, { count: 5580 })).toBe(false);
+  expect(new SourceWindowStore(scope).load()).toEqual({ count: 5582 });
+});
+it.each(["clear", "amnesia"])(
+  "discards private state and its outstanding lease on %s",
+  (mode) => {
+    expect(commit(new SourceWindowStore(scope), { private: "data" })).toBe(
+      true,
+    );
+    const pending = new SourceWindowStore(scope);
+    if (mode === "clear") clearProject(scope.projectPath);
+    else saveSessionTracking(scope.sessionID, { amnesia: true });
+    expect(new SourceWindowStore(scope).load()).toBeUndefined();
+    expect(commit(pending, { private: "stale data" })).toBe(false);
+  },
+);
+it("does not publish into a replacement connection", () => {
+  const pending = new SourceWindowStore(scope);
+  close();
+  expect(commit(pending, { count: 100 })).toBe(false);
+  expect(new SourceWindowStore(scope).load()).toBeUndefined();
+});
+it("bounds abandoned checkpoint leases as well as completed windows", () => {
+  for (let i = 0; i < SOURCE_WINDOW_MAX_SESSIONS + 5; i++) {
+    const sessionID = `abandoned-${i}`;
+    saveSessionTracking(sessionID, {});
+    new SourceWindowStore({ ...scope, sessionID });
+  }
+  expect(db().query("SELECT COUNT(*) AS n FROM source_windows").get()).toEqual({
+    n: SOURCE_WINDOW_MAX_SESSIONS,
+  });
+});
+it("migrates and repairs the disposable table without changing temporal rows", () => {
+  db().exec(
+    "DROP TABLE source_windows; UPDATE schema_version SET version = 86",
+  );
+  close();
+  expect(db().query("SELECT version FROM schema_version").get()).toEqual({
+    version: MIGRATIONS.length,
+  });
+  expect(commit(new SourceWindowStore(scope), { count: 10 })).toBe(true);
+  db().exec("DROP TABLE source_windows");
+  close();
+  expect(new SourceWindowStore(scope).load()).toBeUndefined();
+  expect(commit(new SourceWindowStore(scope), { count: 11 })).toBe(true);
+});

--- a/packages/core/test/sync-registry-contract.test.ts
+++ b/packages/core/test/sync-registry-contract.test.ts
@@ -338,14 +338,15 @@ describe("SYNCED_TABLES local-only secondary UNIQUE → convergence handling (#1
 });
 
 describe("server-internal tables are intentionally NOT synced", () => {
-  test("derived provenance counts never enter any sync tier", () => {
-    for (const tier of ["basic", "pro", "max"] as const)
-      expect(
-        SYNCED_TABLES[tier].find(
-          (metadata) => metadata.table === "semantic_token_cache",
-        ),
-      ).toBeUndefined();
-  });
+  test.each(["semantic_token_cache", "source_windows"])(
+    "local source cache %s never enters any sync tier",
+    (table) => {
+      for (const tier of ["basic", "pro", "max"] as const)
+        expect(
+          SYNCED_TABLES[tier].find((metadata) => metadata.table === table),
+        ).toBeUndefined();
+    },
+  );
   test("the temporal embedding queue is absent from every tier's registry", () => {
     for (const tier of ["basic", "pro", "max"] as const)
       expect(

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -21,7 +21,11 @@ export { responsesProvenanceByMessageId } from "./semantic-preparation";
 import { createHash } from "node:crypto";
 import { isDeepStrictEqual } from "node:util";
 import type { LoreMessageWithParts, LLMClient } from "@loreai/core";
-import { asString, estimateTokens as coreEstimateTokens } from "@loreai/core";
+import {
+  FullSourceRequired,
+  asString,
+  estimateTokens as coreEstimateTokens,
+} from "@loreai/core";
 import {
   load,
   config as loreConfig,
@@ -16239,14 +16243,20 @@ async function handleConversationTurn(
   // Build the Lore message array once (resolved) — shared by the turn-1 LTM
   // decision below (isLargeColdStart) and the gradient transform in step 7, so
   // both see identical input and agree on whether this cold session compresses.
-  const { loreMessages, temporalInput, provenanceByMessageId } =
-    await prepareSemanticMessages({
-      messages: req.messages,
-      sessionID,
-      projectPath,
-      noStore: suppressTemporalStorage,
-      timing: preparationTiming,
-    });
+  let {
+    loreMessages,
+    temporalInput,
+    provenanceByMessageId,
+    sourceWindow,
+    checkpoint,
+  } = await prepareSemanticMessages({
+    messages: req.messages,
+    sessionID,
+    projectPath,
+    noStore: suppressTemporalStorage,
+    protocol: req.protocol,
+    timing: preparationTiming,
+  });
   assertCurrentPipelineGeneration(req.signal, requestGeneration);
 
   // --- 6. LTM injection (system[1] stable prefix + durable-delta context LTM) ---
@@ -16363,6 +16373,7 @@ async function handleConversationTurn(
       const largeColdStart =
         isFirstTurn &&
         isLargeColdStart({
+          sourceWindow,
           messages: loreMessages,
           sessionID,
           ltmTokens: stable?.tokenCount ?? 0,
@@ -16690,15 +16701,42 @@ async function handleConversationTurn(
     req.signal,
   );
   assertCurrentPipelineGeneration(req.signal, requestGeneration);
-  const result = transform({
-    messages: loreMessages,
-    projectPath,
-    sessionID,
-    // Apply this request's model budget atomically inside transform — see the
-    // ModelBudget snapshot above. Prevents a concurrent request for a different
-    // model from clobbering caps/pricing during the intervening ltm awaits.
-    budget: modelBudget,
-  });
+  let result;
+  try {
+    result = transform({
+      messages: loreMessages,
+      projectPath,
+      sessionID,
+      budget: modelBudget,
+      sourceWindow,
+    });
+  } catch (error) {
+    if (!(error instanceof FullSourceRequired) || !sourceWindow) throw error;
+    preparationTiming.metric(`source_fallback_${error.reason}`, 1);
+    ({
+      loreMessages,
+      temporalInput,
+      provenanceByMessageId,
+      sourceWindow,
+      checkpoint,
+    } = await prepareSemanticMessages({
+      messages: req.messages,
+      sessionID,
+      projectPath,
+      noStore: suppressTemporalStorage,
+      protocol: req.protocol,
+      forceFull: true,
+      timing: preparationTiming,
+    }));
+    assertCurrentPipelineGeneration(req.signal, requestGeneration);
+    result = transform({
+      messages: loreMessages,
+      projectPath,
+      sessionID,
+      budget: modelBudget,
+    });
+  }
+  checkpoint?.finish(result.messages);
 
   // Drop trailing pure-text assistant messages to prevent prefill errors
   for (;;) {
@@ -16992,7 +17030,8 @@ async function handleConversationTurn(
   const transformedMessages = loreMessagesToGateway(
     result.messages,
     provenanceByMessageId,
-    result.messages.length === loreMessages.length &&
+    !sourceWindow &&
+      result.messages.length === loreMessages.length &&
       result.messages.every(
         (message, index) => message.info.id === loreMessages[index]?.info.id,
       ),

--- a/packages/gateway/src/semantic-preparation.ts
+++ b/packages/gateway/src/semantic-preparation.ts
@@ -1,3 +1,4 @@
+import { SourceCheckpoint } from "./source-checkpoint";
 import * as Sentry from "@sentry/bun";
 import {
   isToolPart,
@@ -11,6 +12,7 @@ import { captureTurnTemporalInput } from "./turn-temporal";
 import type { GatewayMessage, GatewayRequest } from "./translate/types";
 
 type Stage =
+  | "source_validation"
   | "conversion"
   | "provenance"
   | "temporal_input"
@@ -144,36 +146,61 @@ export async function prepareSemanticMessages(input: {
   projectPath: string;
   noStore: boolean;
   timing: PreparationTiming;
+  protocol?: string;
+  forceFull?: boolean;
 }) {
   const { timing } = input;
+  for (const key of Object.keys(timing.counts) as Array<
+    keyof typeof timing.counts
+  >)
+    timing.counts[key] = 0;
   const started = performance.now();
   const cpu = process.cpuUsage();
   const memory = process.memoryUsage();
-  const tokenCache = new SemanticTokenCache(input);
+  const checkpoint =
+    input.protocol && !input.noStore
+      ? new SourceCheckpoint({ ...input, protocol: input.protocol })
+      : undefined;
+  const tokenCache = new SemanticTokenCache({
+    ...input,
+    retainUnused: !!checkpoint?.base,
+  });
+  const convertedFrom = checkpoint?.convertedFrom ?? 0;
+  const offset = checkpoint?.offset ?? 0;
   // An immediate queued before synchronous preparation observes its event-loop
   // delay. Await it before the next stage so LTM work cannot pollute the sample.
   // The callback retains just a timestamp, never the transcript.
   const loopDelay = new Promise<number>((resolve) =>
     setImmediate(() => resolve(performance.now() - started)),
   );
-  const loreMessages = timing.measure("conversion", () =>
+  const suffix = timing.measure("conversion", () =>
     gatewayMessagesToLore(
-      input.messages,
+      input.messages.slice(convertedFrom),
       input.sessionID,
-      0,
-      0,
+      convertedFrom,
+      convertedFrom,
       (visible, provenance) => tokenCache.count(visible, provenance),
     ),
   );
+  const raw = checkpoint?.base ? [...checkpoint.base.raw, ...suffix] : suffix;
+  const loreMessages = checkpoint ? structuredClone(raw) : raw;
   const temporalInput = timing.measure("temporal_input", () =>
-    captureTurnTemporalInput(loreMessages),
+    captureTurnTemporalInput(raw, input.messages.length, checkpoint),
   );
-  const provenanceByMessageId = timing.measure("provenance", () =>
-    responsesProvenanceByMessageId(input.messages, loreMessages),
-  );
+  timing.metric("source_converted_messages", suffix.length);
+  timing.metric("source_total_messages", input.messages.length);
+  const provenanceByMessageId = timing.measure("provenance", () => {
+    const provenance = checkpoint?.storedProvenance ?? new Map();
+    for (const [id, value] of responsesProvenanceByMessageId(
+      input.messages.slice(convertedFrom),
+      suffix,
+    ))
+      provenance.set(id, value);
+    return provenance;
+  });
   const candidates: Array<{ sourceID: string; legacySourceID?: string }> = [];
   timing.counts.messages = loreMessages.length;
-  for (const message of loreMessages) {
+  for (const [index, message] of loreMessages.entries()) {
     timing.counts.parts += message.parts.length;
     let results = 0;
     for (const part of message.parts)
@@ -188,14 +215,15 @@ export async function prepareSemanticMessages(input: {
       results > 0 &&
       results === message.parts.length
     ) {
+      timing.counts.placeholders++;
+      if (index < convertedFrom - offset) continue;
       candidates.push({
         sourceID: message.info.id,
         legacySourceID: message.legacySourceID,
       });
     }
   }
-  timing.counts.placeholders = candidates.length;
-  const ids = timing.measure("stored_ids", () =>
+  const newIds = timing.measure("stored_ids", () =>
     temporal.storedMessageIds({
       projectPath: input.projectPath,
       sessionID: input.sessionID,
@@ -203,9 +231,12 @@ export async function prepareSemanticMessages(input: {
       readOnly: input.noStore,
     }),
   );
+  const ids = checkpoint?.storedIds ?? new Map<string, string>();
+  for (const [id, stored] of newIds) ids.set(id, stored);
   timing.measure("resolve_tools", () =>
     resolveToolResults(loreMessages, (m) => ids.get(m.info.id) ?? m.info.id),
   );
+  checkpoint?.capture(raw, loreMessages, ids, provenanceByMessageId);
   // Publish before yielding; cache writes never wait for another writer.
   tokenCache.persist();
   const delta = process.cpuUsage(cpu);
@@ -222,5 +253,11 @@ export async function prepareSemanticMessages(input: {
   timing.metric("event_loop_delay_ms", await loopDelay);
   for (const [name, value] of Object.entries(tokenCache.stats))
     timing.metric(`provenance_tokens_${name}`, value);
-  return { loreMessages, temporalInput, provenanceByMessageId };
+  return {
+    loreMessages,
+    temporalInput,
+    provenanceByMessageId,
+    sourceWindow: checkpoint?.sourceWindow,
+    checkpoint,
+  };
 }

--- a/packages/gateway/src/source-checkpoint.ts
+++ b/packages/gateway/src/source-checkpoint.ts
@@ -1,0 +1,393 @@
+import { createHash } from "node:crypto";
+import {
+  SourceWindowStore,
+  TOKEN_ESTIMATE_CACHE_VERSION,
+  estimateMessages,
+  isToolPart,
+  type LoreMessageWithParts,
+  type SourceWindow,
+} from "@loreai/core";
+import type { GatewayMessage } from "./translate/types";
+import type { PreparationTiming } from "./semantic-preparation";
+
+const VERSION = `gateway-source-window-v1:${TOKEN_ESTIMATE_CACHE_VERSION}`;
+export const SOURCE_WINDOW_MAX_MESSAGES = 2048;
+const PREFIX_COUNTS = 4096;
+const BLOOM_BYTES = 65_536;
+type Provenance = Pick<
+  GatewayMessage,
+  "content" | "provenanceContent" | "provenancePositions"
+>;
+interface Payload {
+  version: string;
+  protocol: string;
+  sourceCount: number;
+  sourceDigest: string;
+  raw: LoreMessageWithParts[];
+  resolvedTokens: number[];
+  provenance: Array<[string, Provenance]>;
+  ids: Array<[string, string]>;
+  window: SourceWindow;
+  toolIds: string;
+}
+type Reason =
+  | "disabled"
+  | "missing"
+  | "checkpoint"
+  | "protocol"
+  | "history"
+  | "tool_boundary"
+  | "forced"
+  | "hit";
+
+function validPart(part: LoreMessageWithParts["parts"][number]): boolean {
+  if (!part || typeof part.id !== "string") return false;
+  if (part.type === "text" || part.type === "reasoning")
+    return typeof part.text === "string";
+  if (part.type === "opaque") return !!part.raw && typeof part.raw === "object";
+  if (
+    !isToolPart(part) ||
+    typeof part.callID !== "string" ||
+    typeof part.tool !== "string" ||
+    !part.state
+  )
+    return false;
+  if (part.state.status === "completed")
+    return typeof part.state.output === "string";
+  if (part.state.status === "error")
+    return typeof part.state.error === "string";
+  return part.state.status === "pending";
+}
+
+/** False positives cost a full reconciliation; a false negative must be impossible. */
+class ToolIds {
+  readonly bits: Buffer;
+  constructor(encoded?: string) {
+    this.bits = encoded
+      ? Buffer.from(encoded, "base64")
+      : Buffer.alloc(BLOOM_BYTES);
+  }
+  indexes(id: string): number[] {
+    const hash = createHash("sha256").update(id).digest();
+    return [0, 4, 8, 12].map((i) => hash.readUInt32LE(i) % (BLOOM_BYTES * 8));
+  }
+  add(id: string) {
+    for (const i of this.indexes(id)) this.bits[i >> 3] |= 1 << (i & 7);
+  }
+  has(id: string): boolean {
+    return this.indexes(id).every(
+      (i) => (this.bits[i >> 3] & (1 << (i & 7))) !== 0,
+    );
+  }
+}
+
+function valid(value: unknown, sessionID: string): value is Payload {
+  if (!value || typeof value !== "object") return false;
+  const v = value as Payload;
+  return (
+    v.version === VERSION &&
+    typeof v.protocol === "string" &&
+    Number.isSafeInteger(v.sourceCount) &&
+    v.sourceCount > 0 &&
+    typeof v.sourceDigest === "string" &&
+    /^[a-f0-9]{64}$/.test(v.sourceDigest) &&
+    !!v.window &&
+    Number.isSafeInteger(v.window.offset) &&
+    v.window.offset >= 0 &&
+    v.window.offset < v.sourceCount &&
+    Number.isSafeInteger(v.window.omittedTokens) &&
+    v.window.omittedTokens >= 0 &&
+    Array.isArray(v.window.prefixTokens) &&
+    v.window.prefixTokens.length <= PREFIX_COUNTS + 1 &&
+    v.window.prefixTokens[0] === 0 &&
+    v.window.prefixTokens.every(
+      (n, i, all) =>
+        Number.isSafeInteger(n) && n >= 0 && (i === 0 || n >= all[i - 1]),
+    ) &&
+    (v.window.prefixTokens[v.window.offset] === undefined ||
+      v.window.prefixTokens[v.window.offset] === v.window.omittedTokens) &&
+    Array.isArray(v.window.previousWindowIDs) &&
+    v.window.previousWindowIDs.length <= SOURCE_WINDOW_MAX_MESSAGES + 16 &&
+    v.window.previousWindowIDs.every((id) => typeof id === "string") &&
+    Array.isArray(v.raw) &&
+    v.raw.length === v.sourceCount - v.window.offset &&
+    v.raw.length <= SOURCE_WINDOW_MAX_MESSAGES &&
+    v.raw.every(
+      (m) =>
+        m?.info?.sessionID === sessionID &&
+        typeof m.info.id === "string" &&
+        ["user", "assistant"].includes(m.info.role) &&
+        !!m.info.time &&
+        Number.isFinite(m.info.time.created) &&
+        (m.hiddenInputTokens === undefined ||
+          (Number.isFinite(m.hiddenInputTokens) && m.hiddenInputTokens >= 0)) &&
+        Array.isArray(m.parts) &&
+        m.parts.every(validPart),
+    ) &&
+    Array.isArray(v.resolvedTokens) &&
+    v.resolvedTokens.length === v.raw.length &&
+    v.resolvedTokens.every((n) => Number.isSafeInteger(n) && n >= 0) &&
+    Array.isArray(v.ids) &&
+    v.ids.length <= SOURCE_WINDOW_MAX_MESSAGES &&
+    v.ids.every(
+      (e) =>
+        Array.isArray(e) &&
+        e.length === 2 &&
+        e.every((s) => typeof s === "string"),
+    ) &&
+    Array.isArray(v.provenance) &&
+    v.provenance.length <= SOURCE_WINDOW_MAX_MESSAGES &&
+    v.provenance.every(
+      (e) =>
+        Array.isArray(e) &&
+        e.length === 2 &&
+        typeof e[0] === "string" &&
+        Array.isArray(e[1]?.content) &&
+        Array.isArray(e[1]?.provenanceContent),
+    ) &&
+    typeof v.toolIds === "string" &&
+    Buffer.from(v.toolIds, "base64").length === BLOOM_BYTES
+  );
+}
+
+/**
+ * Generic clients still validate O(wire bytes). Boundary-only digests or client
+ * supplied head IDs cannot prove that an earlier message was not edited. This
+ * pass constructs no Lore objects, pairs no tools and performs no tokenization.
+ */
+function sourceDigests(messages: GatewayMessage[], previousCount?: number) {
+  const hash = createHash("sha256");
+  let previous: string | undefined;
+  for (let i = 0; i < messages.length; i++) {
+    const encoded = JSON.stringify(messages[i]);
+    hash.update(`${Buffer.byteLength(encoded)}:`).update(encoded);
+    if (i + 1 === previousCount) previous = hash.copy().digest("hex");
+  }
+  return { previous, current: hash.digest("hex") };
+}
+
+export class SourceCheckpoint {
+  readonly store: SourceWindowStore;
+  readonly base?: Payload;
+  readonly digest: string;
+  readonly reason: Reason;
+  private next?: Payload;
+  private raw: LoreMessageWithParts[] = [];
+  private resolvedTokens: number[] = [];
+  private provenance = new Map<string, Provenance>();
+  private ids = new Map<string, string>();
+
+  private readonly scope: {
+    protocol: string;
+    noStore: boolean;
+    timing: PreparationTiming;
+    sourceCount: number;
+  };
+
+  constructor(input: {
+    messages: GatewayMessage[];
+    sessionID: string;
+    projectPath: string;
+    noStore: boolean;
+    protocol: string;
+    forceFull?: boolean;
+    timing: PreparationTiming;
+  }) {
+    this.scope = {
+      protocol: input.protocol,
+      noStore: input.noStore,
+      timing: input.timing,
+      sourceCount: input.messages.length,
+    };
+    this.store = new SourceWindowStore(input);
+    const loaded = this.store.load();
+    const candidate = valid(loaded, input.sessionID) ? loaded : undefined;
+    const hashes = input.timing.measure("source_validation", () =>
+      sourceDigests(input.messages, candidate?.sourceCount),
+    );
+    this.digest = hashes.current;
+    let reason: Reason = input.noStore
+      ? "disabled"
+      : input.forceFull
+        ? "forced"
+        : !loaded
+          ? "missing"
+          : !candidate
+            ? "checkpoint"
+            : candidate.protocol !== input.protocol
+              ? "protocol"
+              : candidate.sourceCount > input.messages.length ||
+                  hashes.previous !== candidate.sourceDigest
+                ? "history"
+                : "hit";
+    if (reason === "hit" && candidate) {
+      const toolIds = new ToolIds(candidate.toolIds);
+      // Check both directions: the adapter pairs all results with all calls,
+      // including an old result reused by a newly appended call.
+      const crossing =
+        candidate.raw.some((m) =>
+          m.parts.some((p) => isToolPart(p) && toolIds.has(p.callID)),
+        ) ||
+        input.messages
+          .slice(candidate.sourceCount)
+          .some((m) =>
+            m.content.some(
+              (b) =>
+                (b.type === "tool_use" && toolIds.has(b.id)) ||
+                (b.type === "tool_result" && toolIds.has(b.toolUseId)),
+            ),
+          );
+      if (crossing) reason = "tool_boundary";
+      else this.base = candidate;
+    }
+    this.reason = reason;
+    input.timing.metric("source_checkpoint_hit", reason === "hit" ? 1 : 0);
+    if (reason !== "hit") input.timing.metric(`source_fallback_${reason}`, 1);
+  }
+
+  get offset(): number {
+    return this.base?.window.offset ?? 0;
+  }
+  get convertedFrom(): number {
+    return this.base?.sourceCount ?? 0;
+  }
+  get sourceWindow(): SourceWindow | undefined {
+    return this.base?.window.offset ? this.base.window : undefined;
+  }
+  get storedIds(): Map<string, string> {
+    return new Map(this.base?.ids);
+  }
+  get storedProvenance(): Map<string, Provenance> {
+    return new Map(this.base?.provenance);
+  }
+
+  capture(
+    raw: LoreMessageWithParts[],
+    resolved: LoreMessageWithParts[],
+    ids: Map<string, string>,
+    provenance: ReadonlyMap<string, Provenance>,
+  ) {
+    this.raw = raw;
+    // Appended results may change an older pending call's resolved size.
+    // Every other retained estimate is stable because the source prefix and
+    // stored-ID revision were validated before taking this path.
+    const appendedResults = new Set<string>();
+    for (const m of raw.slice(this.base?.raw.length ?? 0))
+      for (const p of m.parts)
+        if (isToolPart(p) && p.tool === "result") appendedResults.add(p.callID);
+    let estimated = 0;
+    this.resolvedTokens = resolved.map((m, i) => {
+      const cached = this.base?.resolvedTokens[i];
+      if (
+        cached !== undefined &&
+        !raw[i].parts.some(
+          (p) =>
+            isToolPart(p) &&
+            p.tool !== "result" &&
+            appendedResults.has(p.callID),
+        )
+      )
+        return cached;
+      estimated++;
+      return estimateMessages([m]);
+    });
+    this.scope.timing.metric("source_estimated_messages", estimated);
+    this.ids = ids;
+    this.provenance = new Map(provenance);
+  }
+
+  /** Called immediately after gradient, before wire/protocol mutations. */
+  finish(modelWindow: LoreMessageWithParts[]): void {
+    try {
+      this.finishWindow(modelWindow);
+    } finally {
+      this.raw = [];
+      this.resolvedTokens = [];
+      this.ids = new Map();
+      this.provenance = new Map();
+    }
+  }
+
+  private finishWindow(modelWindow: LoreMessageWithParts[]): void {
+    if (this.scope.noStore || !this.raw.length) return;
+    const selected = new Set(modelWindow.map((m) => m.info.id));
+    const earliest = this.raw.findIndex((m) => selected.has(m.info.id));
+    if (earliest < 0) return;
+    // Keep a little extra history so ordinary budget drift does not need a full
+    // reconciliation. The actual previous model window is always included.
+    let cut = Math.max(0, Math.min(earliest - 32, this.raw.length - 256));
+    while (
+      cut > 0 &&
+      (this.raw[cut].info.role !== "assistant" ||
+        this.raw[cut].parts.some(isToolPart))
+    )
+      cut--;
+    const retained = this.raw.slice(cut);
+    if (
+      retained.length > SOURCE_WINDOW_MAX_MESSAGES ||
+      modelWindow.length > SOURCE_WINDOW_MAX_MESSAGES + 16
+    )
+      return;
+    const toolIds = new ToolIds(this.base?.toolIds);
+    for (const m of this.raw.slice(0, cut))
+      for (const p of m.parts) if (isToolPart(p)) toolIds.add(p.callID);
+    if (
+      retained.some((m) =>
+        m.parts.some((p) => isToolPart(p) && toolIds.has(p.callID)),
+      )
+    )
+      return;
+    const prefixTokens = this.base ? [...this.base.window.prefixTokens] : [0];
+    // New results can complete a retained pending call at an OLD absolute
+    // index. Recompute that overlap, not just appended entries, so restart's
+    // count-based calibration subtracts the same resolved prefix as the full path.
+    if (
+      this.offset <= PREFIX_COUNTS &&
+      prefixTokens[this.offset] !== undefined
+    ) {
+      prefixTokens.length = this.offset + 1;
+      for (
+        let i = 0;
+        i < this.resolvedTokens.length && prefixTokens.length <= PREFIX_COUNTS;
+        i++
+      )
+        prefixTokens.push((prefixTokens.at(-1) ?? 0) + this.resolvedTokens[i]);
+    }
+    const keep = new Set(retained.map((m) => m.info.id));
+    this.next = {
+      version: VERSION,
+      protocol: this.scope.protocol,
+      sourceCount: this.scope.sourceCount,
+      sourceDigest: this.digest,
+      raw: retained,
+      resolvedTokens: this.resolvedTokens.slice(cut),
+      provenance: [...this.provenance].filter(([id]) => keep.has(id)),
+      ids: [...this.ids].filter(([id]) => keep.has(id)),
+      window: {
+        offset: this.offset + cut,
+        omittedTokens:
+          (this.base?.window.omittedTokens ?? 0) +
+          this.resolvedTokens.slice(0, cut).reduce((a, b) => a + b, 0),
+        prefixTokens,
+        previousWindowIDs: [...selected],
+      },
+      toolIds: toolIds.bits.toString("base64"),
+    };
+    this.scope.timing.metric("source_checkpoint_messages", retained.length);
+    this.scope.timing.metric(
+      "source_omitted_messages",
+      this.next.window.offset,
+    );
+  }
+
+  claim(): boolean {
+    return this.next !== undefined && this.store.claim();
+  }
+  publish(): void {
+    if (this.next)
+      this.scope.timing.metric(
+        "source_checkpoint_published",
+        this.store.publish(this.next) ? 1 : 0,
+      );
+  }
+}

--- a/packages/gateway/src/source-checkpoint.ts
+++ b/packages/gateway/src/source-checkpoint.ts
@@ -252,7 +252,11 @@ export class SourceCheckpoint {
     return this.base?.sourceCount ?? 0;
   }
   get sourceWindow(): SourceWindow | undefined {
-    return this.base?.window.offset ? this.base.window : undefined;
+    // This describes an omitted prefix, not whether a checkpoint was reused.
+    // At offset zero, base/convertedFrom still enable suffix-only preparation,
+    // while undefined preserves the pipeline's complete-source provenance path.
+    const window = this.base?.window;
+    return window && window.offset > 0 ? window : undefined;
   }
   get storedIds(): Map<string, string> {
     return new Map(this.base?.ids);

--- a/packages/gateway/src/turn-temporal.ts
+++ b/packages/gateway/src/turn-temporal.ts
@@ -16,15 +16,19 @@ export interface TurnTemporalInput {
   readonly latestUser?: LoreMessageWithParts;
   /** Absolute request length, even when only one message is retained. */
   readonly assistantIndex: number;
+  readonly checkpoint?: { claim(): boolean; publish(): void };
 }
 
 export function captureTurnTemporalInput(
   messages: LoreMessageWithParts[],
+  assistantIndex = messages.length,
+  checkpoint?: TurnTemporalInput["checkpoint"],
 ): TurnTemporalInput {
   const latestUser = messages.findLast((m) => m.info.role === "user");
   return Object.freeze({
     ...(latestUser ? { latestUser: structuredClone(latestUser) } : {}),
-    assistantIndex: messages.length,
+    assistantIndex,
+    ...(checkpoint ? { checkpoint } : {}),
   });
 }
 
@@ -42,6 +46,7 @@ export function storeTurnTemporal(input: {
   const { projectPath, sessionID, temporalInput } = input;
   ensureProject(projectPath);
   withSavepoint("post_response_temporal", () => {
+    const checkpointClaimed = temporalInput.checkpoint?.claim() ?? false;
     const user = temporalInput.latestUser;
     if (user) {
       const message = {
@@ -78,5 +83,6 @@ export function storeTurnTemporal(input: {
     if (assistantContent.length > 0) temporal.store(message);
     // Tool-only/error turns still need traces even when no text was stored.
     temporal.recordToolCalls(message);
+    if (checkpointClaimed) temporalInput.checkpoint?.publish();
   });
 }

--- a/packages/gateway/test/pipeline-semantic-preparation.test.ts
+++ b/packages/gateway/test/pipeline-semantic-preparation.test.ts
@@ -1,5 +1,10 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { afterEach, expect, it, vi } from "vitest";
 import * as adapter from "../src/temporal-adapter";
+import { PreparationTiming } from "../src/semantic-preparation";
+import { setForceMinLayer } from "@loreai/core";
 import { createHarness, type Harness } from "./helpers/harness";
 import {
   DEFAULT_MODEL,
@@ -9,9 +14,13 @@ import {
 } from "./helpers/fixtures";
 
 let harness: Harness | undefined;
+let projectDirectory: string | undefined;
 afterEach(async () => {
   await harness?.teardown();
   harness = undefined;
+  if (projectDirectory)
+    rmSync(projectDirectory, { recursive: true, force: true });
+  projectDirectory = undefined;
   vi.restoreAllMocks();
 });
 
@@ -62,5 +71,96 @@ it.each([false, true])(
         "SELECT content FROM temporal_messages WHERE role = 'user'",
       ),
     ).toEqual([{ content: "latest input" }]);
+  },
+);
+
+it.each([false, true])(
+  "restores a bounded source window through the real pipeline (stream=%s)",
+  async (stream) => {
+    projectDirectory = mkdtempSync(join(tmpdir(), "lore-source-pipeline-"));
+    harness = await createHarness({
+      projectPath: projectDirectory,
+      budget: { maxLayer0Tokens: 8000 },
+      fixtures: makeConversationFixtures([
+        { userMessage: "first input", assistantText: "first reply" },
+        { userMessage: "second input", assistantText: "second reply" },
+        { userMessage: "third input", assistantText: "third reply" },
+      ]),
+    });
+    const source = Array.from({ length: 5581 }, (_, i) => ({
+      role: i % 2 ? "assistant" : "user",
+      content:
+        i === 50
+          ? "first input"
+          : i === 51
+            ? "first reply"
+            : i === 5580
+              ? "second input"
+              : `history ${i}: ${"useful context ".repeat(15)}`,
+    }));
+    const send = async (
+      messages: typeof source,
+      reply: string,
+      stored: number,
+    ) => {
+      const response = await harness!.chat(
+        {
+          model: DEFAULT_MODEL,
+          max_tokens: 1024,
+          stream,
+          system: DEFAULT_SYSTEM,
+          messages,
+          tools: STANDARD_TOOLS,
+        },
+        "test-key",
+        { "x-lore-session-id": "source-window-pipeline" },
+      );
+      expect(response.status).toBe(200);
+      expect(await response.text()).toContain(reply);
+      await vi.waitFor(() =>
+        expect(
+          harness!.queryDB(
+            "SELECT content FROM temporal_messages WHERE role = 'assistant'",
+          ),
+        ).toHaveLength(stored),
+      );
+    };
+    await send(source.slice(0, 51), "first reply", 1);
+    const sid = harness.queryDB<{ session_id: string }>(
+      "SELECT session_id FROM temporal_messages LIMIT 1",
+    )[0].session_id;
+    setForceMinLayer(3, sid);
+    await send(source, "second reply", 2);
+    expect(
+      harness.queryDB(
+        "SELECT payload FROM source_windows WHERE payload IS NOT NULL",
+      ),
+    ).toHaveLength(1);
+    await harness.restartPipeline();
+    const conversion = vi.spyOn(adapter, "gatewayMessagesToLore");
+    const metrics = vi.spyOn(PreparationTiming.prototype, "metric");
+    await send(
+      [
+        ...source,
+        { role: "assistant", content: "second reply" },
+        { role: "user", content: "third input" },
+      ],
+      "third reply",
+      3,
+    );
+    expect(
+      conversion.mock.calls.map((call) => [call[0].length, call[2], call[3]]),
+      JSON.stringify(
+        metrics.mock.calls.filter((call) => call[0].startsWith("source_")),
+      ),
+    ).toContainEqual([2, 5581, 5581]);
+    expect(
+      conversion.mock.calls.some(
+        (call) => call[0].length === 2 && call[2] === 5581 && call[3] === 5581,
+      ),
+    ).toBe(true);
+    expect(conversion.mock.calls.every((call) => call[0].length <= 2)).toBe(
+      true,
+    );
   },
 );

--- a/packages/gateway/test/source-checkpoint.test.ts
+++ b/packages/gateway/test/source-checkpoint.test.ts
@@ -142,6 +142,75 @@ it("converts only the appended suffix after warm and database-reopen resumes", a
     );
   }
 });
+it.each([false, true])(
+  "reuses and advances a complete checkpoint with offset zero (restart=%s)",
+  async (restart) => {
+    setModelLimits({ context: 1_000_000, output: 2_000 });
+    setMaxLayer0Tokens(500_000);
+    const source = semanticHistory(6).messages;
+    expect(accept((await prepare(source)).prepared).layer).toBe(0);
+    const saved = new SourceWindowStore(storage).load() as {
+      sourceCount: number;
+      window: { offset: number };
+    };
+    expect(saved.sourceCount).toBe(source.length);
+    expect(saved.window.offset).toBe(0);
+    if (restart) {
+      close();
+      evictSession(sessionID);
+    }
+
+    const unchanged = await prepare(source);
+    expect(unchanged.timing.observations.source_checkpoint_hit).toBe(1);
+    expect(unchanged.timing.observations.source_converted_messages).toBe(0);
+    expect(unchanged.timing.observations.source_estimated_messages).toBe(0);
+    expect(unchanged.timing.observations.stored_id_resolutions).toBe(0);
+    expect(unchanged.prepared.loreMessages).toHaveLength(source.length);
+    accept(unchanged.prepared);
+    expect(unchanged.timing.observations.source_checkpoint_published).toBe(1);
+
+    const next: GatewayMessage[] = [
+      ...source,
+      { role: "assistant", content: [{ type: "text", text: "done" }] },
+      { role: "user", content: [{ type: "text", text: "continue" }] },
+    ];
+    const appended = await prepare(next);
+    expect(appended.timing.observations.source_checkpoint_hit).toBe(1);
+    expect(appended.timing.observations.source_converted_messages).toBe(2);
+    expect(appended.timing.observations.source_estimated_messages).toBe(2);
+    expect(appended.prepared.temporalInput.assistantIndex).toBe(next.length);
+    const actual = accept(appended.prepared);
+    expect(actual.layer).toBe(0);
+    expect(appended.timing.observations.source_checkpoint_published).toBe(1);
+    expect(new SourceWindowStore(storage).load()).toMatchObject({
+      sourceCount: next.length,
+      window: { offset: 0 },
+    });
+    evictSession(sessionID);
+    const full = (await prepare(next, true)).prepared;
+    const expected = transform({
+      messages: full.loreMessages,
+      projectPath,
+      sessionID,
+    });
+    // Exercise the same complete-source provenance gate as the pipeline.
+    const render = (result: typeof actual, prepared: typeof full) =>
+      loreMessagesToGateway(
+        result.messages,
+        prepared.provenanceByMessageId,
+        !prepared.sourceWindow &&
+          result.messages.length === prepared.loreMessages.length &&
+          result.messages.every(
+            (message, index) =>
+              message.info.id === prepared.loreMessages[index]?.info.id,
+          ),
+      );
+    const actualWire = render(actual, appended.prepared);
+    expect(JSON.stringify(actualWire)).toContain("synthetic-encrypted-state-");
+    expect(actualWire).toEqual(render(expected, full));
+  },
+);
+
 it("reconciles historical edits even when the old boundary is unchanged", async () => {
   accept((await prepare(messages)).prepared);
   const edited = structuredClone(messages);

--- a/packages/gateway/test/source-checkpoint.test.ts
+++ b/packages/gateway/test/source-checkpoint.test.ts
@@ -1,0 +1,473 @@
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import {
+  db,
+  estimateMessages,
+  temporal,
+  ensureProject,
+  saveSessionTracking,
+  setModelLimits,
+  setMaxLayer0Tokens,
+  transform,
+  evictSession,
+  calibrate,
+  saveGradientState,
+  SourceWindowStore,
+  withSavepoint,
+} from "@loreai/core";
+import { close } from "../../core/src/db";
+import {
+  prepareSemanticMessages,
+  PreparationTiming,
+} from "../src/semantic-preparation";
+import { storeTurnTemporal } from "../src/turn-temporal";
+import { loreMessagesToGateway } from "../src/pipeline";
+import type { GatewayMessage } from "../src/translate/types";
+import { semanticHistory } from "./fixtures/semantic-history";
+const projectPath = "/test/source-checkpoint";
+const sessionID = "source-checkpoint";
+const storage = {
+  projectPath,
+  sessionID,
+  noStore: false,
+  model: "test",
+  usage: { inputTokens: 2000, outputTokens: 10 },
+  assistantContentBlocks: [{ type: "text" as const, text: "done" }],
+};
+const messages: GatewayMessage[] = Array.from({ length: 5580 }, (_, i) => ({
+  role: i % 2 ? "assistant" : "user",
+  content: [
+    { type: "text", text: `message ${i} ` + "useful context ".repeat(15) },
+  ],
+}));
+beforeEach(() => {
+  vi.useFakeTimers({ toFake: ["Date"] });
+  vi.setSystemTime(new Date("2026-09-08T00:00:00Z"));
+  db().exec("DELETE FROM source_windows; DELETE FROM temporal_messages");
+  ensureProject(projectPath);
+  saveSessionTracking(sessionID, {});
+  evictSession(sessionID);
+  setModelLimits({ context: 16000, output: 2000 });
+  setMaxLayer0Tokens(8000);
+});
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+async function prepare(source: GatewayMessage[], forceFull = false) {
+  const timing = new PreparationTiming({
+    protocol: "openai-responses",
+    stream: true,
+  });
+  return {
+    timing,
+    prepared: await prepareSemanticMessages({
+      messages: source,
+      projectPath,
+      sessionID,
+      noStore: false,
+      protocol: "openai-responses",
+      forceFull,
+      timing,
+    }),
+  };
+}
+function accept(prepared: Awaited<ReturnType<typeof prepare>>["prepared"]) {
+  const result = transform({
+    messages: prepared.loreMessages,
+    projectPath,
+    sessionID,
+    sourceWindow: prepared.sourceWindow,
+  });
+  prepared.checkpoint?.finish(result.messages);
+  storeTurnTemporal({ ...storage, temporalInput: prepared.temporalInput });
+  return result;
+}
+it("converts only the appended suffix after warm and database-reopen resumes", async () => {
+  accept((await prepare(messages)).prepared);
+  expect(
+    (await prepare(messages)).timing.observations.source_estimated_messages,
+  ).toBe(0);
+  for (const restart of [false, true]) {
+    if (restart) {
+      evictSession(sessionID);
+      close();
+    }
+    const source = [
+      ...messages,
+      {
+        role: "user" as const,
+        content: [{ type: "text" as const, text: "continue" }],
+      },
+    ];
+    const { prepared, timing } = await prepare(source);
+    expect(timing.observations.source_converted_messages).toBe(1);
+    expect(timing.observations.source_estimated_messages).toBe(1);
+    expect(prepared.loreMessages.length).toBeLessThanOrEqual(2049);
+    expect(timing.counts.parts).toBe(prepared.loreMessages.length);
+    expect(prepared.temporalInput.assistantIndex).toBe(5581);
+    const actual = transform({
+      messages: prepared.loreMessages,
+      projectPath,
+      sessionID,
+      sourceWindow: prepared.sourceWindow,
+    });
+    evictSession(sessionID);
+    const full = (await prepare(source, true)).prepared;
+    const expected = transform({
+      messages: full.loreMessages,
+      projectPath,
+      sessionID,
+    });
+    expect(
+      loreMessagesToGateway(actual.messages, prepared.provenanceByMessageId),
+    ).toEqual(
+      loreMessagesToGateway(expected.messages, full.provenanceByMessageId),
+    );
+  }
+});
+it("reconciles historical edits even when the old boundary is unchanged", async () => {
+  accept((await prepare(messages)).prepared);
+  const edited = structuredClone(messages);
+  edited[0].content = [{ type: "text", text: "historical branch edit" }];
+  const { prepared, timing } = await prepare(edited);
+  expect(prepared.sourceWindow).toBeUndefined();
+  expect(timing.observations.source_converted_messages).toBe(5580);
+});
+
+it.each(["rewind", "protocol", "corrupt", "adapter"])(
+  "fully reconciles a %s boundary",
+  async (mode) => {
+    accept((await prepare(messages)).prepared);
+    let source = messages;
+    if (mode === "rewind") source = messages.slice(0, -10);
+    else {
+      const store = new SourceWindowStore(storage);
+      const payload = store.load() as Record<string, unknown>;
+      if (mode === "protocol") payload.protocol = "anthropic";
+      if (mode === "adapter") payload.version = "obsolete";
+      if (mode === "corrupt")
+        payload.raw = [
+          {
+            info: {
+              id: "bad",
+              sessionID,
+              role: "assistant",
+              time: { created: 1 },
+            },
+            parts: [{ id: "part", type: "tool" }],
+          },
+        ];
+      withSavepoint("alter_checkpoint", () => {
+        expect(store.claim()).toBe(true);
+        expect(store.publish(payload)).toBe(true);
+      });
+    }
+    const { prepared, timing } = await prepare(source);
+    expect(prepared.sourceWindow).toBeUndefined();
+    expect(timing.observations.source_converted_messages).toBe(source.length);
+  },
+);
+
+it("preserves parallel cross-frontier tool results, errors, and encrypted/opaque Responses provenance", async () => {
+  const tail = semanticHistory(4).messages;
+  const source = [...messages, ...tail.slice(0, -1)];
+  accept((await prepare(source)).prepared);
+  close();
+  evictSession(sessionID);
+  const result = structuredClone(tail.at(-1)!);
+  const tool = result.content.find((b) => b.type === "tool_result");
+  if (tool?.type === "tool_result") {
+    tool.isError = true;
+    tool.content.push({
+      type: "opaque",
+      raw: {
+        type: "image",
+        source: {
+          type: "base64",
+          media_type: "image/png",
+          data: "synthetic-image",
+        },
+      },
+    });
+  }
+  result.content.reverse();
+  const resumed = [...source, result];
+  const actual = await prepare(resumed);
+  expect(actual.timing.observations.source_converted_messages).toBe(1);
+  expect(actual.timing.observations.stored_id_resolutions).toBe(1);
+  const full = (await prepare(resumed, true)).prepared;
+  const offset = actual.prepared.sourceWindow!.offset;
+  expect(
+    loreMessagesToGateway(
+      actual.prepared.loreMessages,
+      actual.prepared.provenanceByMessageId,
+    ),
+  ).toEqual(
+    loreMessagesToGateway(
+      full.loreMessages.slice(offset),
+      full.provenanceByMessageId,
+    ),
+  );
+  expect(JSON.stringify([...actual.prepared.provenanceByMessageId])).toContain(
+    "synthetic-encrypted-state",
+  );
+  expect(actual.prepared.temporalInput.latestUser).toEqual(
+    full.temporalInput.latestUser,
+  );
+});
+
+it.each(["call", "result"])(
+  "reconciles a new %s reusing an omitted tool ID",
+  async (kind) => {
+    const early: GatewayMessage[] = [
+      {
+        role: "assistant",
+        content: [
+          { type: "tool_use", id: "ancient-call", name: "read", input: {} },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            toolUseId: "ancient-call",
+            content: [{ type: "text", text: "old result" }],
+          },
+        ],
+      },
+    ];
+    const source = [...early, ...messages];
+    accept((await prepare(source)).prepared);
+    const next: GatewayMessage =
+      kind === "call"
+        ? {
+            role: "assistant",
+            content: [
+              { type: "tool_use", id: "ancient-call", name: "read", input: {} },
+            ],
+          }
+        : {
+            role: "user",
+            content: [
+              {
+                type: "tool_result",
+                toolUseId: "ancient-call",
+                isError: true,
+                content: [{ type: "text", text: "replacement result" }],
+              },
+            ],
+          };
+    const { prepared, timing } = await prepare([...source, next]);
+    expect(prepared.sourceWindow).toBeUndefined();
+    expect(timing.observations.source_fallback_tool_boundary).toBe(1);
+  },
+);
+
+it("rebuilds only suffix tool IDs against a legacy temporal row", async () => {
+  const source = [...messages, ...semanticHistory(4).messages];
+  const first = await prepare(source);
+  const user = first.prepared.temporalInput.latestUser!;
+  const pid = ensureProject(projectPath);
+  db()
+    .query(
+      `INSERT INTO temporal_messages(id, project_id, session_id, role, content, tokens, distilled, created_at) VALUES (?, ?, ?, 'user', 'legacy output', 1, 0, 1)`,
+    )
+    .run(user.legacySourceID!, pid, sessionID);
+  accept((await prepare(source)).prepared);
+  const next = [
+    ...source,
+    {
+      role: "user" as const,
+      content: [{ type: "text" as const, text: "continue" }],
+    },
+  ];
+  const { prepared, timing } = await prepare(next);
+  expect(timing.observations.source_converted_messages).toBe(1);
+  expect(timing.observations.stored_id_resolutions).toBe(0);
+  const full = (await prepare(next, true)).prepared;
+  expect(
+    loreMessagesToGateway(
+      prepared.loreMessages,
+      prepared.provenanceByMessageId,
+    ),
+  ).toEqual(
+    loreMessagesToGateway(
+      full.loreMessages.slice(prepared.sourceWindow!.offset),
+      full.provenanceByMessageId,
+    ),
+  );
+});
+
+it("keeps calibrated warm and restart sizing equivalent to the full path", async () => {
+  const initial = (await prepare(messages)).prepared;
+  const first = accept(initial);
+  calibrate(first.totalTokens + 500, sessionID, first.messages.length);
+  saveGradientState(sessionID);
+  close();
+  evictSession(sessionID);
+  const next = [
+    ...messages,
+    {
+      role: "user" as const,
+      content: [{ type: "text" as const, text: "continue" }],
+    },
+  ];
+  const resumed = (await prepare(next)).prepared;
+  const actual = transform({
+    messages: resumed.loreMessages,
+    sourceWindow: resumed.sourceWindow,
+    projectPath,
+    sessionID,
+  });
+  evictSession(sessionID);
+  const full = (await prepare(next, true)).prepared;
+  const expected = transform({
+    messages: full.loreMessages,
+    projectPath,
+    sessionID,
+  });
+  expect(
+    loreMessagesToGateway(actual.messages, resumed.provenanceByMessageId),
+  ).toEqual(
+    loreMessagesToGateway(expected.messages, full.provenanceByMessageId),
+  );
+  expect(actual.totalTokens).toBe(expected.totalTokens);
+});
+
+it("refreshes cumulative calibration counts when a pending call completes", async () => {
+  setModelLimits({ context: 100000, output: 2000 });
+  setMaxLayer0Tokens(80000);
+  const source: GatewayMessage[] = Array.from({ length: 400 }, (_, i) => ({
+    role: i % 2 ? "assistant" : "user",
+    content: [{ type: "text", text: `tiny ${i}` }],
+  }));
+  source[51] = {
+    role: "assistant",
+    content: [{ type: "tool_use", id: "late-result", name: "read", input: {} }],
+  };
+  accept((await prepare(source)).prepared);
+  const appended: GatewayMessage[] = [
+    ...source,
+    {
+      role: "user",
+      content: [
+        {
+          type: "tool_result",
+          toolUseId: "late-result",
+          content: [{ type: "text", text: "substantial output ".repeat(300) }],
+        },
+      ],
+    },
+  ];
+  const resumed = await prepare(appended);
+  expect(resumed.timing.observations.source_converted_messages).toBe(1);
+  expect(resumed.timing.observations.source_estimated_messages).toBe(2);
+  accept(resumed.prepared);
+  const saved = new SourceWindowStore(storage).load() as {
+    window: { prefixTokens: number[] };
+  };
+  const full = (await prepare(appended, true)).prepared;
+  expect(saved.window.prefixTokens[52]).toBe(
+    estimateMessages(full.loreMessages.slice(0, 52)),
+  );
+});
+
+it("rolls back temporal rows and the frontier together, then accepts an idempotent retry", async () => {
+  accept((await prepare(messages)).prepared);
+  const appended = [
+    ...messages,
+    {
+      role: "user" as const,
+      content: [{ type: "text" as const, text: "retry this input" }],
+    },
+  ];
+  const next = (await prepare(appended)).prepared;
+  const model = transform({
+    messages: next.loreMessages,
+    sourceWindow: next.sourceWindow,
+    projectPath,
+    sessionID,
+  });
+  next.checkpoint?.finish(model.messages);
+  const before = new SourceWindowStore(storage).load();
+  const failure = vi
+    .spyOn(temporal, "recordToolCalls")
+    .mockImplementationOnce(() => {
+      throw new Error("storage interrupted");
+    });
+  expect(() =>
+    storeTurnTemporal({ ...storage, temporalInput: next.temporalInput }),
+  ).toThrow("storage interrupted");
+  expect(new SourceWindowStore(storage).load()).toEqual(before);
+  expect(
+    db()
+      .query(
+        "SELECT id FROM temporal_messages WHERE content = 'retry this input'",
+      )
+      .all(),
+  ).toHaveLength(0);
+  failure.mockRestore();
+  storeTurnTemporal({ ...storage, temporalInput: next.temporalInput });
+  storeTurnTemporal({ ...storage, temporalInput: next.temporalInput });
+  expect(
+    db()
+      .query(
+        "SELECT id FROM temporal_messages WHERE content = 'retry this input'",
+      )
+      .all(),
+  ).toHaveLength(1);
+  // An identical accepted retry may invalidate its old checkpoint through
+  // storage writes, but it must never skip unaccepted input or duplicate rows.
+  const resumed = await prepare([
+    ...appended,
+    { role: "assistant", content: [{ type: "text", text: "done" }] },
+  ]);
+  const full = (
+    await prepare(
+      [
+        ...appended,
+        { role: "assistant", content: [{ type: "text", text: "done" }] },
+      ],
+      true,
+    )
+  ).prepared;
+  expect(
+    loreMessagesToGateway(
+      resumed.prepared.loreMessages,
+      resumed.prepared.provenanceByMessageId,
+    ),
+  ).toEqual(
+    loreMessagesToGateway(
+      full.loreMessages.slice(resumed.prepared.sourceWindow?.offset ?? 0),
+      full.provenanceByMessageId,
+    ),
+  );
+});
+
+it.each(["hidden tokens", "prefix subtotal", "resolved estimate"])(
+  "rejects corrupt %s in a saved checkpoint",
+  async (field) => {
+    const source = messages.slice(0, 100);
+    accept((await prepare(source)).prepared);
+    const store = new SourceWindowStore(storage);
+    const payload = store.load() as {
+      raw: Array<{ hiddenInputTokens?: number }>;
+      resolvedTokens: number[];
+      window: { omittedTokens: number };
+    };
+    if (field === "hidden tokens") payload.raw[0].hiddenInputTokens = -1;
+    if (field === "prefix subtotal") payload.window.omittedTokens++;
+    if (field === "resolved estimate") payload.resolvedTokens = [-1];
+    withSavepoint("corrupt_counts", () => {
+      expect(store.claim()).toBe(true);
+      expect(store.publish(payload)).toBe(true);
+    });
+    const next = await prepare(source);
+    expect(next.timing.observations.source_checkpoint_hit).toBe(0);
+    expect(next.timing.observations.source_fallback_checkpoint).toBe(1);
+    expect(next.timing.observations.source_converted_messages).toBe(
+      source.length,
+    );
+  },
+);

--- a/packages/gateway/test/source-checkpoint.test.ts
+++ b/packages/gateway/test/source-checkpoint.test.ts
@@ -5,6 +5,9 @@ import {
   temporal,
   ensureProject,
   saveSessionTracking,
+  loadSessionTracking,
+  appendSessionPromptDelta,
+  listSessionPromptDeltas,
   setModelLimits,
   setMaxLayer0Tokens,
   transform,
@@ -20,8 +23,22 @@ import {
   PreparationTiming,
 } from "../src/semantic-preparation";
 import { storeTurnTemporal } from "../src/turn-temporal";
-import { loreMessagesToGateway } from "../src/pipeline";
-import type { GatewayMessage } from "../src/translate/types";
+import {
+  loreMessagesToGateway,
+  applySessionPromptDeltas,
+} from "../src/pipeline";
+import {
+  buildRecallAnchor,
+  recallAnchorContext,
+  serializeRecallStore,
+  deserializeRecallStore,
+  expandRecallMarkers,
+} from "../src/recall";
+import type {
+  GatewayMessage,
+  GatewayRequest,
+  RecallStore,
+} from "../src/translate/types";
 import { semanticHistory } from "./fixtures/semantic-history";
 const projectPath = "/test/source-checkpoint";
 const sessionID = "source-checkpoint";
@@ -471,3 +488,123 @@ it.each(["hidden tokens", "prefix subtotal", "resolved estimate"])(
     );
   },
 );
+
+it("replays durable recall, distillations, and knowledge deltas identically after restart", async () => {
+  const source = structuredClone(messages);
+  const anchorId = "123e4567-e89b-42d3-a456-426614174014";
+  const anchorIndex = source.length - 3;
+  source[anchorIndex].content = [
+    { type: "text", text: buildRecallAnchor(anchorId) },
+  ];
+  const recalls: RecallStore = new Map([
+    [
+      `anchor:${anchorId}`,
+      {
+        anchorId,
+        anchorContextId: recallAnchorContext(source, anchorIndex, []),
+        toolUseId: "restored-recall-call",
+        input: { query: "source context", scope: "session" },
+        result: "Recalled source context survives a process restart.",
+        position: 0,
+      },
+    ],
+  ]);
+  saveSessionTracking(sessionID, {
+    recallStore: serializeRecallStore(recalls),
+  });
+  const projectID = ensureProject(projectPath);
+  db()
+    .query(`INSERT INTO distillations
+    (id, project_id, session_id, narrative, facts, observations, source_ids,
+     generation, token_count, archived, created_at)
+    VALUES (?, ?, ?, ?, '[]', ?, '[]', 0, 30, 0, 1)`)
+    .run(
+      "source-window-distillation",
+      projectID,
+      sessionID,
+      "Distilled source context remains available.",
+      "Distilled source context remains available.",
+    );
+  const expand = (history: GatewayMessage[]) => {
+    const request: GatewayRequest = {
+      protocol: "openai-responses",
+      model: "test",
+      system: "test system",
+      messages: structuredClone(history),
+      tools: [],
+      stream: true,
+      maxTokens: 1024,
+      metadata: {},
+      rawHeaders: {},
+    };
+    const durable = loadSessionTracking(sessionID)?.recallStore;
+    expect(durable).toBeTruthy();
+    expect(expandRecallMarkers(request, deserializeRecallStore(durable!))).toBe(
+      true,
+    );
+    return request.messages;
+  };
+  const initial = (await prepare(expand(source))).prepared;
+  accept(initial);
+  appendSessionPromptDelta({
+    sessionID,
+    projectID,
+    selector: JSON.stringify({ target: "messages", insertAt: 2 }),
+    content: JSON.stringify([
+      {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "Lore knowledge update: durable source decision.",
+          },
+        ],
+      },
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Acknowledged durable source decision." },
+        ],
+      },
+    ]),
+  });
+  const durableDelta = listSessionPromptDeltas(sessionID);
+  close();
+  evictSession(sessionID);
+  const next = [
+    ...source,
+    {
+      role: "user" as const,
+      content: [
+        { type: "text" as const, text: "continue from the recalled source" },
+      ],
+    },
+  ];
+  const resumed = await prepare(expand(next));
+  expect(resumed.timing.observations.source_converted_messages).toBe(1);
+  expect(resumed.prepared.sourceWindow?.offset).toBeGreaterThan(0);
+  const render = (prepared: typeof initial) => {
+    const result = transform({
+      messages: prepared.loreMessages,
+      projectPath,
+      sessionID,
+      sourceWindow: prepared.sourceWindow,
+    });
+    const gateway = loreMessagesToGateway(
+      result.messages,
+      prepared.provenanceByMessageId,
+      false,
+    );
+    return applySessionPromptDeltas(gateway, sessionID);
+  };
+  const actual = render(resumed.prepared);
+  evictSession(sessionID);
+  const full = (await prepare(expand(next), true)).prepared;
+  const expected = render(full);
+  expect(actual).toEqual(expected);
+  const wire = JSON.stringify(actual);
+  expect(wire).toContain("Recalled source context survives");
+  expect(wire).toContain("Distilled source context remains available");
+  expect(wire).toContain("Lore knowledge update: durable source decision");
+  expect(listSessionPromptDeltas(sessionID)).toEqual(durableDelta);
+});

--- a/packages/gateway/test/source-window-benchmark.test.ts
+++ b/packages/gateway/test/source-window-benchmark.test.ts
@@ -1,0 +1,265 @@
+import { it, expect } from "vitest";
+import { createHash } from "node:crypto";
+import { writeFileSync } from "node:fs";
+import {
+  close,
+  db,
+  ensureProject,
+  saveSessionTracking,
+  transform,
+  evictSession,
+  setModelLimits,
+  setMaxLayer0Tokens,
+  estimateMessages,
+  log,
+} from "@loreai/core";
+import {
+  prepareSemanticMessages,
+  PreparationTiming,
+} from "../src/semantic-preparation";
+import { storeTurnTemporal } from "../src/turn-temporal";
+import { loreMessagesToGateway } from "../src/pipeline";
+import type { GatewayMessage } from "../src/translate/types";
+
+/** Completed agentic turns, unlike an unbroken tool chain protected in full. */
+function history(): GatewayMessage[] {
+  const messages: GatewayMessage[] = [];
+  for (let i = 0; i < 930; i++)
+    messages.push(
+      {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: `Inspect synthetic module ${i} and explain the behavior of its exported function.`,
+          },
+        ],
+      },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool_use",
+            id: `read-${i}`,
+            name: "read_file",
+            input: { path: `synthetic-${i}.ts` },
+          },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            toolUseId: `read-${i}`,
+            content: [
+              {
+                type: "text",
+                text: `export function synthetic${i}(value: number) { return value + ${i}; } // deterministic fixture`,
+              },
+            ],
+          },
+        ],
+      },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "text",
+            text: `Module ${i} adds its constant to the supplied value. The function is deterministic.`,
+          },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: `That completes review ${i}. Record the behavior for the next independent task.`,
+          },
+        ],
+      },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "text",
+            text: `Review ${i} completed. This task has no outstanding tool calls or follow-up actions.`,
+          },
+        ],
+      },
+    );
+  return messages;
+}
+
+it.skipIf(process.env.LORE_FRONTIER_BENCHMARK !== "1")(
+  "measures full, warm, reopened and appended source preparation",
+  async () => {
+    const scope = {
+      projectPath: "/test/source-window-benchmark",
+      sessionID: "source-window-benchmark",
+      noStore: false,
+    };
+    ensureProject(scope.projectPath);
+    saveSessionTracking(scope.sessionID, {});
+    const source = history();
+    const largeWindow = process.env.LORE_FRONTIER_LARGE_WINDOW === "1";
+    if (largeWindow) {
+      const padding =
+        " The synthetic review verifies deterministic behavior, preserves completed work, and records all relevant context for the next independent task.".repeat(
+          8,
+        );
+      for (const message of source)
+        for (const block of message.content) {
+          if (block.type === "text") block.text += padding;
+          if (block.type === "tool_result")
+            for (const output of block.content)
+              if (output.type === "text") output.text += padding;
+        }
+    }
+    const appended: GatewayMessage[] = [
+      ...source,
+      {
+        role: "user",
+        content: [{ type: "text", text: "Inspect the final synthetic file." }],
+      },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool_use",
+            id: "final-read",
+            name: "read_file",
+            input: { path: "final.ts" },
+          },
+        ],
+      },
+    ];
+    const setBudget = () => {
+      setModelLimits({
+        context: largeWindow ? 1_000_000 : 16_000,
+        output: largeWindow ? 32_000 : 2_000,
+      });
+      setMaxLayer0Tokens(largeWindow ? 500_000 : 8_000);
+    };
+    setBudget();
+    const populate = await prepareSemanticMessages({
+      ...scope,
+      protocol: "anthropic",
+      messages: source,
+      timing: new PreparationTiming({ protocol: "anthropic", stream: false }),
+    });
+    const sourceTokens = estimateMessages(populate.loreMessages);
+    const result = transform({ ...scope, messages: populate.loreMessages });
+    populate.checkpoint?.finish(result.messages);
+    storeTurnTemporal({
+      ...scope,
+      temporalInput: populate.temporalInput,
+      assistantContentBlocks: [{ type: "text", text: "accepted" }],
+      model: "synthetic",
+      usage: { inputTokens: 2000, outputTokens: 10 },
+    });
+    const runs: unknown[] = [];
+    const expected = new Map<string, string>();
+    for (let sample = 0; sample < 5; sample++) {
+      for (const mode of sample % 2
+        ? ["restart", "warm", "full", "append", "full-append"]
+        : ["full", "warm", "restart", "full-append", "append"]) {
+        evictSession(scope.sessionID);
+        if (mode === "restart") close();
+        setBudget();
+        const messages = mode.includes("append") ? appended : source;
+        const timing = new PreparationTiming({
+          protocol: "anthropic",
+          stream: false,
+        });
+        let sqlCount = 0;
+        log.registerSink({
+          info() {},
+          warn() {},
+          error() {},
+          captureException() {},
+          withDbSpan(_sql, fn) {
+            sqlCount++;
+            return fn();
+          },
+        });
+        const start = performance.now();
+        const prepared = await prepareSemanticMessages({
+          ...scope,
+          messages,
+          timing,
+          ...(mode.startsWith("full") ? {} : { protocol: "anthropic" }),
+        });
+        const preparationMs = performance.now() - start;
+        const transformStart = performance.now();
+        const transformed = transform({
+          ...scope,
+          messages: prepared.loreMessages,
+          sourceWindow: prepared.sourceWindow,
+        });
+        const transformMs = performance.now() - transformStart;
+        const hash = createHash("sha256")
+          .update(
+            JSON.stringify(
+              loreMessagesToGateway(
+                transformed.messages,
+                prepared.provenanceByMessageId,
+              ),
+            ),
+          )
+          .digest("hex");
+        const key = mode.includes("append") ? "append" : "same";
+        if (expected.has(key)) expect(hash).toBe(expected.get(key));
+        else expected.set(key, hash);
+        if (!mode.startsWith("full"))
+          expect(timing.observations.source_converted_messages).toBe(
+            mode === "append" ? 2 : 0,
+          );
+        runs.push({
+          sample,
+          mode,
+          sourceMessages: messages.length,
+          preparationMs,
+          transformMs,
+          retainedMessages: prepared.loreMessages.length,
+          modelMessages: transformed.messages.length,
+          modelTokens: transformed.totalTokens,
+          sqlCount,
+          wireHash: hash,
+          stages: timing.stages,
+          observations: timing.observations,
+        });
+      }
+    }
+    const report = {
+      node: process.version,
+      fixture:
+        "930 completed six-message turns, with unique read calls/results",
+      largeWindow,
+      sourceMessages: source.length,
+      sourceTokens,
+      checkpointBytes: (
+        db()
+          .query(
+            "SELECT length(payload) AS bytes FROM source_windows WHERE session_id = ?",
+          )
+          .get(scope.sessionID) as { bytes: number }
+      ).bytes,
+      runs,
+    };
+    if (process.env.LORE_FRONTIER_REPORT)
+      writeFileSync(
+        process.env.LORE_FRONTIER_REPORT,
+        JSON.stringify(report, null, 2) + "\n",
+      );
+    process.stdout.write(
+      JSON.stringify({
+        sourceMessages: report.sourceMessages,
+        sourceTokens: report.sourceTokens,
+        checkpointBytes: report.checkpointBytes,
+        samples: runs.length,
+      }) + "\n",
+    );
+  },
+);

--- a/packages/gateway/test/store-turn-temporal.test.ts
+++ b/packages/gateway/test/store-turn-temporal.test.ts
@@ -1,3 +1,4 @@
+import { MIGRATIONS } from "../../core/src/db";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   close,
@@ -397,7 +398,7 @@ describe("storeTurnTemporal (#1084)", () => {
       `);
       close();
       expect(db().query("SELECT version FROM schema_version").get()).toEqual({
-        version: 86,
+        version: MIGRATIONS.length,
       });
 
       const noStoreLore = gatewayMessagesToLore(conversation, sessionID);

--- a/quality/benchmarks/source-frontier-1710.json
+++ b/quality/benchmarks/source-frontier-1710.json
@@ -1,0 +1,1504 @@
+{
+  "node": "v24.19.0",
+  "fixture": "930 completed six-message turns, with unique read calls/results",
+  "largeWindow": false,
+  "sourceMessages": 5580,
+  "sourceTokens": 276338,
+  "checkpointBytes": 49162,
+  "runs": [
+    {
+      "sample": 0,
+      "mode": "full",
+      "sourceMessages": 5580,
+      "preparationMs": 49.68996999999945,
+      "transformMs": 76.71057799999926,
+      "retainedMessages": 5580,
+      "modelMessages": 40,
+      "modelTokens": 1952,
+      "sqlCount": 21,
+      "wireHash": "5836c239cbe7c623052baa5fa8a7e3c8d04b34567edea28e4f45ab4cca14b502",
+      "stages": {
+        "conversion": {
+          "wallMs": 27.974347000000307,
+          "cpuMs": 39.38
+        },
+        "temporal_input": {
+          "wallMs": 0.15088600000035512,
+          "cpuMs": 0.148
+        },
+        "provenance": {
+          "wallMs": 2.138747000000876,
+          "cpuMs": 0.214
+        },
+        "stored_ids": {
+          "wallMs": 4.98493899999994,
+          "cpuMs": 7.359
+        },
+        "resolve_tools": {
+          "wallMs": 8.17235299999993,
+          "cpuMs": 15.119
+        },
+        "semantic_total": {
+          "wallMs": 49.07686899999953,
+          "cpuMs": 69.115
+        }
+      },
+      "observations": {
+        "source_converted_messages": 5580,
+        "source_total_messages": 5580,
+        "rss_delta_bytes": 3932160,
+        "heap_delta_bytes": 21794568,
+        "messages": 5580,
+        "parts": 5580,
+        "toolUses": 930,
+        "toolResults": 930,
+        "placeholders": 930,
+        "stored_id_resolutions": 930,
+        "event_loop_delay_ms": 49.60590499999944,
+        "provenance_tokens_hits": 0,
+        "provenance_tokens_misses": 0,
+        "provenance_tokens_bpe_bytes": 0,
+        "provenance_tokens_bpe_ms": 0,
+        "provenance_tokens_unavailable": 0
+      }
+    },
+    {
+      "sample": 0,
+      "mode": "warm",
+      "sourceMessages": 5580,
+      "preparationMs": 12.450117000000319,
+      "transformMs": 2.6858200000006036,
+      "retainedMessages": 259,
+      "modelMessages": 40,
+      "modelTokens": 1952,
+      "sqlCount": 12,
+      "wireHash": "5836c239cbe7c623052baa5fa8a7e3c8d04b34567edea28e4f45ab4cca14b502",
+      "stages": {
+        "source_validation": {
+          "wallMs": 5.476568000000043,
+          "cpuMs": 5.441
+        },
+        "conversion": {
+          "wallMs": 0.05702599999949598,
+          "cpuMs": 0.054
+        },
+        "temporal_input": {
+          "wallMs": 0.17873899999995047,
+          "cpuMs": 0.163
+        },
+        "provenance": {
+          "wallMs": 1.1959889999998268,
+          "cpuMs": 0.319
+        },
+        "stored_ids": {
+          "wallMs": 0.032097999999677995,
+          "cpuMs": 0.03
+        },
+        "resolve_tools": {
+          "wallMs": 0.3999309999999241,
+          "cpuMs": 0.511
+        },
+        "semantic_total": {
+          "wallMs": 12.025548000000526,
+          "cpuMs": 16.698
+        }
+      },
+      "observations": {
+        "source_checkpoint_hit": 1,
+        "source_converted_messages": 0,
+        "source_total_messages": 5580,
+        "source_estimated_messages": 0,
+        "rss_delta_bytes": 393216,
+        "heap_delta_bytes": 3254216,
+        "messages": 259,
+        "parts": 259,
+        "toolUses": 43,
+        "toolResults": 43,
+        "placeholders": 43,
+        "stored_id_resolutions": 0,
+        "event_loop_delay_ms": 12.303225999999995,
+        "provenance_tokens_hits": 0,
+        "provenance_tokens_misses": 0,
+        "provenance_tokens_bpe_bytes": 0,
+        "provenance_tokens_bpe_ms": 0,
+        "provenance_tokens_unavailable": 0
+      }
+    },
+    {
+      "sample": 0,
+      "mode": "restart",
+      "sourceMessages": 5580,
+      "preparationMs": 19.00475600000027,
+      "transformMs": 3.1463919999996506,
+      "retainedMessages": 259,
+      "modelMessages": 40,
+      "modelTokens": 1952,
+      "sqlCount": 12,
+      "wireHash": "5836c239cbe7c623052baa5fa8a7e3c8d04b34567edea28e4f45ab4cca14b502",
+      "stages": {
+        "source_validation": {
+          "wallMs": 4.54624799999965,
+          "cpuMs": 5.142
+        },
+        "conversion": {
+          "wallMs": 0.06628999999975349,
+          "cpuMs": 0.063
+        },
+        "temporal_input": {
+          "wallMs": 0.07657499999913853,
+          "cpuMs": 0.111
+        },
+        "provenance": {
+          "wallMs": 0.026630000000295695,
+          "cpuMs": 0.026
+        },
+        "stored_ids": {
+          "wallMs": 0.0863999999992302,
+          "cpuMs": 0.083
+        },
+        "resolve_tools": {
+          "wallMs": 0.1515079999999216,
+          "cpuMs": 0.147
+        },
+        "semantic_total": {
+          "wallMs": 18.659026000000267,
+          "cpuMs": 17.53
+        }
+      },
+      "observations": {
+        "source_checkpoint_hit": 1,
+        "source_converted_messages": 0,
+        "source_total_messages": 5580,
+        "source_estimated_messages": 0,
+        "rss_delta_bytes": 528384,
+        "heap_delta_bytes": 2944200,
+        "messages": 259,
+        "parts": 259,
+        "toolUses": 43,
+        "toolResults": 43,
+        "placeholders": 43,
+        "stored_id_resolutions": 0,
+        "event_loop_delay_ms": 18.936022000000776,
+        "provenance_tokens_hits": 0,
+        "provenance_tokens_misses": 0,
+        "provenance_tokens_bpe_bytes": 0,
+        "provenance_tokens_bpe_ms": 0,
+        "provenance_tokens_unavailable": 0
+      }
+    },
+    {
+      "sample": 0,
+      "mode": "full-append",
+      "sourceMessages": 5582,
+      "preparationMs": 63.45804500000031,
+      "transformMs": 73.95969200000036,
+      "retainedMessages": 5582,
+      "modelMessages": 41,
+      "modelTokens": 1955,
+      "sqlCount": 21,
+      "wireHash": "4d434d14b92ab6d3d0233250db5399eed49076b97ca9d358b4cb56a646c8c998",
+      "stages": {
+        "conversion": {
+          "wallMs": 47.68895599999996,
+          "cpuMs": 42.159
+        },
+        "temporal_input": {
+          "wallMs": 0.239980999999716,
+          "cpuMs": 0.236
+        },
+        "provenance": {
+          "wallMs": 0.05901799999992363,
+          "cpuMs": 0.057
+        },
+        "stored_ids": {
+          "wallMs": 7.15943900000002,
+          "cpuMs": 7.145
+        },
+        "resolve_tools": {
+          "wallMs": 5.817850999999791,
+          "cpuMs": 5.808
+        },
+        "semantic_total": {
+          "wallMs": 63.02515400000084,
+          "cpuMs": 57.226
+        }
+      },
+      "observations": {
+        "source_converted_messages": 5582,
+        "source_total_messages": 5582,
+        "rss_delta_bytes": 3014656,
+        "heap_delta_bytes": 17933392,
+        "messages": 5582,
+        "parts": 5582,
+        "toolUses": 931,
+        "toolResults": 930,
+        "placeholders": 930,
+        "stored_id_resolutions": 930,
+        "event_loop_delay_ms": 63.23885500000051,
+        "provenance_tokens_hits": 0,
+        "provenance_tokens_misses": 0,
+        "provenance_tokens_bpe_bytes": 0,
+        "provenance_tokens_bpe_ms": 0,
+        "provenance_tokens_unavailable": 0
+      }
+    },
+    {
+      "sample": 0,
+      "mode": "append",
+      "sourceMessages": 5582,
+      "preparationMs": 34.35477400000036,
+      "transformMs": 3.673616000000038,
+      "retainedMessages": 261,
+      "modelMessages": 41,
+      "modelTokens": 1955,
+      "sqlCount": 12,
+      "wireHash": "4d434d14b92ab6d3d0233250db5399eed49076b97ca9d358b4cb56a646c8c998",
+      "stages": {
+        "source_validation": {
+          "wallMs": 24.292069000000083,
+          "cpuMs": 33.784
+        },
+        "conversion": {
+          "wallMs": 0.13525300000037532,
+          "cpuMs": 0.129
+        },
+        "temporal_input": {
+          "wallMs": 0.09927999999945314,
+          "cpuMs": 0.095
+        },
+        "provenance": {
+          "wallMs": 0.06102199999986624,
+          "cpuMs": 0.06
+        },
+        "stored_ids": {
+          "wallMs": 0.07793700000001991,
+          "cpuMs": 0.076
+        },
+        "resolve_tools": {
+          "wallMs": 0.23938100000032136,
+          "cpuMs": 0.237
+        },
+        "semantic_total": {
+          "wallMs": 34.14225499999975,
+          "cpuMs": 40.938
+        }
+      },
+      "observations": {
+        "source_checkpoint_hit": 1,
+        "source_converted_messages": 2,
+        "source_total_messages": 5582,
+        "source_estimated_messages": 2,
+        "rss_delta_bytes": 2764800,
+        "heap_delta_bytes": -58268280,
+        "messages": 261,
+        "parts": 261,
+        "toolUses": 44,
+        "toolResults": 43,
+        "placeholders": 43,
+        "stored_id_resolutions": 0,
+        "event_loop_delay_ms": 34.30348700000013,
+        "provenance_tokens_hits": 0,
+        "provenance_tokens_misses": 0,
+        "provenance_tokens_bpe_bytes": 0,
+        "provenance_tokens_bpe_ms": 0,
+        "provenance_tokens_unavailable": 0
+      }
+    },
+    {
+      "sample": 1,
+      "mode": "restart",
+      "sourceMessages": 5580,
+      "preparationMs": 21.599229000000378,
+      "transformMs": 2.466110000000299,
+      "retainedMessages": 259,
+      "modelMessages": 40,
+      "modelTokens": 1952,
+      "sqlCount": 12,
+      "wireHash": "5836c239cbe7c623052baa5fa8a7e3c8d04b34567edea28e4f45ab4cca14b502",
+      "stages": {
+        "source_validation": {
+          "wallMs": 9.168910999999753,
+          "cpuMs": 4.579
+        },
+        "conversion": {
+          "wallMs": 0.09718599999996513,
+          "cpuMs": 0.092
+        },
+        "temporal_input": {
+          "wallMs": 0.055534000000079686,
+          "cpuMs": 0.053
+        },
+        "provenance": {
+          "wallMs": 0.015693999999712105,
+          "cpuMs": 0.015
+        },
+        "stored_ids": {
+          "wallMs": 0.018958999999995285,
+          "cpuMs": 0.018
+        },
+        "resolve_tools": {
+          "wallMs": 0.15052699999978358,
+          "cpuMs": 0.15
+        },
+        "semantic_total": {
+          "wallMs": 21.457914999999957,
+          "cpuMs": 15.79
+        }
+      },
+      "observations": {
+        "source_checkpoint_hit": 1,
+        "source_converted_messages": 0,
+        "source_total_messages": 5580,
+        "source_estimated_messages": 0,
+        "rss_delta_bytes": 397312,
+        "heap_delta_bytes": 2842872,
+        "messages": 259,
+        "parts": 259,
+        "toolUses": 43,
+        "toolResults": 43,
+        "placeholders": 43,
+        "stored_id_resolutions": 0,
+        "event_loop_delay_ms": 21.563383999999132,
+        "provenance_tokens_hits": 0,
+        "provenance_tokens_misses": 0,
+        "provenance_tokens_bpe_bytes": 0,
+        "provenance_tokens_bpe_ms": 0,
+        "provenance_tokens_unavailable": 0
+      }
+    },
+    {
+      "sample": 1,
+      "mode": "warm",
+      "sourceMessages": 5580,
+      "preparationMs": 13.938154999999824,
+      "transformMs": 2.5088040000000547,
+      "retainedMessages": 259,
+      "modelMessages": 40,
+      "modelTokens": 1952,
+      "sqlCount": 12,
+      "wireHash": "5836c239cbe7c623052baa5fa8a7e3c8d04b34567edea28e4f45ab4cca14b502",
+      "stages": {
+        "source_validation": {
+          "wallMs": 5.535166000000572,
+          "cpuMs": 5.594
+        },
+        "conversion": {
+          "wallMs": 0.06408600000031583,
+          "cpuMs": 0.06
+        },
+        "temporal_input": {
+          "wallMs": 0.06543799999963085,
+          "cpuMs": 0.096
+        },
+        "provenance": {
+          "wallMs": 0.019237999999859312,
+          "cpuMs": 0.019
+        },
+        "stored_ids": {
+          "wallMs": 0.01763699999992241,
+          "cpuMs": 0.017
+        },
+        "resolve_tools": {
+          "wallMs": 0.18616999999994732,
+          "cpuMs": 0.184
+        },
+        "semantic_total": {
+          "wallMs": 13.77783400000044,
+          "cpuMs": 10.698
+        }
+      },
+      "observations": {
+        "source_checkpoint_hit": 1,
+        "source_converted_messages": 0,
+        "source_total_messages": 5580,
+        "source_estimated_messages": 0,
+        "rss_delta_bytes": 524288,
+        "heap_delta_bytes": 2560648,
+        "messages": 259,
+        "parts": 259,
+        "toolUses": 43,
+        "toolResults": 43,
+        "placeholders": 43,
+        "stored_id_resolutions": 0,
+        "event_loop_delay_ms": 13.887419000000591,
+        "provenance_tokens_hits": 0,
+        "provenance_tokens_misses": 0,
+        "provenance_tokens_bpe_bytes": 0,
+        "provenance_tokens_bpe_ms": 0,
+        "provenance_tokens_unavailable": 0
+      }
+    },
+    {
+      "sample": 1,
+      "mode": "full",
+      "sourceMessages": 5580,
+      "preparationMs": 63.98483699999997,
+      "transformMs": 68.59145100000023,
+      "retainedMessages": 5580,
+      "modelMessages": 40,
+      "modelTokens": 1952,
+      "sqlCount": 21,
+      "wireHash": "5836c239cbe7c623052baa5fa8a7e3c8d04b34567edea28e4f45ab4cca14b502",
+      "stages": {
+        "conversion": {
+          "wallMs": 36.49127300000055,
+          "cpuMs": 28.555
+        },
+        "temporal_input": {
+          "wallMs": 0.22133299999950395,
+          "cpuMs": 0.216
+        },
+        "provenance": {
+          "wallMs": 0.1040659999998752,
+          "cpuMs": 0.1
+        },
+        "stored_ids": {
+          "wallMs": 17.136304999999993,
+          "cpuMs": 7.902
+        },
+        "resolve_tools": {
+          "wallMs": 8.141757000000325,
+          "cpuMs": 7.2
+        },
+        "semantic_total": {
+          "wallMs": 63.777556000000004,
+          "cpuMs": 45.877
+        }
+      },
+      "observations": {
+        "source_converted_messages": 5580,
+        "source_total_messages": 5580,
+        "rss_delta_bytes": 3014656,
+        "heap_delta_bytes": 17732120,
+        "messages": 5580,
+        "parts": 5580,
+        "toolUses": 930,
+        "toolResults": 930,
+        "placeholders": 930,
+        "stored_id_resolutions": 930,
+        "event_loop_delay_ms": 63.93099700000039,
+        "provenance_tokens_hits": 0,
+        "provenance_tokens_misses": 0,
+        "provenance_tokens_bpe_bytes": 0,
+        "provenance_tokens_bpe_ms": 0,
+        "provenance_tokens_unavailable": 0
+      }
+    },
+    {
+      "sample": 1,
+      "mode": "append",
+      "sourceMessages": 5582,
+      "preparationMs": 22.149045999999544,
+      "transformMs": 3.1493370000007417,
+      "retainedMessages": 261,
+      "modelMessages": 41,
+      "modelTokens": 1955,
+      "sqlCount": 12,
+      "wireHash": "4d434d14b92ab6d3d0233250db5399eed49076b97ca9d358b4cb56a646c8c998",
+      "stages": {
+        "source_validation": {
+          "wallMs": 4.028830000000198,
+          "cpuMs": 4.021
+        },
+        "conversion": {
+          "wallMs": 0.09061599999949976,
+          "cpuMs": 0.087
+        },
+        "temporal_input": {
+          "wallMs": 0.07369099999959872,
+          "cpuMs": 0.07
+        },
+        "provenance": {
+          "wallMs": 0.022032999999282765,
+          "cpuMs": 0.021
+        },
+        "stored_ids": {
+          "wallMs": 0.029313999999430962,
+          "cpuMs": 0.028
+        },
+        "resolve_tools": {
+          "wallMs": 0.24436799999966752,
+          "cpuMs": 0.24
+        },
+        "semantic_total": {
+          "wallMs": 8.498673000000053,
+          "cpuMs": 10.211
+        }
+      },
+      "observations": {
+        "source_checkpoint_hit": 1,
+        "source_converted_messages": 2,
+        "source_total_messages": 5582,
+        "source_estimated_messages": 2,
+        "rss_delta_bytes": 262144,
+        "heap_delta_bytes": 2936472,
+        "messages": 261,
+        "parts": 261,
+        "toolUses": 44,
+        "toolResults": 43,
+        "placeholders": 43,
+        "stored_id_resolutions": 0,
+        "event_loop_delay_ms": 22.05865900000026,
+        "provenance_tokens_hits": 0,
+        "provenance_tokens_misses": 0,
+        "provenance_tokens_bpe_bytes": 0,
+        "provenance_tokens_bpe_ms": 0,
+        "provenance_tokens_unavailable": 0
+      }
+    },
+    {
+      "sample": 1,
+      "mode": "full-append",
+      "sourceMessages": 5582,
+      "preparationMs": 33.96888299999955,
+      "transformMs": 45.117583999999624,
+      "retainedMessages": 5582,
+      "modelMessages": 41,
+      "modelTokens": 1955,
+      "sqlCount": 21,
+      "wireHash": "4d434d14b92ab6d3d0233250db5399eed49076b97ca9d358b4cb56a646c8c998",
+      "stages": {
+        "conversion": {
+          "wallMs": 26.122731999999814,
+          "cpuMs": 31.467
+        },
+        "temporal_input": {
+          "wallMs": 0.14501800000016374,
+          "cpuMs": 0.144
+        },
+        "provenance": {
+          "wallMs": 0.0367260000002716,
+          "cpuMs": 0.036
+        },
+        "stored_ids": {
+          "wallMs": 3.4639500000002954,
+          "cpuMs": 3.457
+        },
+        "resolve_tools": {
+          "wallMs": 3.1436479999993026,
+          "cpuMs": 5.419
+        },
+        "semantic_total": {
+          "wallMs": 33.80399599999964,
+          "cpuMs": 41.441
+        }
+      },
+      "observations": {
+        "source_converted_messages": 5582,
+        "source_total_messages": 5582,
+        "rss_delta_bytes": 3014656,
+        "heap_delta_bytes": 17767504,
+        "messages": 5582,
+        "parts": 5582,
+        "toolUses": 931,
+        "toolResults": 930,
+        "placeholders": 930,
+        "stored_id_resolutions": 930,
+        "event_loop_delay_ms": 33.935623999999734,
+        "provenance_tokens_hits": 0,
+        "provenance_tokens_misses": 0,
+        "provenance_tokens_bpe_bytes": 0,
+        "provenance_tokens_bpe_ms": 0,
+        "provenance_tokens_unavailable": 0
+      }
+    },
+    {
+      "sample": 2,
+      "mode": "full",
+      "sourceMessages": 5580,
+      "preparationMs": 71.3800970000002,
+      "transformMs": 52.953293999999914,
+      "retainedMessages": 5580,
+      "modelMessages": 40,
+      "modelTokens": 1952,
+      "sqlCount": 21,
+      "wireHash": "5836c239cbe7c623052baa5fa8a7e3c8d04b34567edea28e4f45ab4cca14b502",
+      "stages": {
+        "conversion": {
+          "wallMs": 39.05574500000057,
+          "cpuMs": 38.753
+        },
+        "temporal_input": {
+          "wallMs": 0.16035100000044622,
+          "cpuMs": 0.159
+        },
+        "provenance": {
+          "wallMs": 0.034571999999570835,
+          "cpuMs": 0.033
+        },
+        "stored_ids": {
+          "wallMs": 3.3801039999998466,
+          "cpuMs": 3.376
+        },
+        "resolve_tools": {
+          "wallMs": 27.67091099999925,
+          "cpuMs": 33.892
+        },
+        "semantic_total": {
+          "wallMs": 71.19973500000015,
+          "cpuMs": 77.144
+        }
+      },
+      "observations": {
+        "source_converted_messages": 5580,
+        "source_total_messages": 5580,
+        "rss_delta_bytes": 7208960,
+        "heap_delta_bytes": -38202504,
+        "messages": 5580,
+        "parts": 5580,
+        "toolUses": 930,
+        "toolResults": 930,
+        "placeholders": 930,
+        "stored_id_resolutions": 930,
+        "event_loop_delay_ms": 71.33239500000036,
+        "provenance_tokens_hits": 0,
+        "provenance_tokens_misses": 0,
+        "provenance_tokens_bpe_bytes": 0,
+        "provenance_tokens_bpe_ms": 0,
+        "provenance_tokens_unavailable": 0
+      }
+    },
+    {
+      "sample": 2,
+      "mode": "warm",
+      "sourceMessages": 5580,
+      "preparationMs": 12.79592699999921,
+      "transformMs": 3.659885000000031,
+      "retainedMessages": 259,
+      "modelMessages": 40,
+      "modelTokens": 1952,
+      "sqlCount": 12,
+      "wireHash": "5836c239cbe7c623052baa5fa8a7e3c8d04b34567edea28e4f45ab4cca14b502",
+      "stages": {
+        "source_validation": {
+          "wallMs": 7.086449000000357,
+          "cpuMs": 7.072
+        },
+        "conversion": {
+          "wallMs": 0.06821299999955954,
+          "cpuMs": 0.064
+        },
+        "temporal_input": {
+          "wallMs": 0.08959500000037224,
+          "cpuMs": 0.084
+        },
+        "provenance": {
+          "wallMs": 0.025918999999703374,
+          "cpuMs": 0.024
+        },
+        "stored_ids": {
+          "wallMs": 0.022453999999925145,
+          "cpuMs": 0.02
+        },
+        "resolve_tools": {
+          "wallMs": 0.26676100000076985,
+          "cpuMs": 0.263
+        },
+        "semantic_total": {
+          "wallMs": 12.591308999999455,
+          "cpuMs": 12.588
+        }
+      },
+      "observations": {
+        "source_checkpoint_hit": 1,
+        "source_converted_messages": 0,
+        "source_total_messages": 5580,
+        "source_estimated_messages": 0,
+        "rss_delta_bytes": 393216,
+        "heap_delta_bytes": 2608640,
+        "messages": 259,
+        "parts": 259,
+        "toolUses": 43,
+        "toolResults": 43,
+        "placeholders": 43,
+        "stored_id_resolutions": 0,
+        "event_loop_delay_ms": 12.747513999999683,
+        "provenance_tokens_hits": 0,
+        "provenance_tokens_misses": 0,
+        "provenance_tokens_bpe_bytes": 0,
+        "provenance_tokens_bpe_ms": 0,
+        "provenance_tokens_unavailable": 0
+      }
+    },
+    {
+      "sample": 2,
+      "mode": "restart",
+      "sourceMessages": 5580,
+      "preparationMs": 16.040978000000905,
+      "transformMs": 2.675564000000122,
+      "retainedMessages": 259,
+      "modelMessages": 40,
+      "modelTokens": 1952,
+      "sqlCount": 12,
+      "wireHash": "5836c239cbe7c623052baa5fa8a7e3c8d04b34567edea28e4f45ab4cca14b502",
+      "stages": {
+        "source_validation": {
+          "wallMs": 4.227077999999892,
+          "cpuMs": 6.41
+        },
+        "conversion": {
+          "wallMs": 0.2592100000001665,
+          "cpuMs": 0.255
+        },
+        "temporal_input": {
+          "wallMs": 0.048061999999845284,
+          "cpuMs": 0.045
+        },
+        "provenance": {
+          "wallMs": 0.04002000000036787,
+          "cpuMs": 0.039
+        },
+        "stored_ids": {
+          "wallMs": 0.01864800000021205,
+          "cpuMs": 0.016
+        },
+        "resolve_tools": {
+          "wallMs": 0.11815800000022136,
+          "cpuMs": 0.116
+        },
+        "semantic_total": {
+          "wallMs": 15.852254000000357,
+          "cpuMs": 22.156
+        }
+      },
+      "observations": {
+        "source_checkpoint_hit": 1,
+        "source_converted_messages": 0,
+        "source_total_messages": 5580,
+        "source_estimated_messages": 0,
+        "rss_delta_bytes": 262144,
+        "heap_delta_bytes": 3086904,
+        "messages": 259,
+        "parts": 259,
+        "toolUses": 43,
+        "toolResults": 43,
+        "placeholders": 43,
+        "stored_id_resolutions": 0,
+        "event_loop_delay_ms": 15.9958000000006,
+        "provenance_tokens_hits": 0,
+        "provenance_tokens_misses": 0,
+        "provenance_tokens_bpe_bytes": 0,
+        "provenance_tokens_bpe_ms": 0,
+        "provenance_tokens_unavailable": 0
+      }
+    },
+    {
+      "sample": 2,
+      "mode": "full-append",
+      "sourceMessages": 5582,
+      "preparationMs": 65.69791400000031,
+      "transformMs": 46.80623800000012,
+      "retainedMessages": 5582,
+      "modelMessages": 41,
+      "modelTokens": 1955,
+      "sqlCount": 21,
+      "wireHash": "4d434d14b92ab6d3d0233250db5399eed49076b97ca9d358b4cb56a646c8c998",
+      "stages": {
+        "conversion": {
+          "wallMs": 29.810879999999997,
+          "cpuMs": 29.794
+        },
+        "temporal_input": {
+          "wallMs": 0.19480300000032003,
+          "cpuMs": 0.191
+        },
+        "provenance": {
+          "wallMs": 0.040421000000606,
+          "cpuMs": 0.039
+        },
+        "stored_ids": {
+          "wallMs": 6.743754000000081,
+          "cpuMs": 10.584
+        },
+        "resolve_tools": {
+          "wallMs": 10.617811000000074,
+          "cpuMs": 5.944
+        },
+        "semantic_total": {
+          "wallMs": 49.08267699999942,
+          "cpuMs": 50.886
+        }
+      },
+      "observations": {
+        "source_converted_messages": 5582,
+        "source_total_messages": 5582,
+        "rss_delta_bytes": 3276800,
+        "heap_delta_bytes": 19319408,
+        "messages": 5582,
+        "parts": 5582,
+        "toolUses": 931,
+        "toolResults": 930,
+        "placeholders": 930,
+        "stored_id_resolutions": 930,
+        "event_loop_delay_ms": 65.60262999999941,
+        "provenance_tokens_hits": 0,
+        "provenance_tokens_misses": 0,
+        "provenance_tokens_bpe_bytes": 0,
+        "provenance_tokens_bpe_ms": 0,
+        "provenance_tokens_unavailable": 0
+      }
+    },
+    {
+      "sample": 2,
+      "mode": "append",
+      "sourceMessages": 5582,
+      "preparationMs": 8.522019,
+      "transformMs": 2.0563529999999446,
+      "retainedMessages": 261,
+      "modelMessages": 41,
+      "modelTokens": 1955,
+      "sqlCount": 12,
+      "wireHash": "4d434d14b92ab6d3d0233250db5399eed49076b97ca9d358b4cb56a646c8c998",
+      "stages": {
+        "source_validation": {
+          "wallMs": 4.245967000000746,
+          "cpuMs": 4.245
+        },
+        "conversion": {
+          "wallMs": 0.07007499999963329,
+          "cpuMs": 0.068
+        },
+        "temporal_input": {
+          "wallMs": 0.052849000000605884,
+          "cpuMs": 0.051
+        },
+        "provenance": {
+          "wallMs": 0.014812999999776366,
+          "cpuMs": 0.074
+        },
+        "stored_ids": {
+          "wallMs": 0.011107000000265543,
+          "cpuMs": 0.01
+        },
+        "resolve_tools": {
+          "wallMs": 0.27221000000008644,
+          "cpuMs": 0.278
+        },
+        "semantic_total": {
+          "wallMs": 8.316740000000209,
+          "cpuMs": 9.94
+        }
+      },
+      "observations": {
+        "source_checkpoint_hit": 1,
+        "source_converted_messages": 2,
+        "source_total_messages": 5582,
+        "source_estimated_messages": 2,
+        "rss_delta_bytes": 262144,
+        "heap_delta_bytes": 2646120,
+        "messages": 261,
+        "parts": 261,
+        "toolUses": 44,
+        "toolResults": 43,
+        "placeholders": 43,
+        "stored_id_resolutions": 0,
+        "event_loop_delay_ms": 8.487656999999672,
+        "provenance_tokens_hits": 0,
+        "provenance_tokens_misses": 0,
+        "provenance_tokens_bpe_bytes": 0,
+        "provenance_tokens_bpe_ms": 0,
+        "provenance_tokens_unavailable": 0
+      }
+    },
+    {
+      "sample": 3,
+      "mode": "restart",
+      "sourceMessages": 5580,
+      "preparationMs": 20.427511000000777,
+      "transformMs": 4.2966630000000805,
+      "retainedMessages": 259,
+      "modelMessages": 40,
+      "modelTokens": 1952,
+      "sqlCount": 12,
+      "wireHash": "5836c239cbe7c623052baa5fa8a7e3c8d04b34567edea28e4f45ab4cca14b502",
+      "stages": {
+        "source_validation": {
+          "wallMs": 7.295524000000114,
+          "cpuMs": 12.469
+        },
+        "conversion": {
+          "wallMs": 0.067641999999978,
+          "cpuMs": 0.064
+        },
+        "temporal_input": {
+          "wallMs": 0.11638500000026397,
+          "cpuMs": 0.097
+        },
+        "provenance": {
+          "wallMs": 0.023786000000654894,
+          "cpuMs": 0.022
+        },
+        "stored_ids": {
+          "wallMs": 0.022855000000163272,
+          "cpuMs": 0.021
+        },
+        "resolve_tools": {
+          "wallMs": 0.216284999999516,
+          "cpuMs": 0.405
+        },
+        "semantic_total": {
+          "wallMs": 20.187700000000405,
+          "cpuMs": 30.627
+        }
+      },
+      "observations": {
+        "source_checkpoint_hit": 1,
+        "source_converted_messages": 0,
+        "source_total_messages": 5580,
+        "source_estimated_messages": 0,
+        "rss_delta_bytes": 524288,
+        "heap_delta_bytes": 2968248,
+        "messages": 259,
+        "parts": 259,
+        "toolUses": 43,
+        "toolResults": 43,
+        "placeholders": 43,
+        "stored_id_resolutions": 0,
+        "event_loop_delay_ms": 20.379327999999987,
+        "provenance_tokens_hits": 0,
+        "provenance_tokens_misses": 0,
+        "provenance_tokens_bpe_bytes": 0,
+        "provenance_tokens_bpe_ms": 0,
+        "provenance_tokens_unavailable": 0
+      }
+    },
+    {
+      "sample": 3,
+      "mode": "warm",
+      "sourceMessages": 5580,
+      "preparationMs": 12.655165000000125,
+      "transformMs": 3.7185529999997016,
+      "retainedMessages": 259,
+      "modelMessages": 40,
+      "modelTokens": 1952,
+      "sqlCount": 12,
+      "wireHash": "5836c239cbe7c623052baa5fa8a7e3c8d04b34567edea28e4f45ab4cca14b502",
+      "stages": {
+        "source_validation": {
+          "wallMs": 7.215903000000253,
+          "cpuMs": 7.289
+        },
+        "conversion": {
+          "wallMs": 0.08779200000026322,
+          "cpuMs": 0.084
+        },
+        "temporal_input": {
+          "wallMs": 0.11090599999988626,
+          "cpuMs": 0.105
+        },
+        "provenance": {
+          "wallMs": 0.02343600000040169,
+          "cpuMs": 0.021
+        },
+        "stored_ids": {
+          "wallMs": 0.021261999999296677,
+          "cpuMs": 0.019
+        },
+        "resolve_tools": {
+          "wallMs": 0.18146299999989424,
+          "cpuMs": 0.178
+        },
+        "semantic_total": {
+          "wallMs": 12.44856400000026,
+          "cpuMs": 14.525
+        }
+      },
+      "observations": {
+        "source_checkpoint_hit": 1,
+        "source_converted_messages": 0,
+        "source_total_messages": 5580,
+        "source_estimated_messages": 0,
+        "rss_delta_bytes": 393216,
+        "heap_delta_bytes": 2511176,
+        "messages": 259,
+        "parts": 259,
+        "toolUses": 43,
+        "toolResults": 43,
+        "placeholders": 43,
+        "stored_id_resolutions": 0,
+        "event_loop_delay_ms": 12.611128999999892,
+        "provenance_tokens_hits": 0,
+        "provenance_tokens_misses": 0,
+        "provenance_tokens_bpe_bytes": 0,
+        "provenance_tokens_bpe_ms": 0,
+        "provenance_tokens_unavailable": 0
+      }
+    },
+    {
+      "sample": 3,
+      "mode": "full",
+      "sourceMessages": 5580,
+      "preparationMs": 55.46556799999962,
+      "transformMs": 56.52161700000033,
+      "retainedMessages": 5580,
+      "modelMessages": 40,
+      "modelTokens": 1952,
+      "sqlCount": 21,
+      "wireHash": "5836c239cbe7c623052baa5fa8a7e3c8d04b34567edea28e4f45ab4cca14b502",
+      "stages": {
+        "conversion": {
+          "wallMs": 27.762668999999732,
+          "cpuMs": 27.689
+        },
+        "temporal_input": {
+          "wallMs": 0.14491799999996147,
+          "cpuMs": 0.143
+        },
+        "provenance": {
+          "wallMs": 0.033660999999483465,
+          "cpuMs": 0.032
+        },
+        "stored_ids": {
+          "wallMs": 7.566810999999689,
+          "cpuMs": 7.551
+        },
+        "resolve_tools": {
+          "wallMs": 3.437109999999848,
+          "cpuMs": 3.427
+        },
+        "semantic_total": {
+          "wallMs": 39.97466799999984,
+          "cpuMs": 39.914
+        }
+      },
+      "observations": {
+        "source_converted_messages": 5580,
+        "source_total_messages": 5580,
+        "rss_delta_bytes": 3145728,
+        "heap_delta_bytes": 17252016,
+        "messages": 5580,
+        "parts": 5580,
+        "toolUses": 930,
+        "toolResults": 930,
+        "placeholders": 930,
+        "stored_id_resolutions": 930,
+        "event_loop_delay_ms": 55.36716999999953,
+        "provenance_tokens_hits": 0,
+        "provenance_tokens_misses": 0,
+        "provenance_tokens_bpe_bytes": 0,
+        "provenance_tokens_bpe_ms": 0,
+        "provenance_tokens_unavailable": 0
+      }
+    },
+    {
+      "sample": 3,
+      "mode": "append",
+      "sourceMessages": 5582,
+      "preparationMs": 9.219417999999678,
+      "transformMs": 2.5091440000005605,
+      "retainedMessages": 261,
+      "modelMessages": 41,
+      "modelTokens": 1955,
+      "sqlCount": 12,
+      "wireHash": "4d434d14b92ab6d3d0233250db5399eed49076b97ca9d358b4cb56a646c8c998",
+      "stages": {
+        "source_validation": {
+          "wallMs": 4.644745999999941,
+          "cpuMs": 4.794
+        },
+        "conversion": {
+          "wallMs": 0.08367500000076689,
+          "cpuMs": 0.081
+        },
+        "temporal_input": {
+          "wallMs": 0.05086699999992561,
+          "cpuMs": 0.048
+        },
+        "provenance": {
+          "wallMs": 0.012208000000100583,
+          "cpuMs": 0.012
+        },
+        "stored_ids": {
+          "wallMs": 0.012448999999833177,
+          "cpuMs": 0.012
+        },
+        "resolve_tools": {
+          "wallMs": 0.08102099999996426,
+          "cpuMs": 0.08
+        },
+        "semantic_total": {
+          "wallMs": 9.06032899999991,
+          "cpuMs": 9.253
+        }
+      },
+      "observations": {
+        "source_checkpoint_hit": 1,
+        "source_converted_messages": 2,
+        "source_total_messages": 5582,
+        "source_estimated_messages": 2,
+        "rss_delta_bytes": 262144,
+        "heap_delta_bytes": 2338576,
+        "messages": 261,
+        "parts": 261,
+        "toolUses": 44,
+        "toolResults": 43,
+        "placeholders": 43,
+        "stored_id_resolutions": 0,
+        "event_loop_delay_ms": 9.190695000000233,
+        "provenance_tokens_hits": 0,
+        "provenance_tokens_misses": 0,
+        "provenance_tokens_bpe_bytes": 0,
+        "provenance_tokens_bpe_ms": 0,
+        "provenance_tokens_unavailable": 0
+      }
+    },
+    {
+      "sample": 3,
+      "mode": "full-append",
+      "sourceMessages": 5582,
+      "preparationMs": 34.89986399999998,
+      "transformMs": 49.92643599999974,
+      "retainedMessages": 5582,
+      "modelMessages": 41,
+      "modelTokens": 1955,
+      "sqlCount": 21,
+      "wireHash": "4d434d14b92ab6d3d0233250db5399eed49076b97ca9d358b4cb56a646c8c998",
+      "stages": {
+        "conversion": {
+          "wallMs": 28.072854999999436,
+          "cpuMs": 27.957
+        },
+        "temporal_input": {
+          "wallMs": 0.16222400000060588,
+          "cpuMs": 0.16
+        },
+        "provenance": {
+          "wallMs": 0.0330100000001039,
+          "cpuMs": 0.032
+        },
+        "stored_ids": {
+          "wallMs": 3.6621090000007825,
+          "cpuMs": 4.041
+        },
+        "resolve_tools": {
+          "wallMs": 1.975962000000436,
+          "cpuMs": 1.971
+        },
+        "semantic_total": {
+          "wallMs": 34.77317299999959,
+          "cpuMs": 35.19
+        }
+      },
+      "observations": {
+        "source_converted_messages": 5582,
+        "source_total_messages": 5582,
+        "rss_delta_bytes": 3145728,
+        "heap_delta_bytes": 17258832,
+        "messages": 5582,
+        "parts": 5582,
+        "toolUses": 931,
+        "toolResults": 930,
+        "placeholders": 930,
+        "stored_id_resolutions": 930,
+        "event_loop_delay_ms": 34.86874699999953,
+        "provenance_tokens_hits": 0,
+        "provenance_tokens_misses": 0,
+        "provenance_tokens_bpe_bytes": 0,
+        "provenance_tokens_bpe_ms": 0,
+        "provenance_tokens_unavailable": 0
+      }
+    },
+    {
+      "sample": 4,
+      "mode": "full",
+      "sourceMessages": 5580,
+      "preparationMs": 35.91583300000002,
+      "transformMs": 40.09850399999959,
+      "retainedMessages": 5580,
+      "modelMessages": 40,
+      "modelTokens": 1952,
+      "sqlCount": 21,
+      "wireHash": "5836c239cbe7c623052baa5fa8a7e3c8d04b34567edea28e4f45ab4cca14b502",
+      "stages": {
+        "conversion": {
+          "wallMs": 26.584217000000535,
+          "cpuMs": 26.568
+        },
+        "temporal_input": {
+          "wallMs": 0.14336499999990338,
+          "cpuMs": 0.142
+        },
+        "provenance": {
+          "wallMs": 0.033380000000761356,
+          "cpuMs": 0.033
+        },
+        "stored_ids": {
+          "wallMs": 4.9677019999999175,
+          "cpuMs": 4.582
+        },
+        "resolve_tools": {
+          "wallMs": 3.0871339999994234,
+          "cpuMs": 3.08
+        },
+        "semantic_total": {
+          "wallMs": 35.77927699999964,
+          "cpuMs": 35.397
+        }
+      },
+      "observations": {
+        "source_converted_messages": 5580,
+        "source_total_messages": 5580,
+        "rss_delta_bytes": 3145728,
+        "heap_delta_bytes": 17218024,
+        "messages": 5580,
+        "parts": 5580,
+        "toolUses": 930,
+        "toolResults": 930,
+        "placeholders": 930,
+        "stored_id_resolutions": 930,
+        "event_loop_delay_ms": 35.883152999999766,
+        "provenance_tokens_hits": 0,
+        "provenance_tokens_misses": 0,
+        "provenance_tokens_bpe_bytes": 0,
+        "provenance_tokens_bpe_ms": 0,
+        "provenance_tokens_unavailable": 0
+      }
+    },
+    {
+      "sample": 4,
+      "mode": "warm",
+      "sourceMessages": 5580,
+      "preparationMs": 35.77073500000006,
+      "transformMs": 2.835834999999861,
+      "retainedMessages": 259,
+      "modelMessages": 40,
+      "modelTokens": 1952,
+      "sqlCount": 12,
+      "wireHash": "5836c239cbe7c623052baa5fa8a7e3c8d04b34567edea28e4f45ab4cca14b502",
+      "stages": {
+        "source_validation": {
+          "wallMs": 7.666822000000138,
+          "cpuMs": 7.642
+        },
+        "conversion": {
+          "wallMs": 0.06625999999960186,
+          "cpuMs": 0.064
+        },
+        "temporal_input": {
+          "wallMs": 0.061812999999347085,
+          "cpuMs": 0.058
+        },
+        "provenance": {
+          "wallMs": 0.013559999999415595,
+          "cpuMs": 0.013
+        },
+        "stored_ids": {
+          "wallMs": 0.035073000000011234,
+          "cpuMs": 0.031
+        },
+        "resolve_tools": {
+          "wallMs": 0.1418839999996635,
+          "cpuMs": 0.141
+        },
+        "semantic_total": {
+          "wallMs": 16.318324999999277,
+          "cpuMs": 16.317
+        }
+      },
+      "observations": {
+        "source_checkpoint_hit": 1,
+        "source_converted_messages": 0,
+        "source_total_messages": 5580,
+        "source_estimated_messages": 0,
+        "rss_delta_bytes": 262144,
+        "heap_delta_bytes": 2493200,
+        "messages": 259,
+        "parts": 259,
+        "toolUses": 43,
+        "toolResults": 43,
+        "placeholders": 43,
+        "stored_id_resolutions": 0,
+        "event_loop_delay_ms": 35.70132999999987,
+        "provenance_tokens_hits": 0,
+        "provenance_tokens_misses": 0,
+        "provenance_tokens_bpe_bytes": 0,
+        "provenance_tokens_bpe_ms": 0,
+        "provenance_tokens_unavailable": 0
+      }
+    },
+    {
+      "sample": 4,
+      "mode": "restart",
+      "sourceMessages": 5580,
+      "preparationMs": 12.732852000000094,
+      "transformMs": 2.794463999999607,
+      "retainedMessages": 259,
+      "modelMessages": 40,
+      "modelTokens": 1952,
+      "sqlCount": 12,
+      "wireHash": "5836c239cbe7c623052baa5fa8a7e3c8d04b34567edea28e4f45ab4cca14b502",
+      "stages": {
+        "source_validation": {
+          "wallMs": 3.9554589999997916,
+          "cpuMs": 3.928
+        },
+        "conversion": {
+          "wallMs": 0.048783000000184984,
+          "cpuMs": 0.046
+        },
+        "temporal_input": {
+          "wallMs": 0.040652000000591215,
+          "cpuMs": 0.039
+        },
+        "provenance": {
+          "wallMs": 0.01033599999936996,
+          "cpuMs": 0.009
+        },
+        "stored_ids": {
+          "wallMs": 0.01033499999994092,
+          "cpuMs": 0.009
+        },
+        "resolve_tools": {
+          "wallMs": 0.0788990000000922,
+          "cpuMs": 0.078
+        },
+        "semantic_total": {
+          "wallMs": 12.583337000000029,
+          "cpuMs": 13.049
+        }
+      },
+      "observations": {
+        "source_checkpoint_hit": 1,
+        "source_converted_messages": 0,
+        "source_total_messages": 5580,
+        "source_estimated_messages": 0,
+        "rss_delta_bytes": 393216,
+        "heap_delta_bytes": 2805096,
+        "messages": 259,
+        "parts": 259,
+        "toolUses": 43,
+        "toolResults": 43,
+        "placeholders": 43,
+        "stored_id_resolutions": 0,
+        "event_loop_delay_ms": 12.700832999999875,
+        "provenance_tokens_hits": 0,
+        "provenance_tokens_misses": 0,
+        "provenance_tokens_bpe_bytes": 0,
+        "provenance_tokens_bpe_ms": 0,
+        "provenance_tokens_unavailable": 0
+      }
+    },
+    {
+      "sample": 4,
+      "mode": "full-append",
+      "sourceMessages": 5582,
+      "preparationMs": 37.767086999999265,
+      "transformMs": 36.66147400000045,
+      "retainedMessages": 5582,
+      "modelMessages": 41,
+      "modelTokens": 1955,
+      "sqlCount": 21,
+      "wireHash": "4d434d14b92ab6d3d0233250db5399eed49076b97ca9d358b4cb56a646c8c998",
+      "stages": {
+        "conversion": {
+          "wallMs": 28.053046999999424,
+          "cpuMs": 27.993
+        },
+        "temporal_input": {
+          "wallMs": 0.13342999999986205,
+          "cpuMs": 0.132
+        },
+        "provenance": {
+          "wallMs": 0.037867000000005646,
+          "cpuMs": 0.036
+        },
+        "stored_ids": {
+          "wallMs": 4.660429999999906,
+          "cpuMs": 4.651
+        },
+        "resolve_tools": {
+          "wallMs": 3.577251000000615,
+          "cpuMs": 2.698
+        },
+        "semantic_total": {
+          "wallMs": 37.633827999999994,
+          "cpuMs": 36.713
+        }
+      },
+      "observations": {
+        "source_converted_messages": 5582,
+        "source_total_messages": 5582,
+        "rss_delta_bytes": 3145728,
+        "heap_delta_bytes": 17268248,
+        "messages": 5582,
+        "parts": 5582,
+        "toolUses": 931,
+        "toolResults": 930,
+        "placeholders": 930,
+        "stored_id_resolutions": 930,
+        "event_loop_delay_ms": 37.73818500000016,
+        "provenance_tokens_hits": 0,
+        "provenance_tokens_misses": 0,
+        "provenance_tokens_bpe_bytes": 0,
+        "provenance_tokens_bpe_ms": 0,
+        "provenance_tokens_unavailable": 0
+      }
+    },
+    {
+      "sample": 4,
+      "mode": "append",
+      "sourceMessages": 5582,
+      "preparationMs": 22.06147299999975,
+      "transformMs": 2.3807710000000952,
+      "retainedMessages": 261,
+      "modelMessages": 41,
+      "modelTokens": 1955,
+      "sqlCount": 12,
+      "wireHash": "4d434d14b92ab6d3d0233250db5399eed49076b97ca9d358b4cb56a646c8c998",
+      "stages": {
+        "source_validation": {
+          "wallMs": 5.912373000000116,
+          "cpuMs": 4.694
+        },
+        "conversion": {
+          "wallMs": 0.07892900000024383,
+          "cpuMs": 0.077
+        },
+        "temporal_input": {
+          "wallMs": 0.05426099999931466,
+          "cpuMs": 0.051
+        },
+        "provenance": {
+          "wallMs": 0.011978000000453903,
+          "cpuMs": 0.011
+        },
+        "stored_ids": {
+          "wallMs": 0.012658999999985099,
+          "cpuMs": 0.012
+        },
+        "resolve_tools": {
+          "wallMs": 0.11017600000013772,
+          "cpuMs": 0.109
+        },
+        "semantic_total": {
+          "wallMs": 11.889113999999608,
+          "cpuMs": 10.681
+        }
+      },
+      "observations": {
+        "source_checkpoint_hit": 1,
+        "source_converted_messages": 2,
+        "source_total_messages": 5582,
+        "source_estimated_messages": 2,
+        "rss_delta_bytes": 393216,
+        "heap_delta_bytes": 2523024,
+        "messages": 261,
+        "parts": 261,
+        "toolUses": 44,
+        "toolResults": 43,
+        "placeholders": 43,
+        "stored_id_resolutions": 0,
+        "event_loop_delay_ms": 22.00175399999989,
+        "provenance_tokens_hits": 0,
+        "provenance_tokens_misses": 0,
+        "provenance_tokens_bpe_bytes": 0,
+        "provenance_tokens_bpe_ms": 0,
+        "provenance_tokens_unavailable": 0
+      }
+    }
+  ],
+  "candidate": "980896f942367cd7b9af05ff40572c6c82398960",
+  "base": "ffe04ec6be874daae7105c285be5251b27eef0a7",
+  "measuredDate": "2026-09-08",
+  "notes": "Synthetic completed turns; database reopen in one process; excludes HTTP parsing, LTM/embedding retrieval, upstream inference, and checkpoint finish/publication. Full mode uses the existing full-rebuild path without checkpoint work."
+}

--- a/quality/benchmarks/source-frontier-1710.json
+++ b/quality/benchmarks/source-frontier-1710.json
@@ -1500,5 +1500,5 @@
   "candidate": "980896f942367cd7b9af05ff40572c6c82398960",
   "base": "ffe04ec6be874daae7105c285be5251b27eef0a7",
   "measuredDate": "2026-09-08",
-  "notes": "Synthetic completed turns; database reopen in one process; excludes HTTP parsing, LTM/embedding retrieval, upstream inference, and checkpoint finish/publication. Full mode uses the existing full-rebuild path without checkpoint work."
+  "notes": "Synthetic completed turns; database reopen in one process; excludes HTTP parsing, LTM/embedding retrieval, upstream inference, and checkpoint finish/publication. Full mode uses the existing full-rebuild path without checkpoint work. Full modes execute the retained legacy path in the candidate, not a separate base checkout."
 }

--- a/quality/benchmarks/source-frontier-1710.md
+++ b/quality/benchmarks/source-frontier-1710.md
@@ -1,0 +1,143 @@
+# Durable source frontier and bounded model window (#1710)
+
+Measured 2026-09-08 on Linux, Node 24.19, candidate
+`980896f942367cd7b9af05ff40572c6c82398960`, against the full-rebuild path on
+`ffe04ec6be874daae7105c285be5251b27eef0a7`. Raw samples:
+[source-frontier-1710.json](source-frontier-1710.json) and
+[source-frontier-large-window-1710.json](source-frontier-large-window-1710.json).
+
+## What changes
+
+A successful response now commits a local source checkpoint in the same
+savepoint as its temporal writes. A validated append-only request converts
+only the suffix at its absolute source indexes, restores a bounded unresolved
+raw window and lossless Responses provenance, resolves tools within that window,
+and supplies gradient with the omitted token subtotal and calibration metadata.
+Unchanged resolved token estimates are reused; an appended result refreshes
+any retained call it completes. Existing post-response latest-user/assistant
+storage and pre-v82 identity behavior remain intact.
+
+This checkpoint records accepted normalized input. It is **not** a distillation
+or historical-message ingestion watermark and never marks omitted messages as
+stored, observed, or distilled. A failed response transaction rolls back both
+its temporal writes and checkpoint publication; an interrupted request can
+safely replay its suffix.
+
+Generic clients still need a length-framed SHA-256 pass over the complete
+normalized wire prefix to detect arbitrary earlier edits. HTTP decoding and
+this validation remain O(wire bytes). Semantic object creation, per-message ID
+hashing, provenance BPE, identity lookup, tool pairing and gradient input work
+are suffix/window bounded on a hit. Client head/count headers are not trusted
+as proof of unchanged history. Authenticated client revision hints and streaming
+ingress are separate work; no OpenCode header fast path is introduced here.
+
+## Measurement
+
+The fixture contains 930 completed six-message agentic turns (5,580 messages),
+with distinct read calls/results and no user transcript or network calls.
+A smaller-budget case has 276,338 source tokens and a 1,952-token model window.
+The large case has 1,094,736 source tokens and a 170,167-token model window,
+matching the approximate active-window size in the report. Each mode runs five
+times, alternating the order. All unchanged modes produce identical SHA-256
+hashes of serialized model messages; both appended modes also match exactly.
+
+`restart` closes/reopens SQLite and evicts gradient's in-memory session. It is
+a durable rehydration test in the same process, not a whole-process startup
+benchmark. `warm` retains the open database but uses the same evicted gradient
+state for a fair output comparison. `append` adds a user message and assistant
+tool call. Medians below include only semantic preparation and gradient;
+combined medians are computed per sample, not by adding separate medians.
+
+| Fixture | Mode | Preparation ms | Gradient ms | Combined ms | Active raw messages | Converted messages | SQL statements |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| Small model window | full | 55.47 | 56.52 | 124.33 | 5580 | 5580 | 21 |
+| Small model window | warm | 12.80 | 2.84 | 16.45 | 259 | 0 | 12 |
+| Small model window | restart | 19.00 | 2.79 | 22.15 | 259 | 0 | 12 |
+| Small model window | full-append | 37.77 | 46.81 | 84.83 | 5582 | 5582 | 21 |
+| Small model window | append | 22.06 | 2.51 | 24.44 | 261 | 2 | 12 |
+| 170k model window | full | 54.12 | 167.08 | 230.10 | 5580 | 5580 | 21 |
+| 170k model window | warm | 27.75 | 44.99 | 73.56 | 901 | 0 | 12 |
+| 170k model window | restart | 33.96 | 42.41 | 74.85 | 901 | 0 | 12 |
+| 170k model window | full-append | 48.29 | 145.58 | 192.59 | 5582 | 5582 | 21 |
+| 170k model window | append | 26.59 | 48.76 | 74.83 | 903 | 2 | 12 |
+
+The large-window unchanged/reopened paths take about 74–75 ms combined versus
+230 ms for the already-optimized full rebuild (about 3.1×). The improvement
+is the removal of repeated semantic history work; it is not another 10× claim
+against current main. The original acute costs were addressed by
+[batched temporal preparation](temporal-preparation-1712.md) and
+[durable exact provenance counts](semantic-token-cache-1710.md), whose committed
+measurements already exceed the original order-of-magnitude target. These
+synthetic measurements cannot predict the reported machine's total latency.
+
+Unchanged checkpoint requests convert and newly estimate **zero** messages;
+the appended request converts and newly estimates **two**. The large checkpoint
+retains 901 messages (903 after append) and occupies 136,192 compressed bytes;
+the smaller one retains 259 messages and occupies 49,162 bytes. Total traced SQL
+is 21 on the full path and 12 on the hit path, including gradient's fixed reads.
+Historical placeholder identities are restored from the checkpoint; only new
+suffix placeholders invoke batched resolution.
+
+First population, checkpoint finish/compression/publication, request decoding,
+LTM/embedding retrieval, and model inference are outside the timing table.
+Initial population still rebuilds the full source. CPU/load and GC affect the
+individual samples; raw observations include stage timings and process-wide
+CPU/memory counters. No live-session speed or full-request latency is claimed.
+
+Reproduce from the repository root:
+
+```sh
+LORE_FRONTIER_BENCHMARK=1 LORE_FRONTIER_REPORT=/tmp/frontier.json \
+  pnpm exec vitest run packages/gateway/test/source-window-benchmark.test.ts
+LORE_FRONTIER_BENCHMARK=1 LORE_FRONTIER_LARGE_WINDOW=1 \
+  LORE_FRONTIER_REPORT=/tmp/frontier-large.json \
+  pnpm exec vitest run packages/gateway/test/source-window-benchmark.test.ts
+```
+
+## Bounds and fallback
+
+Schema v87 introduces the disposable, unsynced `source_windows` table. Limits
+are 2,048 retained raw messages, 16 MB uncompressed JSON, 4 MB compressed data,
+32 session rows, 4,096 cumulative prefix counts and a 64 KiB omitted-tool-ID
+Bloom filter. Checkpoints contain private source text/provenance and inherit
+the local database's access controls; they are never included in sync.
+
+The old full path is retained for missing/damaged/version-mismatched state,
+protocol changes, rewinds/compaction/earlier edits, uncertain omitted tool
+boundaries, budget growth beyond the retained window, unavailable calibration
+counts, uninterrupted tool chains, and full-source passthrough. Bloom false
+positives only cost a full reconciliation. Both directions of old tool-ID reuse
+are checked, so a late result or newly reused call cannot silently modify an
+omitted message. Speculative gradient fallback restores session state and
+preserves pending forced-layer requests before replaying the full source.
+
+Publication requires a same-connection, same-tenant generation/revision lease
+claimed under the temporal transaction's writer lock. External temporal source
+edits invalidate the payload. Project/session deletion, project clear/merge,
+amnesia and project/credential rebinding invalidate ownership; source-only
+sessions are covered even before their first temporal row. Canonical paths
+and tenant-scoped worktree aliases remain valid project bindings. No-store
+requests bypass checkpoint persistence.
+
+## Validation and diagnostics
+
+Regression coverage includes 5,580-message warm/reopen suffix conversion,
+real buffered and streamed pipeline resumes, exact full/window wire parity,
+late and parallel tool results/errors, encrypted reasoning/opaque provenance,
+legacy temporal IDs, history edits, corrupt payloads, version/protocol/rewind
+fallback, transaction rollback/retry, competing completions, external writes,
+delete/recreate, project clear/merge/rebind, amnesia, tenant isolation and bounds.
+Review-found cumulative token and ownership defects were reproduced before
+repair. Independent correctness and security reviews exercise mutation guards
+and compare local full-suite failures to the base revision.
+
+`source_validation` adds a bounded-label preparation span. Existing numeric
+Sentry distributions and the serialized `semantic-preparation` log report
+`source_checkpoint_hit`, fixed `source_fallback_*` reasons,
+`source_total_messages`, `source_converted_messages`,
+`source_estimated_messages`, `source_checkpoint_messages`,
+`source_omitted_messages`, and `stored_id_resolutions` alongside stage latency.
+The active message/part/tool counters consistently describe the restored window
+plus suffix. `source_checkpoint_published` is emitted after response storage,
+so it is a Sentry distribution rather than a field in the earlier pre-upstream
+log. Telemetry includes no transcript, provenance, IDs, credentials or paths.

--- a/quality/benchmarks/source-frontier-1710.md
+++ b/quality/benchmarks/source-frontier-1710.md
@@ -1,8 +1,9 @@
 # Durable source frontier and bounded model window (#1710)
 
 Measured 2026-09-08 on Linux, Node 24.19, candidate
-`980896f942367cd7b9af05ff40572c6c82398960`, against the full-rebuild path on
-`ffe04ec6be874daae7105c285be5251b27eef0a7`. Raw samples:
+`980896f942367cd7b9af05ff40572c6c82398960`, using the legacy full-rebuild path retained in the candidate
+(base `ffe04ec6be874daae7105c285be5251b27eef0a7`). The full modes disable
+checkpoint preparation; they do not execute a separate base checkout. Raw samples:
 [source-frontier-1710.json](source-frontier-1710.json) and
 [source-frontier-large-window-1710.json](source-frontier-large-window-1710.json).
 

--- a/quality/benchmarks/source-frontier-large-window-1710.json
+++ b/quality/benchmarks/source-frontier-large-window-1710.json
@@ -1,0 +1,1504 @@
+{
+  "node": "v24.19.0",
+  "fixture": "930 completed six-message turns, with unique read calls/results",
+  "largeWindow": true,
+  "sourceMessages": 5580,
+  "sourceTokens": 1094736,
+  "checkpointBytes": 136192,
+  "runs": [
+    {
+      "sample": 0,
+      "mode": "full",
+      "sourceMessages": 5580,
+      "preparationMs": 63.019123000000036,
+      "transformMs": 167.07898599999953,
+      "retainedMessages": 5580,
+      "modelMessages": 868,
+      "modelTokens": 170167,
+      "sqlCount": 21,
+      "wireHash": "e4f2ba077c75883b01fcc1069d7e94a87bef8ae16b4f293f329a4b879834221d",
+      "stages": {
+        "conversion": {
+          "wallMs": 42.55980499999987,
+          "cpuMs": 51.935
+        },
+        "temporal_input": {
+          "wallMs": 0.22236400000019785,
+          "cpuMs": 1.239
+        },
+        "provenance": {
+          "wallMs": 0.17864800000006653,
+          "cpuMs": 0.174
+        },
+        "stored_ids": {
+          "wallMs": 6.379597000000103,
+          "cpuMs": 9.715
+        },
+        "resolve_tools": {
+          "wallMs": 8.969203000000562,
+          "cpuMs": 16.551
+        },
+        "semantic_total": {
+          "wallMs": 62.23929000000044,
+          "cpuMs": 90.191
+        }
+      },
+      "observations": {
+        "source_converted_messages": 5580,
+        "source_total_messages": 5580,
+        "rss_delta_bytes": 4063232,
+        "heap_delta_bytes": 32664608,
+        "messages": 5580,
+        "parts": 5580,
+        "toolUses": 930,
+        "toolResults": 930,
+        "placeholders": 930,
+        "stored_id_resolutions": 930,
+        "event_loop_delay_ms": 62.91361500000039,
+        "provenance_tokens_hits": 0,
+        "provenance_tokens_misses": 0,
+        "provenance_tokens_bpe_bytes": 0,
+        "provenance_tokens_bpe_ms": 0,
+        "provenance_tokens_unavailable": 0
+      }
+    },
+    {
+      "sample": 0,
+      "mode": "warm",
+      "sourceMessages": 5580,
+      "preparationMs": 27.74925500000063,
+      "transformMs": 39.26323599999978,
+      "retainedMessages": 901,
+      "modelMessages": 868,
+      "modelTokens": 170167,
+      "sqlCount": 12,
+      "wireHash": "e4f2ba077c75883b01fcc1069d7e94a87bef8ae16b4f293f329a4b879834221d",
+      "stages": {
+        "source_validation": {
+          "wallMs": 14.632902999999715,
+          "cpuMs": 17.57
+        },
+        "conversion": {
+          "wallMs": 0.06360600000061822,
+          "cpuMs": 0.06
+        },
+        "temporal_input": {
+          "wallMs": 0.11381099999925937,
+          "cpuMs": 0.108
+        },
+        "provenance": {
+          "wallMs": 0.08173299999998562,
+          "cpuMs": 0.061
+        },
+        "stored_ids": {
+          "wallMs": 0.026691000000027998,
+          "cpuMs": 0.024
+        },
+        "resolve_tools": {
+          "wallMs": 0.4059299999998984,
+          "cpuMs": 0.404
+        },
+        "semantic_total": {
+          "wallMs": 27.336873999999625,
+          "cpuMs": 31.82
+        }
+      },
+      "observations": {
+        "source_checkpoint_hit": 1,
+        "source_converted_messages": 0,
+        "source_total_messages": 5580,
+        "source_estimated_messages": 0,
+        "rss_delta_bytes": 0,
+        "heap_delta_bytes": 12278424,
+        "messages": 901,
+        "parts": 901,
+        "toolUses": 150,
+        "toolResults": 150,
+        "placeholders": 150,
+        "stored_id_resolutions": 0,
+        "event_loop_delay_ms": 27.669073999999455,
+        "provenance_tokens_hits": 0,
+        "provenance_tokens_misses": 0,
+        "provenance_tokens_bpe_bytes": 0,
+        "provenance_tokens_bpe_ms": 0,
+        "provenance_tokens_unavailable": 0
+      }
+    },
+    {
+      "sample": 0,
+      "mode": "restart",
+      "sourceMessages": 5580,
+      "preparationMs": 30.64549199999965,
+      "transformMs": 40.93289800000002,
+      "retainedMessages": 901,
+      "modelMessages": 868,
+      "modelTokens": 170167,
+      "sqlCount": 12,
+      "wireHash": "e4f2ba077c75883b01fcc1069d7e94a87bef8ae16b4f293f329a4b879834221d",
+      "stages": {
+        "source_validation": {
+          "wallMs": 14.437848999999915,
+          "cpuMs": 18.369
+        },
+        "conversion": {
+          "wallMs": 0.0858990000006088,
+          "cpuMs": 0.083
+        },
+        "temporal_input": {
+          "wallMs": 0.06711100000029546,
+          "cpuMs": 0.064
+        },
+        "provenance": {
+          "wallMs": 0.019729999999981374,
+          "cpuMs": 0.019
+        },
+        "stored_ids": {
+          "wallMs": 0.04680999999982305,
+          "cpuMs": 0.046
+        },
+        "resolve_tools": {
+          "wallMs": 0.3857299999999668,
+          "cpuMs": 0.64
+        },
+        "semantic_total": {
+          "wallMs": 30.469507000000704,
+          "cpuMs": 37.09
+        }
+      },
+      "observations": {
+        "source_checkpoint_hit": 1,
+        "source_converted_messages": 0,
+        "source_total_messages": 5580,
+        "source_estimated_messages": 0,
+        "rss_delta_bytes": 131072,
+        "heap_delta_bytes": 12559112,
+        "messages": 901,
+        "parts": 901,
+        "toolUses": 150,
+        "toolResults": 150,
+        "placeholders": 150,
+        "stored_id_resolutions": 0,
+        "event_loop_delay_ms": 30.61005800000021,
+        "provenance_tokens_hits": 0,
+        "provenance_tokens_misses": 0,
+        "provenance_tokens_bpe_bytes": 0,
+        "provenance_tokens_bpe_ms": 0,
+        "provenance_tokens_unavailable": 0
+      }
+    },
+    {
+      "sample": 0,
+      "mode": "full-append",
+      "sourceMessages": 5582,
+      "preparationMs": 51.41818200000034,
+      "transformMs": 137.68436699999984,
+      "retainedMessages": 5582,
+      "modelMessages": 869,
+      "modelTokens": 170168,
+      "sqlCount": 21,
+      "wireHash": "2243eb89e51486047391611a708d4e857a3d6e213fd8b762520a5fe74257cdf7",
+      "stages": {
+        "conversion": {
+          "wallMs": 37.42530199999965,
+          "cpuMs": 40.838
+        },
+        "temporal_input": {
+          "wallMs": 0.1505859999997483,
+          "cpuMs": 0.149
+        },
+        "provenance": {
+          "wallMs": 0.03550300000006246,
+          "cpuMs": 0.035
+        },
+        "stored_ids": {
+          "wallMs": 4.00472499999978,
+          "cpuMs": 3.999
+        },
+        "resolve_tools": {
+          "wallMs": 2.595734999999877,
+          "cpuMs": 2.591
+        },
+        "semantic_total": {
+          "wallMs": 45.23646199999985,
+          "cpuMs": 48.748
+        }
+      },
+      "observations": {
+        "source_converted_messages": 5582,
+        "source_total_messages": 5582,
+        "rss_delta_bytes": 3276800,
+        "heap_delta_bytes": 29851832,
+        "messages": 5582,
+        "parts": 5582,
+        "toolUses": 931,
+        "toolResults": 930,
+        "placeholders": 930,
+        "stored_id_resolutions": 930,
+        "event_loop_delay_ms": 51.34368900000027,
+        "provenance_tokens_hits": 0,
+        "provenance_tokens_misses": 0,
+        "provenance_tokens_bpe_bytes": 0,
+        "provenance_tokens_bpe_ms": 0,
+        "provenance_tokens_unavailable": 0
+      }
+    },
+    {
+      "sample": 0,
+      "mode": "append",
+      "sourceMessages": 5582,
+      "preparationMs": 26.589238999999907,
+      "transformMs": 98.08751699999993,
+      "retainedMessages": 903,
+      "modelMessages": 869,
+      "modelTokens": 170168,
+      "sqlCount": 12,
+      "wireHash": "2243eb89e51486047391611a708d4e857a3d6e213fd8b762520a5fe74257cdf7",
+      "stages": {
+        "source_validation": {
+          "wallMs": 14.644440000000031,
+          "cpuMs": 14.626
+        },
+        "conversion": {
+          "wallMs": 0.10394699999960721,
+          "cpuMs": 0.101
+        },
+        "temporal_input": {
+          "wallMs": 0.08590900000035617,
+          "cpuMs": 0.081
+        },
+        "provenance": {
+          "wallMs": 0.01887799999985873,
+          "cpuMs": 0.018
+        },
+        "stored_ids": {
+          "wallMs": 0.019478999999591906,
+          "cpuMs": 0.018
+        },
+        "resolve_tools": {
+          "wallMs": 0.33382200000050943,
+          "cpuMs": 0.332
+        },
+        "semantic_total": {
+          "wallMs": 25.75397299999986,
+          "cpuMs": 27.759
+        }
+      },
+      "observations": {
+        "source_checkpoint_hit": 1,
+        "source_converted_messages": 2,
+        "source_total_messages": 5582,
+        "source_estimated_messages": 2,
+        "rss_delta_bytes": 0,
+        "heap_delta_bytes": 12030960,
+        "messages": 903,
+        "parts": 903,
+        "toolUses": 151,
+        "toolResults": 150,
+        "placeholders": 150,
+        "stored_id_resolutions": 0,
+        "event_loop_delay_ms": 26.54232899999988,
+        "provenance_tokens_hits": 0,
+        "provenance_tokens_misses": 0,
+        "provenance_tokens_bpe_bytes": 0,
+        "provenance_tokens_bpe_ms": 0,
+        "provenance_tokens_unavailable": 0
+      }
+    },
+    {
+      "sample": 1,
+      "mode": "restart",
+      "sourceMessages": 5580,
+      "preparationMs": 34.758827000000565,
+      "transformMs": 39.642023000000336,
+      "retainedMessages": 901,
+      "modelMessages": 868,
+      "modelTokens": 170167,
+      "sqlCount": 12,
+      "wireHash": "e4f2ba077c75883b01fcc1069d7e94a87bef8ae16b4f293f329a4b879834221d",
+      "stages": {
+        "source_validation": {
+          "wallMs": 15.197390999999698,
+          "cpuMs": 18.42
+        },
+        "conversion": {
+          "wallMs": 0.0810620000002018,
+          "cpuMs": 0.078
+        },
+        "temporal_input": {
+          "wallMs": 0.08905400000003283,
+          "cpuMs": 0.085
+        },
+        "provenance": {
+          "wallMs": 0.017695999999887135,
+          "cpuMs": 0.017
+        },
+        "stored_ids": {
+          "wallMs": 0.0187580000001617,
+          "cpuMs": 0.018
+        },
+        "resolve_tools": {
+          "wallMs": 0.2742130000006,
+          "cpuMs": 0.272
+        },
+        "semantic_total": {
+          "wallMs": 34.54294200000004,
+          "cpuMs": 39.646
+        }
+      },
+      "observations": {
+        "source_checkpoint_hit": 1,
+        "source_converted_messages": 0,
+        "source_total_messages": 5580,
+        "source_estimated_messages": 0,
+        "rss_delta_bytes": 0,
+        "heap_delta_bytes": 12201264,
+        "messages": 901,
+        "parts": 901,
+        "toolUses": 150,
+        "toolResults": 150,
+        "placeholders": 150,
+        "stored_id_resolutions": 0,
+        "event_loop_delay_ms": 34.72502600000007,
+        "provenance_tokens_hits": 0,
+        "provenance_tokens_misses": 0,
+        "provenance_tokens_bpe_bytes": 0,
+        "provenance_tokens_bpe_ms": 0,
+        "provenance_tokens_unavailable": 0
+      }
+    },
+    {
+      "sample": 1,
+      "mode": "warm",
+      "sourceMessages": 5580,
+      "preparationMs": 24.4007959999999,
+      "transformMs": 49.15997900000002,
+      "retainedMessages": 901,
+      "modelMessages": 868,
+      "modelTokens": 170167,
+      "sqlCount": 12,
+      "wireHash": "e4f2ba077c75883b01fcc1069d7e94a87bef8ae16b4f293f329a4b879834221d",
+      "stages": {
+        "source_validation": {
+          "wallMs": 13.948381999999583,
+          "cpuMs": 13.993
+        },
+        "conversion": {
+          "wallMs": 0.05298899999979767,
+          "cpuMs": 0.05
+        },
+        "temporal_input": {
+          "wallMs": 0.0626140000003943,
+          "cpuMs": 0.06
+        },
+        "provenance": {
+          "wallMs": 0.020161000000371132,
+          "cpuMs": 0.019
+        },
+        "stored_ids": {
+          "wallMs": 0.021200999999564374,
+          "cpuMs": 0.02
+        },
+        "resolve_tools": {
+          "wallMs": 0.3082429999994929,
+          "cpuMs": 0.306
+        },
+        "semantic_total": {
+          "wallMs": 24.22980700000062,
+          "cpuMs": 24.58
+        }
+      },
+      "observations": {
+        "source_checkpoint_hit": 1,
+        "source_converted_messages": 0,
+        "source_total_messages": 5580,
+        "source_estimated_messages": 0,
+        "rss_delta_bytes": 0,
+        "heap_delta_bytes": 11897376,
+        "messages": 901,
+        "parts": 901,
+        "toolUses": 150,
+        "toolResults": 150,
+        "placeholders": 150,
+        "stored_id_resolutions": 0,
+        "event_loop_delay_ms": 24.369126999999935,
+        "provenance_tokens_hits": 0,
+        "provenance_tokens_misses": 0,
+        "provenance_tokens_bpe_bytes": 0,
+        "provenance_tokens_bpe_ms": 0,
+        "provenance_tokens_unavailable": 0
+      }
+    },
+    {
+      "sample": 1,
+      "mode": "full",
+      "sourceMessages": 5580,
+      "preparationMs": 51.285227000000305,
+      "transformMs": 137.11492700000053,
+      "retainedMessages": 5580,
+      "modelMessages": 868,
+      "modelTokens": 170167,
+      "sqlCount": 21,
+      "wireHash": "e4f2ba077c75883b01fcc1069d7e94a87bef8ae16b4f293f329a4b879834221d",
+      "stages": {
+        "conversion": {
+          "wallMs": 36.03838199999973,
+          "cpuMs": 44.998
+        },
+        "temporal_input": {
+          "wallMs": 0.15227899999990768,
+          "cpuMs": 0.151
+        },
+        "provenance": {
+          "wallMs": 0.060631000000284985,
+          "cpuMs": 0.059
+        },
+        "stored_ids": {
+          "wallMs": 4.000457000000097,
+          "cpuMs": 3.993
+        },
+        "resolve_tools": {
+          "wallMs": 2.590396999999939,
+          "cpuMs": 3.188
+        },
+        "semantic_total": {
+          "wallMs": 45.67848199999935,
+          "cpuMs": 55.57
+        }
+      },
+      "observations": {
+        "source_converted_messages": 5580,
+        "source_total_messages": 5580,
+        "rss_delta_bytes": 0,
+        "heap_delta_bytes": 28458280,
+        "messages": 5580,
+        "parts": 5580,
+        "toolUses": 930,
+        "toolResults": 930,
+        "placeholders": 930,
+        "stored_id_resolutions": 930,
+        "event_loop_delay_ms": 51.21450999999979,
+        "provenance_tokens_hits": 0,
+        "provenance_tokens_misses": 0,
+        "provenance_tokens_bpe_bytes": 0,
+        "provenance_tokens_bpe_ms": 0,
+        "provenance_tokens_unavailable": 0
+      }
+    },
+    {
+      "sample": 1,
+      "mode": "append",
+      "sourceMessages": 5582,
+      "preparationMs": 28.178635999999642,
+      "transformMs": 37.646631000000525,
+      "retainedMessages": 903,
+      "modelMessages": 869,
+      "modelTokens": 170168,
+      "sqlCount": 12,
+      "wireHash": "2243eb89e51486047391611a708d4e857a3d6e213fd8b762520a5fe74257cdf7",
+      "stages": {
+        "source_validation": {
+          "wallMs": 14.56638600000042,
+          "cpuMs": 19.038
+        },
+        "conversion": {
+          "wallMs": 0.09788800000023912,
+          "cpuMs": 0.095
+        },
+        "temporal_input": {
+          "wallMs": 0.09340100000008533,
+          "cpuMs": 0.089
+        },
+        "provenance": {
+          "wallMs": 0.022092999999586027,
+          "cpuMs": 0.021
+        },
+        "stored_ids": {
+          "wallMs": 0.0320080000001326,
+          "cpuMs": 0.03
+        },
+        "resolve_tools": {
+          "wallMs": 0.28274600000077044,
+          "cpuMs": 0.282
+        },
+        "semantic_total": {
+          "wallMs": 25.987318000000414,
+          "cpuMs": 37.01
+        }
+      },
+      "observations": {
+        "source_checkpoint_hit": 1,
+        "source_converted_messages": 2,
+        "source_total_messages": 5582,
+        "source_estimated_messages": 2,
+        "rss_delta_bytes": 0,
+        "heap_delta_bytes": 11985352,
+        "messages": 903,
+        "parts": 903,
+        "toolUses": 151,
+        "toolResults": 150,
+        "placeholders": 150,
+        "stored_id_resolutions": 0,
+        "event_loop_delay_ms": 28.135991000000104,
+        "provenance_tokens_hits": 0,
+        "provenance_tokens_misses": 0,
+        "provenance_tokens_bpe_bytes": 0,
+        "provenance_tokens_bpe_ms": 0,
+        "provenance_tokens_unavailable": 0
+      }
+    },
+    {
+      "sample": 1,
+      "mode": "full-append",
+      "sourceMessages": 5582,
+      "preparationMs": 48.357144999999946,
+      "transformMs": 137.89051100000052,
+      "retainedMessages": 5582,
+      "modelMessages": 869,
+      "modelTokens": 170168,
+      "sqlCount": 21,
+      "wireHash": "2243eb89e51486047391611a708d4e857a3d6e213fd8b762520a5fe74257cdf7",
+      "stages": {
+        "conversion": {
+          "wallMs": 40.972914999999375,
+          "cpuMs": 46.402
+        },
+        "temporal_input": {
+          "wallMs": 0.13700599999992846,
+          "cpuMs": 0.135
+        },
+        "provenance": {
+          "wallMs": 0.03583299999991141,
+          "cpuMs": 0.034
+        },
+        "stored_ids": {
+          "wallMs": 3.7106329999996888,
+          "cpuMs": 3.705
+        },
+        "resolve_tools": {
+          "wallMs": 1.9756420000003345,
+          "cpuMs": 1.97
+        },
+        "semantic_total": {
+          "wallMs": 48.008450000000266,
+          "cpuMs": 53.452
+        }
+      },
+      "observations": {
+        "source_converted_messages": 5582,
+        "source_total_messages": 5582,
+        "rss_delta_bytes": -917504,
+        "heap_delta_bytes": -34016248,
+        "messages": 5582,
+        "parts": 5582,
+        "toolUses": 931,
+        "toolResults": 930,
+        "placeholders": 930,
+        "stored_id_resolutions": 930,
+        "event_loop_delay_ms": 48.24646800000028,
+        "provenance_tokens_hits": 0,
+        "provenance_tokens_misses": 0,
+        "provenance_tokens_bpe_bytes": 0,
+        "provenance_tokens_bpe_ms": 0,
+        "provenance_tokens_unavailable": 0
+      }
+    },
+    {
+      "sample": 2,
+      "mode": "full",
+      "sourceMessages": 5580,
+      "preparationMs": 42.768747000000076,
+      "transformMs": 137.65976499999942,
+      "retainedMessages": 5580,
+      "modelMessages": 868,
+      "modelTokens": 170167,
+      "sqlCount": 21,
+      "wireHash": "e4f2ba077c75883b01fcc1069d7e94a87bef8ae16b4f293f329a4b879834221d",
+      "stages": {
+        "conversion": {
+          "wallMs": 36.151952000000165,
+          "cpuMs": 37.759
+        },
+        "temporal_input": {
+          "wallMs": 0.13844799999969837,
+          "cpuMs": 0.137
+        },
+        "provenance": {
+          "wallMs": 0.032739000000219676,
+          "cpuMs": 0.032
+        },
+        "stored_ids": {
+          "wallMs": 3.6114529999995284,
+          "cpuMs": 3.606
+        },
+        "resolve_tools": {
+          "wallMs": 1.8028320000003077,
+          "cpuMs": 1.798
+        },
+        "semantic_total": {
+          "wallMs": 42.64448999999968,
+          "cpuMs": 44.281
+        }
+      },
+      "observations": {
+        "source_converted_messages": 5580,
+        "source_total_messages": 5580,
+        "rss_delta_bytes": -393216,
+        "heap_delta_bytes": -38431168,
+        "messages": 5580,
+        "parts": 5580,
+        "toolUses": 930,
+        "toolResults": 930,
+        "placeholders": 930,
+        "stored_id_resolutions": 930,
+        "event_loop_delay_ms": 42.73772099999951,
+        "provenance_tokens_hits": 0,
+        "provenance_tokens_misses": 0,
+        "provenance_tokens_bpe_bytes": 0,
+        "provenance_tokens_bpe_ms": 0,
+        "provenance_tokens_unavailable": 0
+      }
+    },
+    {
+      "sample": 2,
+      "mode": "warm",
+      "sourceMessages": 5580,
+      "preparationMs": 24.490476999999373,
+      "transformMs": 36.418642999999975,
+      "retainedMessages": 901,
+      "modelMessages": 868,
+      "modelTokens": 170167,
+      "sqlCount": 12,
+      "wireHash": "e4f2ba077c75883b01fcc1069d7e94a87bef8ae16b4f293f329a4b879834221d",
+      "stages": {
+        "source_validation": {
+          "wallMs": 14.014265000000705,
+          "cpuMs": 14.001
+        },
+        "conversion": {
+          "wallMs": 0.05697599999984959,
+          "cpuMs": 0.055
+        },
+        "temporal_input": {
+          "wallMs": 0.06700100000034581,
+          "cpuMs": 0.063
+        },
+        "provenance": {
+          "wallMs": 0.014260999999351043,
+          "cpuMs": 0.014
+        },
+        "stored_ids": {
+          "wallMs": 0.015011999999842374,
+          "cpuMs": 0.014
+        },
+        "resolve_tools": {
+          "wallMs": 0.2805719999996654,
+          "cpuMs": 0.279
+        },
+        "semantic_total": {
+          "wallMs": 24.2960750000002,
+          "cpuMs": 24.293
+        }
+      },
+      "observations": {
+        "source_checkpoint_hit": 1,
+        "source_converted_messages": 0,
+        "source_total_messages": 5580,
+        "source_estimated_messages": 0,
+        "rss_delta_bytes": 0,
+        "heap_delta_bytes": 11814976,
+        "messages": 901,
+        "parts": 901,
+        "toolUses": 150,
+        "toolResults": 150,
+        "placeholders": 150,
+        "stored_id_resolutions": 0,
+        "event_loop_delay_ms": 24.439691000000494,
+        "provenance_tokens_hits": 0,
+        "provenance_tokens_misses": 0,
+        "provenance_tokens_bpe_bytes": 0,
+        "provenance_tokens_bpe_ms": 0,
+        "provenance_tokens_unavailable": 0
+      }
+    },
+    {
+      "sample": 2,
+      "mode": "restart",
+      "sourceMessages": 5580,
+      "preparationMs": 32.43641200000002,
+      "transformMs": 42.41215000000011,
+      "retainedMessages": 901,
+      "modelMessages": 868,
+      "modelTokens": 170167,
+      "sqlCount": 12,
+      "wireHash": "e4f2ba077c75883b01fcc1069d7e94a87bef8ae16b4f293f329a4b879834221d",
+      "stages": {
+        "source_validation": {
+          "wallMs": 16.32069500000034,
+          "cpuMs": 20.889
+        },
+        "conversion": {
+          "wallMs": 0.0647370000006049,
+          "cpuMs": 0.062
+        },
+        "temporal_input": {
+          "wallMs": 0.12156299999969633,
+          "cpuMs": 0.205
+        },
+        "provenance": {
+          "wallMs": 0.019007999999303138,
+          "cpuMs": 0.018
+        },
+        "stored_ids": {
+          "wallMs": 0.019560000000637956,
+          "cpuMs": 0.017
+        },
+        "resolve_tools": {
+          "wallMs": 0.2883240000001024,
+          "cpuMs": 0.582
+        },
+        "semantic_total": {
+          "wallMs": 32.27142399999957,
+          "cpuMs": 37.718
+        }
+      },
+      "observations": {
+        "source_checkpoint_hit": 1,
+        "source_converted_messages": 0,
+        "source_total_messages": 5580,
+        "source_estimated_messages": 0,
+        "rss_delta_bytes": -1908736,
+        "heap_delta_bytes": -50200280,
+        "messages": 901,
+        "parts": 901,
+        "toolUses": 150,
+        "toolResults": 150,
+        "placeholders": 150,
+        "stored_id_resolutions": 0,
+        "event_loop_delay_ms": 32.398175000000265,
+        "provenance_tokens_hits": 0,
+        "provenance_tokens_misses": 0,
+        "provenance_tokens_bpe_bytes": 0,
+        "provenance_tokens_bpe_ms": 0,
+        "provenance_tokens_unavailable": 0
+      }
+    },
+    {
+      "sample": 2,
+      "mode": "full-append",
+      "sourceMessages": 5582,
+      "preparationMs": 48.28941399999985,
+      "transformMs": 149.09677699999975,
+      "retainedMessages": 5582,
+      "modelMessages": 869,
+      "modelTokens": 170168,
+      "sqlCount": 21,
+      "wireHash": "2243eb89e51486047391611a708d4e857a3d6e213fd8b762520a5fe74257cdf7",
+      "stages": {
+        "conversion": {
+          "wallMs": 38.53337499999998,
+          "cpuMs": 46.4
+        },
+        "temporal_input": {
+          "wallMs": 0.19915000000037253,
+          "cpuMs": 0.195
+        },
+        "provenance": {
+          "wallMs": 0.04184299999997165,
+          "cpuMs": 0.041
+        },
+        "stored_ids": {
+          "wallMs": 5.069677000000411,
+          "cpuMs": 5.149
+        },
+        "resolve_tools": {
+          "wallMs": 3.2039199999999255,
+          "cpuMs": 3.198
+        },
+        "semantic_total": {
+          "wallMs": 48.15347899999961,
+          "cpuMs": 57.178
+        }
+      },
+      "observations": {
+        "source_converted_messages": 5582,
+        "source_total_messages": 5582,
+        "rss_delta_bytes": -131072,
+        "heap_delta_bytes": -34182976,
+        "messages": 5582,
+        "parts": 5582,
+        "toolUses": 931,
+        "toolResults": 930,
+        "placeholders": 930,
+        "stored_id_resolutions": 930,
+        "event_loop_delay_ms": 48.25654399999985,
+        "provenance_tokens_hits": 0,
+        "provenance_tokens_misses": 0,
+        "provenance_tokens_bpe_bytes": 0,
+        "provenance_tokens_bpe_ms": 0,
+        "provenance_tokens_unavailable": 0
+      }
+    },
+    {
+      "sample": 2,
+      "mode": "append",
+      "sourceMessages": 5582,
+      "preparationMs": 35.041331000000355,
+      "transformMs": 55.06598899999972,
+      "retainedMessages": 903,
+      "modelMessages": 869,
+      "modelTokens": 170168,
+      "sqlCount": 12,
+      "wireHash": "2243eb89e51486047391611a708d4e857a3d6e213fd8b762520a5fe74257cdf7",
+      "stages": {
+        "source_validation": {
+          "wallMs": 17.56742000000031,
+          "cpuMs": 17.545
+        },
+        "conversion": {
+          "wallMs": 0.10300499999993917,
+          "cpuMs": 0.099
+        },
+        "temporal_input": {
+          "wallMs": 0.19082699999944452,
+          "cpuMs": 0.181
+        },
+        "provenance": {
+          "wallMs": 0.03389100000003964,
+          "cpuMs": 0.032
+        },
+        "stored_ids": {
+          "wallMs": 0.03306900000006863,
+          "cpuMs": 0.03
+        },
+        "resolve_tools": {
+          "wallMs": 0.4956959999999526,
+          "cpuMs": 0.491
+        },
+        "semantic_total": {
+          "wallMs": 34.8292220000003,
+          "cpuMs": 34.824
+        }
+      },
+      "observations": {
+        "source_checkpoint_hit": 1,
+        "source_converted_messages": 2,
+        "source_total_messages": 5582,
+        "source_estimated_messages": 2,
+        "rss_delta_bytes": 0,
+        "heap_delta_bytes": 11833496,
+        "messages": 903,
+        "parts": 903,
+        "toolUses": 151,
+        "toolResults": 150,
+        "placeholders": 150,
+        "stored_id_resolutions": 0,
+        "event_loop_delay_ms": 34.998867000000246,
+        "provenance_tokens_hits": 0,
+        "provenance_tokens_misses": 0,
+        "provenance_tokens_bpe_bytes": 0,
+        "provenance_tokens_bpe_ms": 0,
+        "provenance_tokens_unavailable": 0
+      }
+    },
+    {
+      "sample": 3,
+      "mode": "restart",
+      "sourceMessages": 5580,
+      "preparationMs": 38.9180180000003,
+      "transformMs": 44.07497299999977,
+      "retainedMessages": 901,
+      "modelMessages": 868,
+      "modelTokens": 170167,
+      "sqlCount": 12,
+      "wireHash": "e4f2ba077c75883b01fcc1069d7e94a87bef8ae16b4f293f329a4b879834221d",
+      "stages": {
+        "source_validation": {
+          "wallMs": 15.63104199999998,
+          "cpuMs": 15.61
+        },
+        "conversion": {
+          "wallMs": 0.062264000000141095,
+          "cpuMs": 0.061
+        },
+        "temporal_input": {
+          "wallMs": 0.17643499999940104,
+          "cpuMs": 0.124
+        },
+        "provenance": {
+          "wallMs": 0.02646999999979016,
+          "cpuMs": 0.024
+        },
+        "stored_ids": {
+          "wallMs": 0.03159700000014709,
+          "cpuMs": 0.028
+        },
+        "resolve_tools": {
+          "wallMs": 0.45580599999993865,
+          "cpuMs": 0.653
+        },
+        "semantic_total": {
+          "wallMs": 38.66217299999971,
+          "cpuMs": 42.688
+        }
+      },
+      "observations": {
+        "source_checkpoint_hit": 1,
+        "source_converted_messages": 0,
+        "source_total_messages": 5580,
+        "source_estimated_messages": 0,
+        "rss_delta_bytes": -1560576,
+        "heap_delta_bytes": -51279408,
+        "messages": 901,
+        "parts": 901,
+        "toolUses": 150,
+        "toolResults": 150,
+        "placeholders": 150,
+        "stored_id_resolutions": 0,
+        "event_loop_delay_ms": 38.8706259999999,
+        "provenance_tokens_hits": 0,
+        "provenance_tokens_misses": 0,
+        "provenance_tokens_bpe_bytes": 0,
+        "provenance_tokens_bpe_ms": 0,
+        "provenance_tokens_unavailable": 0
+      }
+    },
+    {
+      "sample": 3,
+      "mode": "warm",
+      "sourceMessages": 5580,
+      "preparationMs": 38.359834000000774,
+      "transformMs": 44.985341999999946,
+      "retainedMessages": 901,
+      "modelMessages": 868,
+      "modelTokens": 170167,
+      "sqlCount": 12,
+      "wireHash": "e4f2ba077c75883b01fcc1069d7e94a87bef8ae16b4f293f329a4b879834221d",
+      "stages": {
+        "source_validation": {
+          "wallMs": 21.10106799999994,
+          "cpuMs": 21.076
+        },
+        "conversion": {
+          "wallMs": 0.06530800000018644,
+          "cpuMs": 0.062
+        },
+        "temporal_input": {
+          "wallMs": 0.10412600000017846,
+          "cpuMs": 0.095
+        },
+        "provenance": {
+          "wallMs": 0.0156940000006216,
+          "cpuMs": 0.015
+        },
+        "stored_ids": {
+          "wallMs": 0.017686000000139757,
+          "cpuMs": 0.016
+        },
+        "resolve_tools": {
+          "wallMs": 0.4281440000004295,
+          "cpuMs": 0.425
+        },
+        "semantic_total": {
+          "wallMs": 38.08778400000028,
+          "cpuMs": 41.946
+        }
+      },
+      "observations": {
+        "source_checkpoint_hit": 1,
+        "source_converted_messages": 0,
+        "source_total_messages": 5580,
+        "source_estimated_messages": 0,
+        "rss_delta_bytes": 1814528,
+        "heap_delta_bytes": -48857376,
+        "messages": 901,
+        "parts": 901,
+        "toolUses": 150,
+        "toolResults": 150,
+        "placeholders": 150,
+        "stored_id_resolutions": 0,
+        "event_loop_delay_ms": 38.310529000000315,
+        "provenance_tokens_hits": 0,
+        "provenance_tokens_misses": 0,
+        "provenance_tokens_bpe_bytes": 0,
+        "provenance_tokens_bpe_ms": 0,
+        "provenance_tokens_unavailable": 0
+      }
+    },
+    {
+      "sample": 3,
+      "mode": "full",
+      "sourceMessages": 5580,
+      "preparationMs": 56.31683100000009,
+      "transformMs": 178.88538000000062,
+      "retainedMessages": 5580,
+      "modelMessages": 868,
+      "modelTokens": 170167,
+      "sqlCount": 21,
+      "wireHash": "e4f2ba077c75883b01fcc1069d7e94a87bef8ae16b4f293f329a4b879834221d",
+      "stages": {
+        "conversion": {
+          "wallMs": 47.953096999999616,
+          "cpuMs": 50.121
+        },
+        "temporal_input": {
+          "wallMs": 0.13867799999934505,
+          "cpuMs": 0.138
+        },
+        "provenance": {
+          "wallMs": 0.03242900000077498,
+          "cpuMs": 0.031
+        },
+        "stored_ids": {
+          "wallMs": 3.9766030000000683,
+          "cpuMs": 3.969
+        },
+        "resolve_tools": {
+          "wallMs": 2.931630000000041,
+          "cpuMs": 2.923
+        },
+        "semantic_total": {
+          "wallMs": 56.18243799999982,
+          "cpuMs": 58.52
+        }
+      },
+      "observations": {
+        "source_converted_messages": 5580,
+        "source_total_messages": 5580,
+        "rss_delta_bytes": 6180864,
+        "heap_delta_bytes": -32456448,
+        "messages": 5580,
+        "parts": 5580,
+        "toolUses": 930,
+        "toolResults": 930,
+        "placeholders": 930,
+        "stored_id_resolutions": 930,
+        "event_loop_delay_ms": 56.27928399999928,
+        "provenance_tokens_hits": 0,
+        "provenance_tokens_misses": 0,
+        "provenance_tokens_bpe_bytes": 0,
+        "provenance_tokens_bpe_ms": 0,
+        "provenance_tokens_unavailable": 0
+      }
+    },
+    {
+      "sample": 3,
+      "mode": "append",
+      "sourceMessages": 5582,
+      "preparationMs": 26.06742000000031,
+      "transformMs": 48.76259500000015,
+      "retainedMessages": 903,
+      "modelMessages": 869,
+      "modelTokens": 170168,
+      "sqlCount": 12,
+      "wireHash": "2243eb89e51486047391611a708d4e857a3d6e213fd8b762520a5fe74257cdf7",
+      "stages": {
+        "source_validation": {
+          "wallMs": 14.666987000000518,
+          "cpuMs": 14.646
+        },
+        "conversion": {
+          "wallMs": 0.10786199999984092,
+          "cpuMs": 0.105
+        },
+        "temporal_input": {
+          "wallMs": 0.12287499999911233,
+          "cpuMs": 0.116
+        },
+        "provenance": {
+          "wallMs": 0.015362999999524618,
+          "cpuMs": 0.014
+        },
+        "stored_ids": {
+          "wallMs": 0.016585000000304717,
+          "cpuMs": 0.015
+        },
+        "resolve_tools": {
+          "wallMs": 0.2917090000000826,
+          "cpuMs": 0.29
+        },
+        "semantic_total": {
+          "wallMs": 25.87485000000015,
+          "cpuMs": 26.082
+        }
+      },
+      "observations": {
+        "source_checkpoint_hit": 1,
+        "source_converted_messages": 2,
+        "source_total_messages": 5582,
+        "source_estimated_messages": 2,
+        "rss_delta_bytes": 131072,
+        "heap_delta_bytes": 11835504,
+        "messages": 903,
+        "parts": 903,
+        "toolUses": 151,
+        "toolResults": 150,
+        "placeholders": 150,
+        "stored_id_resolutions": 0,
+        "event_loop_delay_ms": 26.01127600000018,
+        "provenance_tokens_hits": 0,
+        "provenance_tokens_misses": 0,
+        "provenance_tokens_bpe_bytes": 0,
+        "provenance_tokens_bpe_ms": 0,
+        "provenance_tokens_unavailable": 0
+      }
+    },
+    {
+      "sample": 3,
+      "mode": "full-append",
+      "sourceMessages": 5582,
+      "preparationMs": 47.01031899999998,
+      "transformMs": 145.57653500000015,
+      "retainedMessages": 5582,
+      "modelMessages": 869,
+      "modelTokens": 170168,
+      "sqlCount": 21,
+      "wireHash": "2243eb89e51486047391611a708d4e857a3d6e213fd8b762520a5fe74257cdf7",
+      "stages": {
+        "conversion": {
+          "wallMs": 38.83172299999933,
+          "cpuMs": 38.8
+        },
+        "temporal_input": {
+          "wallMs": 0.20149299999957293,
+          "cpuMs": 0.201
+        },
+        "provenance": {
+          "wallMs": 0.0324479999999312,
+          "cpuMs": 0.032
+        },
+        "stored_ids": {
+          "wallMs": 4.307270999999673,
+          "cpuMs": 4.301
+        },
+        "resolve_tools": {
+          "wallMs": 2.4439769999999044,
+          "cpuMs": 2.438
+        },
+        "semantic_total": {
+          "wallMs": 46.88491000000067,
+          "cpuMs": 47.002
+        }
+      },
+      "observations": {
+        "source_converted_messages": 5582,
+        "source_total_messages": 5582,
+        "rss_delta_bytes": 3276800,
+        "heap_delta_bytes": 28063704,
+        "messages": 5582,
+        "parts": 5582,
+        "toolUses": 931,
+        "toolResults": 930,
+        "placeholders": 930,
+        "stored_id_resolutions": 930,
+        "event_loop_delay_ms": 46.97355400000015,
+        "provenance_tokens_hits": 0,
+        "provenance_tokens_misses": 0,
+        "provenance_tokens_bpe_bytes": 0,
+        "provenance_tokens_bpe_ms": 0,
+        "provenance_tokens_unavailable": 0
+      }
+    },
+    {
+      "sample": 4,
+      "mode": "full",
+      "sourceMessages": 5580,
+      "preparationMs": 54.11867399999937,
+      "transformMs": 186.0588830000006,
+      "retainedMessages": 5580,
+      "modelMessages": 868,
+      "modelTokens": 170167,
+      "sqlCount": 21,
+      "wireHash": "e4f2ba077c75883b01fcc1069d7e94a87bef8ae16b4f293f329a4b879834221d",
+      "stages": {
+        "conversion": {
+          "wallMs": 43.8622519999999,
+          "cpuMs": 43.842
+        },
+        "temporal_input": {
+          "wallMs": 0.16175400000065565,
+          "cpuMs": 0.16
+        },
+        "provenance": {
+          "wallMs": 0.041191999999682594,
+          "cpuMs": 0.04
+        },
+        "stored_ids": {
+          "wallMs": 5.6119730000000345,
+          "cpuMs": 5.6
+        },
+        "resolve_tools": {
+          "wallMs": 2.6537029999999504,
+          "cpuMs": 2.648
+        },
+        "semantic_total": {
+          "wallMs": 53.989018000000215,
+          "cpuMs": 53.988
+        }
+      },
+      "observations": {
+        "source_converted_messages": 5580,
+        "source_total_messages": 5580,
+        "rss_delta_bytes": 3276800,
+        "heap_delta_bytes": 28019608,
+        "messages": 5580,
+        "parts": 5580,
+        "toolUses": 930,
+        "toolResults": 930,
+        "placeholders": 930,
+        "stored_id_resolutions": 930,
+        "event_loop_delay_ms": 54.08310000000074,
+        "provenance_tokens_hits": 0,
+        "provenance_tokens_misses": 0,
+        "provenance_tokens_bpe_bytes": 0,
+        "provenance_tokens_bpe_ms": 0,
+        "provenance_tokens_unavailable": 0
+      }
+    },
+    {
+      "sample": 4,
+      "mode": "warm",
+      "sourceMessages": 5580,
+      "preparationMs": 43.5805679999994,
+      "transformMs": 64.20660099999986,
+      "retainedMessages": 901,
+      "modelMessages": 868,
+      "modelTokens": 170167,
+      "sqlCount": 12,
+      "wireHash": "e4f2ba077c75883b01fcc1069d7e94a87bef8ae16b4f293f329a4b879834221d",
+      "stages": {
+        "source_validation": {
+          "wallMs": 24.390357000000222,
+          "cpuMs": 24.722
+        },
+        "conversion": {
+          "wallMs": 0.08503800000016781,
+          "cpuMs": 0.079
+        },
+        "temporal_input": {
+          "wallMs": 0.16504799999984243,
+          "cpuMs": 0.15
+        },
+        "provenance": {
+          "wallMs": 0.027220999999371998,
+          "cpuMs": 0.025
+        },
+        "stored_ids": {
+          "wallMs": 0.035472999999910826,
+          "cpuMs": 0.032
+        },
+        "resolve_tools": {
+          "wallMs": 0.5184099999996761,
+          "cpuMs": 0.514
+        },
+        "semantic_total": {
+          "wallMs": 43.37536,
+          "cpuMs": 44.229
+        }
+      },
+      "observations": {
+        "source_checkpoint_hit": 1,
+        "source_converted_messages": 0,
+        "source_total_messages": 5580,
+        "source_estimated_messages": 0,
+        "rss_delta_bytes": 131072,
+        "heap_delta_bytes": 11893848,
+        "messages": 901,
+        "parts": 901,
+        "toolUses": 150,
+        "toolResults": 150,
+        "placeholders": 150,
+        "stored_id_resolutions": 0,
+        "event_loop_delay_ms": 43.53469000000041,
+        "provenance_tokens_hits": 0,
+        "provenance_tokens_misses": 0,
+        "provenance_tokens_bpe_bytes": 0,
+        "provenance_tokens_bpe_ms": 0,
+        "provenance_tokens_unavailable": 0
+      }
+    },
+    {
+      "sample": 4,
+      "mode": "restart",
+      "sourceMessages": 5580,
+      "preparationMs": 33.961631000000125,
+      "transformMs": 53.6150260000004,
+      "retainedMessages": 901,
+      "modelMessages": 868,
+      "modelTokens": 170167,
+      "sqlCount": 12,
+      "wireHash": "e4f2ba077c75883b01fcc1069d7e94a87bef8ae16b4f293f329a4b879834221d",
+      "stages": {
+        "source_validation": {
+          "wallMs": 14.769471000000522,
+          "cpuMs": 14.79
+        },
+        "conversion": {
+          "wallMs": 0.06623000000035972,
+          "cpuMs": 0.062
+        },
+        "temporal_input": {
+          "wallMs": 0.16426700000010896,
+          "cpuMs": 0.153
+        },
+        "provenance": {
+          "wallMs": 0.01785699999982171,
+          "cpuMs": 0.017
+        },
+        "stored_ids": {
+          "wallMs": 0.061081999999260006,
+          "cpuMs": 0.059
+        },
+        "resolve_tools": {
+          "wallMs": 0.3832270000002609,
+          "cpuMs": 0.381
+        },
+        "semantic_total": {
+          "wallMs": 33.77440999999999,
+          "cpuMs": 35.475
+        }
+      },
+      "observations": {
+        "source_checkpoint_hit": 1,
+        "source_converted_messages": 0,
+        "source_total_messages": 5580,
+        "source_estimated_messages": 0,
+        "rss_delta_bytes": 131072,
+        "heap_delta_bytes": 12127824,
+        "messages": 901,
+        "parts": 901,
+        "toolUses": 150,
+        "toolResults": 150,
+        "placeholders": 150,
+        "stored_id_resolutions": 0,
+        "event_loop_delay_ms": 33.922513000000436,
+        "provenance_tokens_hits": 0,
+        "provenance_tokens_misses": 0,
+        "provenance_tokens_bpe_bytes": 0,
+        "provenance_tokens_bpe_ms": 0,
+        "provenance_tokens_unavailable": 0
+      }
+    },
+    {
+      "sample": 4,
+      "mode": "full-append",
+      "sourceMessages": 5582,
+      "preparationMs": 46.55889000000025,
+      "transformMs": 190.53285400000004,
+      "retainedMessages": 5582,
+      "modelMessages": 869,
+      "modelTokens": 170168,
+      "sqlCount": 21,
+      "wireHash": "2243eb89e51486047391611a708d4e857a3d6e213fd8b762520a5fe74257cdf7",
+      "stages": {
+        "conversion": {
+          "wallMs": 38.31127100000049,
+          "cpuMs": 38.526
+        },
+        "temporal_input": {
+          "wallMs": 0.13389100000040344,
+          "cpuMs": 0.132
+        },
+        "provenance": {
+          "wallMs": 0.03185800000028394,
+          "cpuMs": 0.03
+        },
+        "stored_ids": {
+          "wallMs": 4.114840999999615,
+          "cpuMs": 4.106
+        },
+        "resolve_tools": {
+          "wallMs": 2.5925310000002355,
+          "cpuMs": 2.586
+        },
+        "semantic_total": {
+          "wallMs": 46.43793800000003,
+          "cpuMs": 46.668
+        }
+      },
+      "observations": {
+        "source_converted_messages": 5582,
+        "source_total_messages": 5582,
+        "rss_delta_bytes": 3276800,
+        "heap_delta_bytes": 28058104,
+        "messages": 5582,
+        "parts": 5582,
+        "toolUses": 931,
+        "toolResults": 930,
+        "placeholders": 930,
+        "stored_id_resolutions": 930,
+        "event_loop_delay_ms": 46.52470899999935,
+        "provenance_tokens_hits": 0,
+        "provenance_tokens_misses": 0,
+        "provenance_tokens_bpe_bytes": 0,
+        "provenance_tokens_bpe_ms": 0,
+        "provenance_tokens_unavailable": 0
+      }
+    },
+    {
+      "sample": 4,
+      "mode": "append",
+      "sourceMessages": 5582,
+      "preparationMs": 26.549864999999954,
+      "transformMs": 38.89615000000049,
+      "retainedMessages": 903,
+      "modelMessages": 869,
+      "modelTokens": 170168,
+      "sqlCount": 12,
+      "wireHash": "2243eb89e51486047391611a708d4e857a3d6e213fd8b762520a5fe74257cdf7",
+      "stages": {
+        "source_validation": {
+          "wallMs": 14.711824999999408,
+          "cpuMs": 14.689
+        },
+        "conversion": {
+          "wallMs": 0.1030350000000908,
+          "cpuMs": 0.099
+        },
+        "temporal_input": {
+          "wallMs": 0.10281499999928201,
+          "cpuMs": 0.096
+        },
+        "provenance": {
+          "wallMs": 0.014892000000145345,
+          "cpuMs": 0.014
+        },
+        "stored_ids": {
+          "wallMs": 0.016684999999597494,
+          "cpuMs": 0.016
+        },
+        "resolve_tools": {
+          "wallMs": 0.2999409999993077,
+          "cpuMs": 0.299
+        },
+        "semantic_total": {
+          "wallMs": 26.360230999999658,
+          "cpuMs": 27.404
+        }
+      },
+      "observations": {
+        "source_checkpoint_hit": 1,
+        "source_converted_messages": 2,
+        "source_total_messages": 5582,
+        "source_estimated_messages": 2,
+        "rss_delta_bytes": 131072,
+        "heap_delta_bytes": 11854128,
+        "messages": 903,
+        "parts": 903,
+        "toolUses": 151,
+        "toolResults": 150,
+        "placeholders": 150,
+        "stored_id_resolutions": 0,
+        "event_loop_delay_ms": 26.51706699999977,
+        "provenance_tokens_hits": 0,
+        "provenance_tokens_misses": 0,
+        "provenance_tokens_bpe_bytes": 0,
+        "provenance_tokens_bpe_ms": 0,
+        "provenance_tokens_unavailable": 0
+      }
+    }
+  ],
+  "candidate": "980896f942367cd7b9af05ff40572c6c82398960",
+  "base": "ffe04ec6be874daae7105c285be5251b27eef0a7",
+  "measuredDate": "2026-09-08",
+  "notes": "Synthetic completed turns; database reopen in one process; excludes HTTP parsing, LTM/embedding retrieval, upstream inference, and checkpoint finish/publication. Full mode uses the existing full-rebuild path without checkpoint work."
+}

--- a/quality/benchmarks/source-frontier-large-window-1710.json
+++ b/quality/benchmarks/source-frontier-large-window-1710.json
@@ -1500,5 +1500,5 @@
   "candidate": "980896f942367cd7b9af05ff40572c6c82398960",
   "base": "ffe04ec6be874daae7105c285be5251b27eef0a7",
   "measuredDate": "2026-09-08",
-  "notes": "Synthetic completed turns; database reopen in one process; excludes HTTP parsing, LTM/embedding retrieval, upstream inference, and checkpoint finish/publication. Full mode uses the existing full-rebuild path without checkpoint work."
+  "notes": "Synthetic completed turns; database reopen in one process; excludes HTTP parsing, LTM/embedding retrieval, upstream inference, and checkpoint finish/publication. Full mode uses the existing full-rebuild path without checkpoint work. Full modes execute the retained legacy path in the candidate, not a separate base checkout."
 }


### PR DESCRIPTION
Long resumed sessions still rebuild the complete semantic transcript after the earlier batching and provenance-token fixes. This PR persists an accepted source frontier and a bounded raw window, so unchanged resumes convert no historical messages and appended turns convert only their suffix.

- Restore stable source indexes, legacy temporal identities, lossless Responses provenance, pending tools and token/calibration metadata after restart.
- Keep full-prefix wire validation for generic clients and use the full rebuild when history, protocol, ownership, tool boundaries, calibration or window bounds are uncertain.
- Publish the checkpoint in the response temporal savepoint, with generation/revision checks and project/session/tenant lifecycle invalidation. Checkpoints are bounded, local and excluded from sync.
- Add numeric hit/fallback/window telemetry and committed benchmark samples.

On the 5,580-message synthetic fixture with a roughly 170,000-token model window, preparation plus gradient takes about **75 ms after database reopen versus 230 ms for the current full rebuild**. Both paths produce identical serialized model messages. Appending two messages converts and newly estimates only those two. This comparison excludes HTTP parsing, LTM/embedding retrieval and upstream inference; reopen is in the same process. Generic validation remains O(wire bytes).

See [benchmark report](https://github.com/BYK/loreai/blob/fix/durable-source-frontier/quality/benchmarks/source-frontier-1710.md) for samples, limits and reproduction.

Validation:
- **Independent correctness and security reviews are complete; all findings are resolved.** Both conclude MERGE subject to hosted gates.
- Typecheck, lint, formatting and gateway bundle pass. Combined focused run before the Seer follow-up: **65 passed, one opt-in benchmark skipped**. The offset-zero follow-up passes **39 affected tests, one benchmark skipped**. Separate final affected runs: correctness 324 passed, security 306 passed.
- Both reviewers ran the full suite on the initial candidate: **9,928 passed, 229 skipped, nine failures**. Seven failures were reproduced on the base/environment (installer ps/proc, compact endpoint, optional CUDA asset, cache-stability); the other two were stale schema-version assertions fixed and retested here. This is not a claim of a green final hosted full suite.
- Ten consecutive sync-property runs passed independently in each review. Mutation checks catch history/tool-boundary/revision defects, pinned/plain/nuclear exhaustion, stale cumulative and changed-call estimates, and ownership/no-store/decompression guards.
- A 40-scenario gradient parity battery and a database-reopen regression preserve canonical recall results, distillation context and durable knowledge deltas exactly. Real buffered and streamed pipeline resumes also pass.
- Final published head: `450f1c90bea07f546fc897f17acc012bb2bdeaf4`; tree `ee325ecf012c2828c0bf36fb0d4538213eb4b675` matches the clean locally verified tree. The implementation and subsequent behavior-preserving offset-zero clarification/tests were independently reviewed.
- Seer's offset-zero finding was independently verified as a false positive and resolved with four new regressions, explicit comments and an equivalent positive-offset predicate. Applying the suggested change fails encrypted-provenance tests; changing the related force guard fails durable-escalation tests.
- Hosted CI and Seer are rerunning on the final head.

Fixes #1710