### PR TITLE
fix(core): move startup vector orphan discovery to idle read workers

### DIFF
--- a/packages/core/src/db/vec-store.ts
+++ b/packages/core/src/db/vec-store.ts
@@ -690,8 +690,9 @@ const ALL_EMBEDDING_TABLES: readonly EmbeddingTable[] = [
  * rows. These rows are already HARMLESS for correctness (recall hydration drops
  * a hit whose base row is missing, and a deleted project's rows live in their
  * own partition), so this is a bloat / recall-quality backstop, not a fix. Runs
- * at startup in vec0 mode (all tables) and after a bulk base-row delete (scoped
- * to the tables that delete touched — see `data.ts`). One bounded anti-join pass
+ * only after an explicit bulk base-row delete (scoped to the tables that delete
+ * touched — see `data.ts`). Startup uses idle read-worker maintenance instead.
+ * One full anti-join pass
  * per requested table; each is a single scan (cheaper than a per-id delete on
  * the un-indexed `temporal_vec.message_id` aux column for large id sets).
  */

--- a/packages/core/src/embedding.ts
+++ b/packages/core/src/embedding.ts
@@ -33,7 +33,6 @@ import {
   type EmbeddingTable,
   embeddingColumnExists,
   ensureVec0Store,
-  gcVec0DanglingRows,
   hasEmbeddingSql,
   missingEmbeddingSql,
   readStorageMode,
@@ -3458,9 +3457,8 @@ export async function runStartupBackfill(
     };
   }
 
-  // Startup backstop: reclaim vec0 rows orphaned by bulk base-row deletes
-  // (project/session/prune) since the last run. Harmless if there are none.
-  if (mode === "vec0") gcVec0DanglingRows(db());
+  // Orphan discovery belongs to the host's idle read-worker maintenance.
+  // Never scan the full vector corpus on the startup writer (#1681).
 
   // Coverage stats — always log to stderr so the problem is visible.
   const kTotal = (

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -103,6 +103,7 @@ export {
 export { dataDir } from "./data-dir";
 export { currentTenantId, withTenant, LOCAL_TENANT_ID } from "./tenant";
 export { isVecAvailable } from "./db/vec";
+export { startVec0OrphanMaintenance } from "./vec0-orphan-maintenance";
 export {
   checkVecWorker,
   type VecWorkerCheck,

--- a/packages/core/src/vec0-orphan-maintenance.ts
+++ b/packages/core/src/vec0-orphan-maintenance.ts
@@ -1,0 +1,135 @@
+/** Idle, bounded vec0 garbage collection. Never fall back to a writer scan. */
+import { db, isCurrentDatabase } from "./db";
+import { isVecAvailable } from "./db/vec";
+import { readStorageMode } from "./db/vec-store";
+import { READ_JOB_TIMED_OUT, tryPoolRead } from "./vector-pool";
+
+const TABLES = [
+  { vec: "knowledge_vec", key: "id", source: "id", base: "knowledge_current" },
+  { vec: "entity_vec", key: "id", source: "id", base: "entities" },
+  { vec: "distillation_vec", key: "id", source: "id", base: "distillations" },
+  {
+    vec: "temporal_vec",
+    key: "chunk_id",
+    source: "message_id",
+    base: "temporal_messages",
+  },
+] as const;
+
+export const VEC0_ORPHAN_PAGE_SIZE = 128;
+const PAGE_INTERVAL_MS = 1000;
+const RETRY_INTERVAL_MS = 30_000;
+const SWEEP_INTERVAL_MS = 60 * 60 * 1000;
+
+interface Row {
+  cursor: number;
+  id: string;
+  orphan: number;
+}
+
+/**
+ * The host owns this service and must stop it before closing storage. A stop
+ * fences late worker results; neither those results nor a timer can reopen DB.
+ * One page is in flight at a time, and foreground activity gates both its read
+ * and its deletes. An unavailable worker leaves harmless orphans for a retry.
+ */
+export function startVec0OrphanMaintenance(
+  shouldPause: () => boolean,
+): () => void {
+  const connection = db();
+  let stopped = false;
+  let tableIndex = 0;
+  let cursor = 0;
+  let timer: ReturnType<typeof setTimeout>;
+  const current = () => !stopped && isCurrentDatabase(connection);
+  const schedule = (delay: number) => {
+    if (!current()) return;
+    timer = setTimeout(() => {
+      void tick();
+    }, delay);
+    timer.unref?.();
+  };
+  const tick = async () => {
+    let delay = PAGE_INTERVAL_MS;
+    try {
+      if (!current()) return;
+      if (shouldPause()) return;
+      if (!isVecAvailable() || readStorageMode(connection) !== "vec0") {
+        delay = RETRY_INTERVAL_MS;
+        return;
+      }
+      const table = TABLES[tableIndex];
+      // vec0's text-key shadow index supplies an indexed rowid cursor. Reading
+      // shadow metadata is safe; all writes go through the virtual table API.
+      // Materialize BEFORE testing liveness: LIMIT on orphan matches alone
+      // would still walk an entire healthy corpus. No vectors cross the RPC.
+      const result = await tryPoolRead({
+        sql: `WITH page AS MATERIALIZED (
+          SELECT rowid AS cursor, id FROM ${table.vec}_rowids
+          WHERE rowid > ? ORDER BY rowid LIMIT ?
+        ) SELECT page.cursor, page.id,
+          NOT EXISTS (SELECT 1 FROM ${table.base} b WHERE b.id = v.${table.source}) AS orphan
+          FROM page CROSS JOIN ${table.vec} v ON v.${table.key} = page.id
+          ORDER BY page.cursor`,
+        params: [cursor, VEC0_ORPHAN_PAGE_SIZE],
+        mode: "all",
+      });
+      if (!current()) return;
+      if (!result || result === READ_JOB_TIMED_OUT) {
+        delay = RETRY_INTERVAL_MS;
+        return;
+      }
+      if (shouldPause()) return; // replay this small page after traffic settles
+      const rows = result.rows as Row[];
+      // Bound the writer lock to one small page. The liveness check uses the
+      // CURRENT vector source, not the reader's snapshot: delete/recreate and
+      // a restored base row must survive. The equality selects the exact key.
+      const busyTimeout = (
+        connection.query("PRAGMA busy_timeout").get() as { timeout: number }
+      ).timeout;
+      connection.exec("PRAGMA busy_timeout = 0");
+      try {
+        connection.exec("SAVEPOINT vec0_idle_gc");
+        try {
+          for (const row of rows) {
+            if (row.orphan) {
+              connection
+                .query(`DELETE FROM ${table.vec} WHERE ${table.key} = ?
+              AND NOT EXISTS (SELECT 1 FROM ${table.base} b
+                WHERE b.id = ${table.vec}.${table.source})`)
+                .run(row.id);
+            }
+          }
+          connection.exec("RELEASE vec0_idle_gc");
+        } catch (error) {
+          connection.exec("ROLLBACK TO vec0_idle_gc");
+          connection.exec("RELEASE vec0_idle_gc");
+          throw error;
+        }
+      } finally {
+        connection.exec(`PRAGMA busy_timeout = ${busyTimeout}`);
+      }
+      if (rows.length < VEC0_ORPHAN_PAGE_SIZE) {
+        cursor = 0;
+        tableIndex++;
+        if (tableIndex === TABLES.length) {
+          tableIndex = 0;
+          delay = SWEEP_INTERVAL_MS;
+        }
+      } else {
+        cursor = rows[rows.length - 1].cursor;
+      }
+    } catch {
+      // Best-effort derived index maintenance. Do not expose raw SQL/row data
+      // to diagnostics, and do not turn worker/schema failures into scan loops.
+      delay = RETRY_INTERVAL_MS;
+    } finally {
+      schedule(delay);
+    }
+  };
+  schedule(PAGE_INTERVAL_MS);
+  return () => {
+    stopped = true;
+    clearTimeout(timer);
+  };
+}

--- a/packages/core/test/vec0-cutover.test.ts
+++ b/packages/core/test/vec0-cutover.test.ts
@@ -232,6 +232,24 @@ db();
 const describeVec = isVecAvailable() ? describe : describe.skip;
 
 describeVec("vec0 write + read round-trip", () => {
+  test("converged startup leaves orphan discovery to idle maintenance (#1681)", async () => {
+    setStorageMode(db(), "vec0");
+    ensureVec0Store(db(), DIM);
+    db()
+      .query("INSERT INTO knowledge_vec (id, embedding) VALUES (?, ?)")
+      .run("orphan", toBlob(v(1)));
+    const token = _saveAndClearProvider();
+    _restoreProvider({ provider: { maxBatchSize: 8, embed: vi.fn() } });
+    try {
+      await runStartupBackfill();
+      expect(
+        db().query("SELECT id FROM knowledge_vec WHERE id = ?").get("orphan"),
+      ).toBeTruthy();
+    } finally {
+      _restoreProvider(token);
+    }
+  });
+
   test("storeEmbedding writes to the vec0 table (not the base column)", () => {
     setStorageMode(db(), "vec0");
     ensureVec0Store(db(), DIM);

--- a/packages/core/test/vec0-orphan-maintenance.test.ts
+++ b/packages/core/test/vec0-orphan-maintenance.test.ts
@@ -1,0 +1,266 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { close, db, ensureProject } from "../src/db";
+import { isVecAvailable } from "../src/db/vec";
+import { ensureVec0Store, setStorageMode } from "../src/db/vec-store";
+import { toBlob } from "../src/vector-query";
+import { Worker } from "node:worker_threads";
+import { resolve } from "node:path";
+import * as log from "../src/log";
+import * as pool from "../src/vector-pool";
+import {
+  startVec0OrphanMaintenance,
+  VEC0_ORPHAN_PAGE_SIZE,
+} from "../src/vec0-orphan-maintenance";
+
+db();
+const describeVec = isVecAvailable() ? describe : describe.skip;
+let stop: (() => void) | undefined;
+let pid: string;
+let beforeReply: (() => void) | undefined;
+const specs: string[] = [];
+const blob = toBlob(new Float32Array([1, 0, 0, 0]));
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  pid = ensureProject("/test/orphan-maintenance");
+  db().query("DELETE FROM temporal_messages WHERE project_id = ?").run(pid);
+  for (const table of [
+    "knowledge_vec",
+    "entity_vec",
+    "distillation_vec",
+    "temporal_vec",
+  ])
+    db().exec(`DROP TABLE IF EXISTS ${table}`);
+  ensureVec0Store(db(), 4);
+  setStorageMode(db(), "vec0");
+  specs.length = 0;
+  beforeReply = undefined;
+  // Execute the actual read SQL against the native extension. Separate tests
+  // exercise the real worker seam; this seam controls races after its snapshot.
+  vi.spyOn(pool, "tryPoolRead").mockImplementation(async (spec) => {
+    specs.push(spec.sql);
+    const rows = db()
+      .query(spec.sql)
+      .all(...spec.params);
+    beforeReply?.();
+    beforeReply = undefined;
+    return { rows };
+  });
+});
+afterEach(() => {
+  stop?.();
+  stop = undefined;
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+  log.registerSink({ info() {}, warn() {}, error() {}, captureException() {} });
+  pool._setTestVectorWorkerFactory(null);
+  pool._resetVectorPoolForTest();
+  close();
+});
+
+function temporal(id: string, source = id) {
+  db()
+    .query(
+      "INSERT INTO temporal_vec (chunk_id, message_id, session_id, project_id, embedding) VALUES (?, ?, 's', ?, ?)",
+    )
+    .run(id, source, pid, blob);
+}
+function base(id: string) {
+  db()
+    .query(
+      "INSERT INTO temporal_messages (id, project_id, session_id, role, content, tokens, created_at) VALUES (?, ?, 's', 'user', 'x', 1, 1)",
+    )
+    .run(id, pid);
+}
+function keys() {
+  return db()
+    .query("SELECT chunk_id FROM temporal_vec ORDER BY chunk_id")
+    .all();
+}
+
+describeVec("idle vec0 orphan maintenance", () => {
+  it("executes discovery on the bundled native read worker", async () => {
+    vi.useRealTimers();
+    vi.mocked(pool.tryPoolRead).mockRestore();
+    pool._setTestVectorWorkerFactory(
+      (init) =>
+        new Worker(resolve("packages/gateway/dist/vector-worker.cjs"), {
+          workerData: init,
+        }),
+    );
+    db()
+      .query("INSERT INTO knowledge_vec (id, embedding) VALUES (?, ?)")
+      .run("worker-orphan", blob);
+    stop = startVec0OrphanMaintenance(() => false);
+    await vi.waitFor(
+      () => {
+        expect(
+          db()
+            .query("SELECT id FROM knowledge_vec WHERE id = ?")
+            .get("worker-orphan"),
+        ).toBeNull();
+      },
+      { timeout: 10_000, interval: 25 },
+    );
+  });
+
+  it.each([
+    [
+      "knowledge_vec",
+      "INSERT INTO knowledge_vec (id, embedding) VALUES (?, ?)",
+      ["orphan", blob],
+    ],
+    [
+      "entity_vec",
+      "INSERT INTO entity_vec (id, embedding) VALUES (?, ?)",
+      ["orphan", blob],
+    ],
+    [
+      "distillation_vec",
+      "INSERT INTO distillation_vec (id, project_id, session_id, embedding) VALUES (?, 'p', 's', ?)",
+      ["orphan", blob],
+    ],
+  ] as const)("covers the %s registry member", async (table, sql, params) => {
+    db()
+      .query(sql)
+      .run(...params);
+    stop = startVec0OrphanMaintenance(() => false);
+    await vi.advanceTimersByTimeAsync(4000);
+    expect(db().query(`SELECT id FROM ${table}`).all()).toEqual([]);
+  });
+
+  it("uses an indexed page cursor and exact-key vector lookup", async () => {
+    temporal("orphan");
+    stop = startVec0OrphanMaintenance(() => false);
+    await vi.advanceTimersByTimeAsync(4000);
+    const plan = db()
+      .query(`EXPLAIN QUERY PLAN ${specs[3]}`)
+      .all(0, VEC0_ORPHAN_PAGE_SIZE) as { detail: string }[];
+    expect(plan.map((row) => row.detail).join("\n")).toContain(
+      "SEARCH temporal_vec_rowids USING INTEGER PRIMARY KEY (rowid>?)",
+    );
+    // sqlite-vec's exact text-primary-key lookup is the 3 plan. The fullscan
+    // plan would rescan the virtual table once per candidate.
+    expect(plan.map((row) => row.detail).join("\n")).toMatch(
+      /SCAN v VIRTUAL TABLE INDEX 3:/,
+    );
+  });
+
+  it("does not busy-wait on the writer and restores the caller's timeout", async () => {
+    temporal("orphan");
+    db().exec("PRAGMA busy_timeout = 1234");
+    const observed: number[] = [];
+    log.registerSink({
+      info() {},
+      warn() {},
+      error() {},
+      captureException() {},
+      withDbSpan(sql, fn) {
+        if (sql.startsWith("DELETE FROM temporal_vec WHERE")) {
+          const timeout = db().query("PRAGMA busy_timeout").get() as {
+            timeout: number;
+          };
+          observed.push(timeout.timeout);
+        }
+        return fn();
+      },
+    });
+    stop = startVec0OrphanMaintenance(() => false);
+    await vi.advanceTimersByTimeAsync(4000);
+    expect(observed).toEqual([0]);
+    expect(db().query("PRAGMA busy_timeout").get()).toEqual({ timeout: 1234 });
+  });
+
+  it("deletes dangling exact chunk IDs while retaining backed chunks", async () => {
+    base("live");
+    temporal("live#0", "live");
+    temporal("live#1", "live");
+    temporal("old#0", "old");
+    temporal("old#1", "old");
+    stop = startVec0OrphanMaintenance(() => false);
+    await vi.advanceTimersByTimeAsync(4000);
+    expect(keys()).toEqual([{ chunk_id: "live#0" }, { chunk_id: "live#1" }]);
+    expect(specs).toHaveLength(4);
+  });
+
+  it("advances bounded pages through healthy rows before later orphans", async () => {
+    base("live");
+    for (let i = 0; i < VEC0_ORPHAN_PAGE_SIZE + 1; i++)
+      temporal(`live#${i}`, "live");
+    temporal("orphan");
+    stop = startVec0OrphanMaintenance(() => false);
+    await vi.advanceTimersByTimeAsync(4000);
+    expect(keys()).toHaveLength(VEC0_ORPHAN_PAGE_SIZE + 2);
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(keys()).toHaveLength(VEC0_ORPHAN_PAGE_SIZE + 1);
+    expect(specs).toHaveLength(5);
+  });
+
+  it("rechecks a source restored after the worker snapshot", async () => {
+    temporal("restored#0", "restored");
+    stop = startVec0OrphanMaintenance(() => false);
+    await vi.advanceTimersByTimeAsync(3000);
+    beforeReply = () => base("restored");
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(keys()).toEqual([{ chunk_id: "restored#0" }]);
+  });
+
+  it("rechecks a chunk replaced with a different live source", async () => {
+    base("live");
+    temporal("replaced", "missing");
+    stop = startVec0OrphanMaintenance(() => false);
+    await vi.advanceTimersByTimeAsync(3000);
+    beforeReply = () => {
+      db().query("DELETE FROM temporal_vec WHERE chunk_id = ?").run("replaced");
+      temporal("replaced", "live");
+    };
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(keys()).toEqual([{ chunk_id: "replaced" }]);
+  });
+
+  it.each([null, pool.READ_JOB_TIMED_OUT] as const)(
+    "backs off unavailable/timed out reads without a synchronous scan: %s",
+    async (result) => {
+      vi.mocked(pool.tryPoolRead).mockResolvedValue(result);
+      temporal("orphan");
+      stop = startVec0OrphanMaintenance(() => false);
+      await vi.advanceTimersByTimeAsync(30_000);
+      expect(pool.tryPoolRead).toHaveBeenCalledTimes(1);
+      expect(keys()).toHaveLength(1);
+    },
+  );
+
+  it("pauses reads and replays a page if foreground work starts during the read", async () => {
+    temporal("orphan");
+    let paused = true;
+    stop = startVec0OrphanMaintenance(() => paused);
+    await vi.advanceTimersByTimeAsync(4000);
+    expect(specs).toHaveLength(0);
+    paused = false;
+    await vi.advanceTimersByTimeAsync(3000);
+    beforeReply = () => {
+      paused = true;
+    };
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(keys()).toHaveLength(1);
+    paused = false;
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(keys()).toHaveLength(0);
+  });
+
+  it.each(["stop", "reopen"])("ignores a late page after %s", async (event) => {
+    temporal("orphan");
+    stop = startVec0OrphanMaintenance(() => false);
+    await vi.advanceTimersByTimeAsync(3000);
+    beforeReply = () => {
+      if (event === "stop") stop!();
+      else {
+        close();
+        db();
+      }
+    };
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(keys()).toHaveLength(1);
+    expect(specs).toHaveLength(4);
+  });
+});

--- a/packages/core/test/vec0-orphan-maintenance.test.ts
+++ b/packages/core/test/vec0-orphan-maintenance.test.ts
@@ -1,10 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { close, db, ensureProject } from "../src/db";
+import { close, db, dbPath, ensureProject } from "../src/db";
 import { isVecAvailable } from "../src/db/vec";
 import { ensureVec0Store, setStorageMode } from "../src/db/vec-store";
 import { toBlob } from "../src/vector-query";
 import { Worker } from "node:worker_threads";
+import { DatabaseSync } from "node:sqlite";
 import { resolve } from "node:path";
+import { withTenant } from "../src/tenant";
 import * as log from "../src/log";
 import * as pool from "../src/vector-pool";
 import {
@@ -79,6 +81,34 @@ function keys() {
 }
 
 describeVec("idle vec0 orphan maintenance", () => {
+  it("rolls back a partly deleted page and retries without advancing", async () => {
+    temporal("first-orphan");
+    temporal("second-orphan");
+    db().exec("PRAGMA busy_timeout = 5678");
+    let deletes = 0;
+    log.registerSink({
+      info() {},
+      warn() {},
+      error() {},
+      captureException() {},
+      withDbSpan(sql, fn) {
+        if (sql.startsWith("DELETE FROM temporal_vec WHERE") && ++deletes === 2)
+          throw new Error("second delete rejected");
+        return fn();
+      },
+    });
+    stop = startVec0OrphanMaintenance(() => false);
+    await vi.advanceTimersByTimeAsync(4000);
+    expect(keys()).toEqual([
+      { chunk_id: "first-orphan" },
+      { chunk_id: "second-orphan" },
+    ]);
+    expect(db().query("PRAGMA busy_timeout").get()).toEqual({ timeout: 5678 });
+    await vi.advanceTimersByTimeAsync(30000);
+    expect(keys()).toEqual([]);
+    expect(specs).toHaveLength(5);
+  });
+
   it("executes discovery on the bundled native read worker", async () => {
     vi.useRealTimers();
     vi.mocked(pool.tryPoolRead).mockRestore();
@@ -216,6 +246,117 @@ describeVec("idle vec0 orphan maintenance", () => {
     };
     await vi.advanceTimersByTimeAsync(1000);
     expect(keys()).toEqual([{ chunk_id: "replaced" }]);
+  });
+
+  it("retains current knowledge across tenants while pruning deleted and historical vectors", async () => {
+    for (const [id, current, deleted, tenant] of [
+      ["current-local", 1, 0, ""],
+      ["current-other", 1, 0, "tenant-b"],
+      ["old-version", 0, 0, "tenant-b"],
+      ["deleted", 1, 1, "tenant-c"],
+    ] as const) {
+      db()
+        .query(
+          "INSERT INTO knowledge (id, project_id, category, title, content, created_at, updated_at, logical_id, is_current, is_deleted, tenant_id) VALUES (?, ?, 'test', '', '', 1, 1, ?, ?, ?, ?)",
+        )
+        .run(id, pid, id, current, deleted, tenant);
+      db()
+        .query("INSERT INTO knowledge_vec (id, embedding) VALUES (?, ?)")
+        .run(id, blob);
+    }
+    stop = withTenant("tenant-a", () =>
+      startVec0OrphanMaintenance(() => false),
+    );
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(
+      db().query("SELECT id FROM knowledge_vec ORDER BY id").all(),
+    ).toEqual([{ id: "current-local" }, { id: "current-other" }]);
+    expect(
+      db()
+        .query("SELECT COUNT(*) AS n FROM knowledge WHERE project_id = ?")
+        .get(pid),
+    ).toEqual({ n: 4 });
+  });
+
+  it("rechecks a knowledge tombstone restored after the worker snapshot", async () => {
+    db()
+      .query(
+        "INSERT INTO knowledge (id, project_id, category, title, content, created_at, updated_at, logical_id, is_deleted) VALUES ('restored', ?, 'test', '', '', 1, 1, 'restored', 1)",
+      )
+      .run(pid);
+    db()
+      .query("INSERT INTO knowledge_vec (id, embedding) VALUES (?, ?)")
+      .run("restored", blob);
+    beforeReply = () => {
+      db()
+        .query("UPDATE knowledge SET is_deleted = 0 WHERE id = ?")
+        .run("restored");
+    };
+    stop = startVec0OrphanMaintenance(() => false);
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(db().query("SELECT id FROM knowledge_vec").all()).toEqual([
+      { id: "restored" },
+    ]);
+  });
+
+  it("binds SQL-looking and large vector IDs without touching live source rows", async () => {
+    base("live");
+    temporal("live#0", "live");
+    temporal("x'); DROP TABLE temporal_messages; --");
+    temporal("x".repeat(262_144));
+    stop = startVec0OrphanMaintenance(() => false);
+    await vi.advanceTimersByTimeAsync(4000);
+    expect(keys()).toEqual([{ chunk_id: "live#0" }]);
+    expect(
+      db()
+        .query("SELECT id FROM temporal_messages WHERE project_id = ?")
+        .all(pid),
+    ).toEqual([{ id: "live" }]);
+  });
+
+  it("retries a real competing writer lock without losing rows or busy timeout state", async () => {
+    temporal("orphan");
+    db().exec("PRAGMA busy_timeout = 1234");
+    const observed: number[] = [];
+    log.registerSink({
+      info() {},
+      warn() {},
+      error() {},
+      captureException() {},
+      withDbSpan(sql, fn) {
+        if (sql.startsWith("DELETE FROM temporal_vec WHERE")) {
+          observed.push(
+            (db().query("PRAGMA busy_timeout").get() as { timeout: number })
+              .timeout,
+          );
+        }
+        return fn();
+      },
+    });
+    const other = new DatabaseSync(dbPath());
+    let locked = false;
+    try {
+      stop = startVec0OrphanMaintenance(() => false);
+      await vi.advanceTimersByTimeAsync(3000);
+      beforeReply = () => {
+        other.exec("BEGIN IMMEDIATE");
+        locked = true;
+      };
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(observed).toEqual([0]);
+      expect(keys()).toEqual([{ chunk_id: "orphan" }]);
+      expect(db().query("PRAGMA busy_timeout").get()).toEqual({
+        timeout: 1234,
+      });
+      other.exec("ROLLBACK");
+      locked = false;
+      await vi.advanceTimersByTimeAsync(30_000);
+      expect(keys()).toEqual([]);
+      expect(observed).toEqual([0, 0]);
+    } finally {
+      if (locked) other.exec("ROLLBACK");
+      other.close();
+    }
   });
 
   it.each([null, pool.READ_JOB_TIMED_OUT] as const)(

--- a/packages/gateway/src/idle.ts
+++ b/packages/gateway/src/idle.ts
@@ -54,6 +54,7 @@ import {
   freelistBytes,
   dbFileSizeBytes,
   embedding,
+  startVec0OrphanMaintenance,
 } from "@loreai/core";
 import type { CacheStrategy, ChangedEntry, LLMClient } from "@loreai/core";
 import {
@@ -452,6 +453,21 @@ export function startIdleScheduler(
   // periods stay quiet instead of repeating a stale p50/p95 line every tick.
   let lastVecLatencyLogged = 0;
 
+  const stopVec0Maintenance = startVec0OrphanMaintenance(() => {
+    if (shouldShedLowPriority()) return true;
+    const now = Date.now();
+    for (const [id, state] of sessions) {
+      if (
+        isExternallyActive?.(id) ||
+        state.backgroundWorkCount ||
+        now - Math.max(state.lastRequestTime, state.lastResponseTime ?? 0) <
+          config.idleTimeoutSeconds * 1000
+      )
+        return true;
+    }
+    return false;
+  });
+
   // Begin sampling event-loop delay for the periodic resource gauge below.
   startResourceMonitor();
 
@@ -831,7 +847,10 @@ export function startIdleScheduler(
     }
   }, POLL_INTERVAL_MS);
 
-  return () => clearInterval(timer);
+  return () => {
+    stopVec0Maintenance();
+    clearInterval(timer);
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/gateway/test/eviction.test.ts
+++ b/packages/gateway/test/eviction.test.ts
@@ -24,6 +24,7 @@ import {
   ltm,
 } from "@loreai/core";
 import { startIdleScheduler, evictIdleSessions } from "../src/idle";
+import * as orphanMaintenance from "../../core/src/vec0-orphan-maintenance";
 import { loadConfig } from "../src/config";
 import type { GatewayConfig } from "../src/config";
 import type { SessionState } from "../src/translate/types";
@@ -654,6 +655,44 @@ describe("evictIdleSessions", () => {
 // ---------------------------------------------------------------------------
 
 describe("startIdleScheduler", () => {
+  test("owns orphan maintenance and gates it on live work and recent responses", () => {
+    vi.useFakeTimers();
+    const childStop = vi.fn();
+    const start = vi
+      .spyOn(orphanMaintenance, "startVec0OrphanMaintenance")
+      .mockReturnValue(childStop);
+    let active = false;
+    const state = makeSessionState({ lastRequestTime: Date.now() - 120_000 });
+    const sessions = new Map([["s", state]]);
+    const stop = startIdleScheduler(
+      makeConfig(),
+      sessions,
+      async () => {},
+      undefined,
+      () => active,
+    );
+    try {
+      const gate = start.mock.calls[0][0];
+      expect(gate()).toBe(false);
+      active = true;
+      expect(gate()).toBe(true);
+      active = false;
+      state.lastResponseTime = Date.now();
+      expect(gate()).toBe(true);
+      state.lastResponseTime = Date.now() - 120_000;
+      state.backgroundWorkCount = 1;
+      expect(gate()).toBe(true);
+      state.backgroundWorkCount = 0;
+      state.lastRequestTime = Date.now();
+      expect(gate()).toBe(true);
+    } finally {
+      stop();
+      start.mockRestore();
+      vi.useRealTimers();
+    }
+    expect(childStop).toHaveBeenCalledTimes(1);
+  });
+
   test("accepts optional onEvict callback", () => {
     const sessions = new Map<string, SessionState>();
     const config = makeConfig();


### PR DESCRIPTION
Startup still scanned every vec0 row on the SQLite writer after embedding backfill, even when migration and re-chunking had already converged. Large databases could block the gateway's event loop during that scan.

This moves startup orphan discovery to idle read-worker maintenance. Each page examines at most 128 vector keys using an indexed cursor. The writer deletes exact keys only after rechecking their current backing rows, skips lock contention, and ignores late results after shutdown or database replacement. Maintenance pauses for active sessions and retries worker failures without a synchronous fallback. Existing explicit bulk-delete behavior is unchanged.

Fixes #1681

## Validation

- 129 focused tests pass, including 20 cleanup regressions, the native bundled read-worker path, indexed query plans, restore/replacement races, shutdown fencing, worker failure/backoff, actual SQLite contention and gateway idle ownership.
- Startup and busy-timeout regressions were proven failing before their fixes; independent mutation checks verify liveness, rollback, ownership, foreground priority, paging and knowledge-current guards.
- Typecheck, lint, formatting and gateway bundle pass. Both reviewers independently passed ten property-test runs.
- Two independent full-suite runs: 9,969 passed, 7 documented base/environment failures, 234 skipped. Failures are installer process checks (3), compact endpoint behavior (2), cache raw-window boundary (1), and optional Linux GPU assets (1). A separate stale-bundle setup failure was resolved with an isolated rebuild; all 7 bundle-export retests pass. Final test-only additions were rerun separately.
- Independent correctness and security reviews: MERGE subject to hosted gates; no unresolved findings. Exact reviewed tree: `cb36632e1f1bf54955f5cd3c60efd8017a238b15`.
- Seer passed on final head `1f5077215079fc32d48a08ac6c5e820d18d20e5d` with no issues. Hosted test completion remains pending.
