### PR TITLE
fix(installer): preserve descriptor identity on macOS and Bash 3.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,19 @@ jobs:
       - name: Check installer bash-3.2 compatibility
         run: bash packages/website/scripts/check-install-script-bashisms.sh
 
+  install-script-portability:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+      - name: Test installer descriptor and lifecycle portability
+        run: node --test packages/website/scripts/test-install-script-portability.mjs
+
   test:
     needs: [changes]
     if: needs.changes.outputs.code == 'true'
@@ -1278,13 +1291,18 @@ jobs:
   ci-status:
     name: CI Status
     if: always()
-    needs: [changes, test, binary-smoke-native, check-docs, check-links, check-preview-links, check-social, check-patches, actionlint, sync-integration, hermes-test, hermes-real-abc]
+    needs: [changes, test, binary-smoke-native, check-docs, check-links, check-preview-links, check-social, check-patches, actionlint, install-script-bash-compat, install-script-portability, sync-integration, hermes-test, hermes-real-abc]
     runs-on: ubuntu-latest
     steps:
       - name: Check CI result
         run: |
           if [ "${{ needs.actionlint.result }}" != "success" ]; then
             echo "::error::actionlint job did not succeed (result: ${{ needs.actionlint.result }})"
+            exit 1
+          fi
+          if [ "${{ needs.install-script-bash-compat.result }}" != "success" ] ||
+             [ "${{ needs.install-script-portability.result }}" != "success" ]; then
+            echo "::error::installer portability checks did not succeed"
             exit 1
           fi
           if [ "${{ needs.changes.outputs.code }}" == "true" ]; then

--- a/packages/website/public/install
+++ b/packages/website/public/install
@@ -589,8 +589,8 @@ inspect_lifecycle_owner_record() {
   (( owner_size > 0 && owner_size <= 16384 )) || return 1
   before_owner=$(lifecycle_owner_file_identity "$owner_path") || return 1
   owner_content=$(<"$owner_path") || return 1
-  [[ "$(wc -l < "$owner_path")" == "1" ]] || return 1
-  owner_content_size=$(LC_ALL=C printf '%s' "$owner_content" | wc -c)
+  [[ "$(wc -l < "$owner_path" | tr -d '[:space:]')" == "1" ]] || return 1
+  owner_content_size=$(LC_ALL=C printf '%s' "$owner_content" | wc -c | tr -d '[:space:]')
   [[ "$owner_content_size" =~ ^[0-9]+$ ]] || return 1
   (( owner_content_size + 1 == owner_size )) || return 1
   [[ -f "$owner_path" && ! -L "$owner_path" ]] || return 1
@@ -1123,19 +1123,19 @@ acquire_lifecycle_lock() {
      [[ "$(stable_file_identity "$lifecycle_initialization_stage_path" 2>/dev/null || true)" != "$lifecycle_initialization_stage_identity" ]] ||
      { [[ "$os" != "windows" && ! -O "$lifecycle_initialization_stage_path" ]] ||
         ! fd_has_exact_mode "$owner_fd" 600; }; then
-    exec 9>&- 2>/dev/null || true
+    { exec 9>&-; } 2>/dev/null || true
     remove_lifecycle_initialization_stage
     die "Could not stage Lore lifecycle lock owner"
   fi
   sync_path "$owner_fd_path" 2>/dev/null || true
   if ! lifecycle_state_dir_is_trusted ||
      [[ "$(stable_file_identity "$lifecycle_initialization_stage_path" 2>/dev/null || true)" != "$lifecycle_initialization_stage_identity" ]]; then
-    exec 9>&- 2>/dev/null || true
+    { exec 9>&-; } 2>/dev/null || true
     remove_lifecycle_initialization_stage
     die "Lifecycle owner generation changed before claim publication"
   fi
   if ! ln "$lifecycle_initialization_stage_path" "$lifecycle_initialization_claim_path"; then
-    exec 9>&- 2>/dev/null || true
+    { exec 9>&-; } 2>/dev/null || true
     remove_lifecycle_initialization_stage
     die "Could not publish Lore lifecycle initialization claim"
   fi
@@ -1148,7 +1148,7 @@ acquire_lifecycle_lock() {
         "$inspected_lock_process_identity" != "$process_identity" ||
         "$inspected_lock_owner_content" != "$owner_content" ||
         "$(stable_file_identity "$lifecycle_initialization_claim_path" 2>/dev/null || true)" != "$lifecycle_initialization_stage_identity" ]]; then
-    exec 9>&- 2>/dev/null || true
+    { exec 9>&-; } 2>/dev/null || true
     release_lifecycle_initialization_claim
     remove_lifecycle_initialization_stage
     die "Lore lifecycle initialization claim changed during publication"
@@ -1568,7 +1568,7 @@ else
     if ! curl -fsSL "$checksum_asset_url" > "$checksums_file"; then
       die "Failed to download stable release checksum metadata"
     fi
-    checksum_metadata_size=$(wc -c < "$checksums_file")
+    checksum_metadata_size=$(wc -c < "$checksums_file" | tr -d '[:space:]')
     if [[ ! "$checksum_metadata_size" =~ ^[0-9]+$ ]] || (( checksum_metadata_size > 65536 )); then
       die "Stable release checksum metadata is too large"
     fi

--- a/packages/website/public/install
+++ b/packages/website/public/install
@@ -1084,7 +1084,10 @@ acquire_lifecycle_lock() {
   fi
   [[ "$owner_pid" =~ ^[1-9][0-9]*$ ]] || owner_pid=$$
   local process_start
-  process_start=$(ps -o lstart= -p "$$" 2>/dev/null || true)
+  # BSD ps pads lstart to its column width. Publish a strict process timestamp
+  # independent of the user's locale.
+  process_start=$(LC_ALL=C ps -o lstart= -p "$$" 2>/dev/null |
+    sed 's/^[[:space:]]*//; s/[[:space:]]*$//' || true)
   [[ -n "$process_start" ]] && process_started_at="$process_start"
   process_identity="unverified:${lifecycle_lock_token}"
   if [[ "$os" == "linux" && -r "/proc/$$/stat" && -r /proc/sys/kernel/random/boot_id ]]; then

--- a/packages/website/public/install
+++ b/packages/website/public/install
@@ -124,7 +124,7 @@ dest=""
 lifecycle_lock_path=""
 lifecycle_lock_token=""
 lifecycle_lock_held=false
-lifecycle_lock_bash_pid=""
+lifecycle_lock_subshell=""
 lifecycle_lock_pid=""
 lifecycle_lock_process_identity=""
 lifecycle_lock_directory_identity=""
@@ -135,13 +135,12 @@ lifecycle_initialization_claim_identity=""
 lifecycle_initialization_claim_content=""
 lifecycle_initialization_stage_identity=""
 lifecycle_initialization_claim_held=false
-lifecycle_initialization_claim_bash_pid=""
+lifecycle_initialization_claim_subshell=""
 lifecycle_initialization_stage_path=""
 lifecycle_initialization_lease_seconds=10
 lifecycle_state_dir=""
 lifecycle_state_dir_identity=""
 lifecycle_state_dir_fd=""
-lifecycle_state_dir_fd_path=""
 inspected_lock_token=""
 inspected_lock_pid=""
 inspected_lock_process_identity=""
@@ -235,12 +234,15 @@ stable_file_identity() {
   printf '%s' "$identity"
 }
 
-stable_followed_file_identity() {
-  local path=$1 identity device inode
+# Apple stat with no pathname calls fstat(0). /dev/fd/N pathname metadata
+# describes a synthetic devfs node, not the held file's device/mode.
+# https://github.com/apple-oss-distributions/file_cmds/blob/main/stat/stat.c
+stable_fd_identity() {
+  local fd=$1 identity device inode
   if [[ "$os" == "darwin" ]]; then
-    identity=$(stat -Lf '%d:%i' "$path") || return 1
+    identity=$(stat -f '%d:%i' <&"$fd") || return 1
   else
-    identity=$(stat -Lc '%d:%i' "$path") || return 1
+    identity=$(stat -Lc '%d:%i' "/dev/fd/$fd") || return 1
   fi
   IFS=: read -r device inode <<< "$identity"
   if [[ ! "$device" =~ ^[1-9][0-9]*$ || ! "$inode" =~ ^[1-9][0-9]*$ ]]; then
@@ -442,11 +444,11 @@ path_owner_only_mode() {
   local path=$1 mode
   [[ "$os" == "windows" ]] && return 0
   if [[ "$os" == "darwin" ]]; then
-    mode=$(stat -f '%Lp' "$path") || return 1
+    mode=$(stat -f '%p' "$path") || return 1
   else
     mode=$(stat -c '%a' "$path") || return 1
   fi
-  [[ "$mode" =~ ^[0-7]{3,4}$ ]] || return 1
+  [[ "$mode" =~ ^[0-7]{3,7}$ ]] || return 1
   (( (8#$mode & 077) == 0 ))
 }
 
@@ -454,40 +456,39 @@ path_has_exact_mode() {
   local path=$1 expected=$2 mode
   [[ "$os" == "windows" ]] && return 0
   if [[ "$os" == "darwin" ]]; then
-    mode=$(stat -f '%Lp' "$path") || return 1
+    mode=$(stat -f '%p' "$path") || return 1
   else
     mode=$(stat -c '%a' "$path") || return 1
   fi
-  [[ "$mode" =~ ^[0-7]{3,4}$ ]] || return 1
-  (( 8#$mode == 8#$expected ))
+  [[ "$mode" =~ ^[0-7]{3,7}$ ]] || return 1
+  (( (8#$mode & 07777) == 8#$expected ))
 }
 
-followed_path_has_exact_mode() {
-  local path=$1 expected=$2 mode
+fd_has_exact_mode() {
+  local fd=$1 expected=$2 mode
   [[ "$os" == "windows" ]] && return 0
   if [[ "$os" == "darwin" ]]; then
-    mode=$(stat -Lf '%Lp' "$path") || return 1
+    mode=$(stat -f '%p' <&"$fd") || return 1
   else
-    mode=$(stat -Lc '%a' "$path") || return 1
+    mode=$(stat -Lc '%a' "/dev/fd/$fd") || return 1
   fi
-  [[ "$mode" =~ ^[0-7]{3,4}$ ]] || return 1
-  (( 8#$mode == 8#$expected ))
+  [[ "$mode" =~ ^[0-7]{3,7}$ ]] || return 1
+  (( (8#$mode & 07777) == 8#$expected ))
 }
 
 lifecycle_state_dir_is_trusted() {
   local path_identity fd_identity
   [[ -n "$lifecycle_state_dir" && -n "$lifecycle_state_dir_identity" ]] || return 1
-  [[ -n "$lifecycle_state_dir_fd_path" ]] || return 1
+  [[ -n "$lifecycle_state_dir_fd" ]] || return 1
   [[ -d "$lifecycle_state_dir" && ! -L "$lifecycle_state_dir" ]] || return 1
-  [[ -d "$lifecycle_state_dir_fd_path" ]] || return 1
   if [[ "$os" != "windows" ]] &&
      { [[ ! -O "$lifecycle_state_dir" ]] ||
        ! path_has_exact_mode "$lifecycle_state_dir" 700 ||
-       ! followed_path_has_exact_mode "$lifecycle_state_dir_fd_path" 700; }; then
+       ! fd_has_exact_mode "$lifecycle_state_dir_fd" 700; }; then
     return 1
   fi
   path_identity=$(stable_file_identity "$lifecycle_state_dir") || return 1
-  fd_identity=$(stable_followed_file_identity "$lifecycle_state_dir_fd_path") || return 1
+  fd_identity=$(stable_fd_identity "$lifecycle_state_dir_fd") || return 1
   [[ "$path_identity" == "$lifecycle_state_dir_identity" &&
      "$fd_identity" == "$lifecycle_state_dir_identity" ]]
 }
@@ -516,8 +517,7 @@ secure_lifecycle_state_dir() {
   if ! exec 8<"$state_dir"; then
     die "Could not open installer state directory safely: ${state_dir}"
   fi
-  lifecycle_state_dir_fd_path="/dev/fd/${lifecycle_state_dir_fd}"
-  opened=$(stable_followed_file_identity "$lifecycle_state_dir_fd_path") ||
+  opened=$(stable_fd_identity "$lifecycle_state_dir_fd") ||
     die "Could not capture opened installer state directory identity"
   if [[ "$before" != "$opened" ]]; then
     die "Installer state directory changed while it was opened"
@@ -525,11 +525,16 @@ secure_lifecycle_state_dir() {
   # Tightening happens before lifecycle.lock can be created. The held directory
   # descriptor pins the generation so a path replacement during chmod is
   # detected instead of being trusted as the secured parent.
-  if [[ "$os" != "windows" ]] && ! chmod 700 "$lifecycle_state_dir_fd_path"; then
+  if [[ "$os" != "windows" ]] && ! (
+    trap - EXIT
+    cd -P -- "$state_dir" || exit 1
+    [[ "$(stable_file_identity .)" == "$opened" ]] || exit 1
+    chmod 700 . || exit 1
+  ); then
     die "Could not secure installer state directory: ${state_dir}"
   fi
   after_path=$(require_file_identity "$state_dir" "secured installer state directory")
-  after_fd=$(stable_followed_file_identity "$lifecycle_state_dir_fd_path") ||
+  after_fd=$(stable_fd_identity "$lifecycle_state_dir_fd") ||
     die "Could not recapture opened installer state directory identity"
   if [[ "$before" != "$after_path" ]] || [[ "$before" != "$after_fd" ]]; then
     die "Installer state directory was replaced while permissions were tightened"
@@ -537,7 +542,7 @@ secure_lifecycle_state_dir() {
   if [[ "$os" != "windows" ]] &&
      { [[ ! -O "$state_dir" ]] ||
        ! path_has_exact_mode "$state_dir" 700 ||
-       ! followed_path_has_exact_mode "$lifecycle_state_dir_fd_path" 700; }; then
+       ! fd_has_exact_mode "$lifecycle_state_dir_fd" 700; }; then
     die "Installer state directory is not current-owner mode 0700: ${state_dir}"
   fi
   lifecycle_state_dir="$state_dir"
@@ -717,7 +722,7 @@ same_inspected_lifecycle_owner_record() {
 
 release_lifecycle_initialization_claim() {
   [[ "$lifecycle_initialization_claim_held" == "true" ]] || return 0
-  [[ "$BASHPID" == "$lifecycle_initialization_claim_bash_pid" ]] || return 0
+  [[ "$BASH_SUBSHELL" == "$lifecycle_initialization_claim_subshell" ]] || return 0
   if same_inspected_lifecycle_owner_record \
     "$lifecycle_lock_token" "$lifecycle_lock_pid" "$lifecycle_lock_process_identity" \
     "$lifecycle_initialization_claim_identity" \
@@ -832,7 +837,7 @@ quarantine_definitively_stale_lifecycle_lock() {
   local expected_dir=$inspected_lock_directory_identity
   local expected_owner=$inspected_lock_owner_identity
   local expected_content=$inspected_lock_owner_content
-  local claim_path guard_tmp portable_guard stale_fd stale_fd_path
+  local claim_path guard_tmp portable_guard stale_fd
 
   lifecycle_owner_is_definitively_dead \
     "$expected_pid" "$expected_process_identity" || return 1
@@ -861,50 +866,55 @@ quarantine_definitively_stale_lifecycle_lock() {
     return 1
   fi
   stale_fd=10
-  stale_fd_path="/dev/fd/${stale_fd}"
-  if [[ "$(stable_followed_file_identity "$stale_fd_path" 2>/dev/null || true)" != "$expected_dir" ]]; then
+  if [[ "$(stable_fd_identity "$stale_fd" 2>/dev/null || true)" != "$expected_dir" ]]; then
     exec 10<&-
     return 1
   fi
-  # Portable mv treats an existing directory as a parent. Reserve the source
-  # basename inside the stale generation with a non-directory entry, so a
-  # delayed same-generation move cannot nest a live successor under the claim.
-  portable_guard="$stale_fd_path/lifecycle.lock"
-  if [[ -e "$portable_guard" || -L "$portable_guard" ]]; then
-    if ! lifecycle_portable_reclaim_guard_is_valid "$portable_guard"; then
-      exec 10<&-
-      return 1
-    fi
-  else
-    set -o noclobber
-    if ! : > "$portable_guard"; then
-      set +o noclobber
-      exec 10<&-
-      return 1
-    fi
-    set +o noclobber
-  fi
-  # Preserve the legacy GNU-mv guard where -T exists. The direct portable
-  # source-basename guard above is sufficient on BSD/macOS.
-  if [[ "$os" != "darwin" ]]; then
-    if [[ -e "$stale_fd_path/lock" || -L "$stale_fd_path/lock" ]]; then
-      if ! lifecycle_reclaim_guard_is_valid "$stale_fd_path/lock"; then
-        exec 10<&-
-        return 1
+  # Work relative to a verified cwd: macOS /dev/fd/N is a devfs node,
+  # not a traversable directory. The cwd pins the generation across renames.
+  if ! (
+    trap - EXIT
+    cd -P -- "$lock_path" || exit 1
+    [[ "$(stable_file_identity .)" == "$expected_dir" ]] || exit 1
+    # Portable mv treats an existing directory as a parent. Reserve the source
+    # basename inside the stale generation with a non-directory entry, so a
+    # delayed same-generation move cannot nest a live successor under the claim.
+    portable_guard="./lifecycle.lock"
+    if [[ -e "$portable_guard" || -L "$portable_guard" ]]; then
+      if ! lifecycle_portable_reclaim_guard_is_valid "$portable_guard"; then
+        exit 1
       fi
     else
-      guard_tmp=$(mktemp -d "$(dirname "$lock_path")/.lifecycle.guard.${expected_token}.XXXXXX")
-      chmod 700 "$guard_tmp"
-      mkdir -m 700 "$guard_tmp/lifecycle.lock"
-      mkdir -m 700 "$guard_tmp/lifecycle.lock/sentinel"
-      if ! mv -T "$guard_tmp" "$stale_fd_path/lock"; then
-        rmdir "$guard_tmp/lifecycle.lock/sentinel" 2>/dev/null || true
-        rmdir "$guard_tmp/lifecycle.lock" 2>/dev/null || true
-        rmdir "$guard_tmp" 2>/dev/null || true
-        exec 10<&-
-        return 1
+      set -o noclobber
+      if ! : > "$portable_guard"; then
+        set +o noclobber
+        exit 1
+      fi
+      set +o noclobber
+    fi
+    # Preserve the legacy GNU-mv guard where -T exists. The direct portable
+    # source-basename guard above is sufficient on BSD/macOS.
+    if [[ "$os" != "darwin" ]]; then
+      if [[ -e "./lock" || -L "./lock" ]]; then
+        if ! lifecycle_reclaim_guard_is_valid "./lock"; then
+          exit 1
+        fi
+      else
+        guard_tmp=$(mktemp -d "$(dirname "$lock_path")/.lifecycle.guard.${expected_token}.XXXXXX") || exit 1
+        chmod 700 "$guard_tmp" || exit 1
+        mkdir -m 700 "$guard_tmp/lifecycle.lock" || exit 1
+        mkdir -m 700 "$guard_tmp/lifecycle.lock/sentinel" || exit 1
+        if ! mv -T "$guard_tmp" "./lock"; then
+          rmdir "$guard_tmp/lifecycle.lock/sentinel" 2>/dev/null || true
+          rmdir "$guard_tmp/lifecycle.lock" 2>/dev/null || true
+          rmdir "$guard_tmp" 2>/dev/null || true
+          exit 1
+        fi
       fi
     fi
+  ); then
+    exec 10<&-
+    return 1
   fi
   exec 10<&-
   same_inspected_lifecycle_generation \
@@ -954,9 +964,9 @@ assert_lifecycle_lock_owned() {
 
 release_lifecycle_lock() {
   [[ "$lifecycle_lock_held" == "true" ]] || return 0
-  # EXIT traps can run in command subshells. Only the Bash process that
-  # acquired the lock may release it.
-  [[ "$BASHPID" == "$lifecycle_lock_bash_pid" ]] || return 0
+  # EXIT traps can run in command subshells. Only the acquisition depth may
+  # release the lock; BASH_SUBSHELL also exists in macOS stock Bash 3.2.
+  [[ "$BASH_SUBSHELL" == "$lifecycle_lock_subshell" ]] || return 0
   # A predecessor must never remove a successor's lock or an owner file that
   # was swapped while retaining the predecessor token.
   lifecycle_lock_is_owned || return 0
@@ -1106,12 +1116,13 @@ acquire_lifecycle_lock() {
   set +o noclobber
   owner_fd=9
   owner_fd_path="/dev/fd/${owner_fd}"
-  if ! chmod 600 "$owner_fd_path" ||
-     ! printf '%s\n' "$owner_content" >&"$owner_fd" ||
-     ! lifecycle_initialization_stage_identity=$(stable_followed_file_identity "$owner_fd_path") ||
+  # noclobber plus the installer umask 077 creates this inode with mode 0600.
+  # Verify the descriptor itself; chmod on macOS devfs changes the fd node.
+  if ! printf '%s\n' "$owner_content" >&"$owner_fd" ||
+     ! lifecycle_initialization_stage_identity=$(stable_fd_identity "$owner_fd") ||
      [[ "$(stable_file_identity "$lifecycle_initialization_stage_path" 2>/dev/null || true)" != "$lifecycle_initialization_stage_identity" ]] ||
      { [[ "$os" != "windows" && ! -O "$lifecycle_initialization_stage_path" ]] ||
-        ! followed_path_has_exact_mode "$owner_fd_path" 600; }; then
+        ! fd_has_exact_mode "$owner_fd" 600; }; then
     exec 9>&- 2>/dev/null || true
     remove_lifecycle_initialization_stage
     die "Could not stage Lore lifecycle lock owner"
@@ -1129,7 +1140,7 @@ acquire_lifecycle_lock() {
     die "Could not publish Lore lifecycle initialization claim"
   fi
   lifecycle_initialization_claim_content="$owner_content"
-  lifecycle_initialization_claim_bash_pid=$BASHPID
+  lifecycle_initialization_claim_subshell=$BASH_SUBSHELL
   lifecycle_initialization_claim_held=true
   if ! inspect_lifecycle_owner_record "$lifecycle_initialization_claim_path" ||
      [[ "$inspected_lock_token" != "$lifecycle_lock_token" ||
@@ -1205,7 +1216,7 @@ acquire_lifecycle_lock() {
   lifecycle_lock_directory_identity="$inspected_lock_directory_identity"
   lifecycle_lock_owner_identity="$inspected_lock_owner_identity"
   lifecycle_lock_owner_content="$inspected_lock_owner_content"
-  lifecycle_lock_bash_pid=$BASHPID
+  lifecycle_lock_subshell=$BASH_SUBSHELL
   lifecycle_lock_held=true
   assert_lifecycle_lock_owned
   read_trusted_uninstall_tombstone "$uninstall_tombstone_path"
@@ -1397,7 +1408,6 @@ cleanup_installer() {
   if [[ -n "$lifecycle_state_dir_fd" ]]; then
     exec 8<&-
     lifecycle_state_dir_fd=""
-    lifecycle_state_dir_fd_path=""
   fi
   return "$status"
 }
@@ -2076,6 +2086,5 @@ release_lifecycle_lock
 if [[ -n "$lifecycle_state_dir_fd" ]]; then
   exec 8<&-
   lifecycle_state_dir_fd=""
-  lifecycle_state_dir_fd_path=""
 fi
 exit 0

--- a/packages/website/public/install
+++ b/packages/website/public/install
@@ -601,7 +601,9 @@ inspect_lifecycle_owner_record() {
   after_owner=$(lifecycle_owner_file_identity "$owner_path") || return 1
   [[ "$before_owner" == "$after_owner" ]] || return 1
 
-  owner_pattern='^\{"version":1,"token":"([A-Za-z0-9_-]{32,256})","pid":([1-9][0-9]*),"operation":"(gateway-start|gateway-shutdown|upgrade|setup|uninstall|hosted-install)","createdAt":"([^"]{1,64})","processStartedAt":"([^"]{1,64})","processIdentity":"([^"]{1,1024})"\}$'
+  # Darwin's regex engine caps each repetition bound at 255. Split the
+  # token (32..256) and identity (1..1024) bounds without extra captures.
+  owner_pattern='^\{"version":1,"token":"([A-Za-z0-9_-]{32,255}[A-Za-z0-9_-]?)","pid":([1-9][0-9]*),"operation":"(gateway-start|gateway-shutdown|upgrade|setup|uninstall|hosted-install)","createdAt":"([^"]{1,64})","processStartedAt":"([^"]{1,64})","processIdentity":"([^"]{1,255}[^"]{0,255}[^"]{0,255}[^"]{0,255}[^"]{0,4})"\}$'
   [[ "$owner_content" =~ $owner_pattern ]] || return 1
   owner_token=${BASH_REMATCH[1]}
   owner_pid=${BASH_REMATCH[2]}
@@ -1008,7 +1010,7 @@ claim_expired_incomplete_lifecycle_lock() {
   shopt -u nullglob
   for claim in "${initialization_claims[@]}"; do
     claim_token=${claim##*.lifecycle.lock.init.}
-    [[ "$claim_token" =~ ^[A-Za-z0-9_-]{32,256}$ ]] || return 1
+    [[ "$claim_token" =~ ^[A-Za-z0-9_-]{32,255}[A-Za-z0-9_-]?$ ]] || return 1
     inspect_lifecycle_owner_record "$claim" || return 1
     [[ "$inspected_lock_token" == "$claim_token" ]] || return 1
     if [[ "$claim" == "$lifecycle_initialization_claim_path" ]]; then
@@ -1922,7 +1924,7 @@ append_path_block() {
     if (( ${#recovery_claims[@]} == 1 )); then
       recovery_claim=${recovery_claims[0]}
       recovery_suffix=${recovery_claim#"${rc}.lore-original."}
-      if [[ ! "$recovery_suffix" =~ ^[A-Za-z0-9_-]{32,256}\.([1-9][0-9]*)\.([1-9][0-9]*)\.([a-f0-9]{64})$ ||
+      if [[ ! "$recovery_suffix" =~ ^[A-Za-z0-9_-]{32,255}[A-Za-z0-9_-]?\.([1-9][0-9]*)\.([1-9][0-9]*)\.([a-f0-9]{64})$ ||
             -L "$recovery_claim" || ! -f "$recovery_claim" ||
             ( "$os" != "windows" && ! -O "$recovery_claim" ) ]]; then
         die "Refusing unsafe shell profile recovery claim: ${recovery_claim}"

--- a/packages/website/scripts/check-install-script-bashisms.sh
+++ b/packages/website/scripts/check-install-script-bashisms.sh
@@ -33,6 +33,8 @@ patterns=(
   '\$\{[a-zA-Z_][a-zA-Z0-9_]*@(U|L|E|P|Q|a|A)\}' # transform expansion (4.0)
 )
 
+patterns+=('[$][{]?BASHPID([^a-zA-Z0-9_]|$)') # BASHPID (4.0)
+
 labels=(
   'named file descriptor (bash 4.1+)'
   'named file descriptor close (bash 4.1+)'
@@ -44,6 +46,8 @@ labels=(
   'case-modifying parameter expansion (bash 4.0+)'
   'parameter transformation expansion (bash 4.0+)'
 )
+
+labels+=('BASHPID variable (bash 4.0+)')
 
 while IFS= read -r line; do
   lineno="${line%%:*}"

--- a/packages/website/scripts/test-install-script-portability.mjs
+++ b/packages/website/scripts/test-install-script-portability.mjs
@@ -224,6 +224,7 @@ await test("owner records retain exact token and process identity length limits"
     ${functions}
     set -- "\${owner_cases[@]}"
     checked=0
+    set -x
     while (( $# > 0 )); do
       if inspect_lifecycle_owner_record "$1"; then
         [[ "$2" == true ]] || exit 31

--- a/packages/website/scripts/test-install-script-portability.mjs
+++ b/packages/website/scripts/test-install-script-portability.mjs
@@ -224,7 +224,6 @@ await test("owner records retain exact token and process identity length limits"
     ${functions}
     set -- "\${owner_cases[@]}"
     checked=0
-    set -x
     while (( $# > 0 )); do
       if inspect_lifecycle_owner_record "$1"; then
         [[ "$2" == true ]] || exit 31
@@ -250,6 +249,7 @@ await test("nested subshell cleanup cannot release the parent's lock", (t) => {
     `${functions}
     unset BASHPID
     canonical_home=$(pwd -P)
+    set -x
     acquire_lifecycle_lock
     (release_lifecycle_lock; release_lifecycle_initialization_claim)
     [[ -f "$HOME/.lore/lifecycle.lock/owner.json" ]]

--- a/packages/website/scripts/test-install-script-portability.mjs
+++ b/packages/website/scripts/test-install-script-portability.mjs
@@ -249,7 +249,6 @@ await test("nested subshell cleanup cannot release the parent's lock", (t) => {
     `${functions}
     unset BASHPID
     canonical_home=$(pwd -P)
-    set -x
     acquire_lifecycle_lock
     (release_lifecycle_lock; release_lifecycle_initialization_claim)
     [[ -f "$HOME/.lore/lifecycle.lock/owner.json" ]]
@@ -358,6 +357,30 @@ await test("installs and releases locks without Bash 4 BASHPID", (t) => {
     installer,
   );
   assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(readdirSync(join(f.home, ".lore")).sort(), [
+    "channel",
+    "install-path",
+  ]);
+});
+
+await test("installs with padded BSD process timestamps", (t) => {
+  const f = fixture(t);
+  const result = run(
+    f,
+    `
+    unset LC_ALL
+    ps() {
+      if [[ "$*" == '-o lstart= -p '* ]]; then
+        [[ "\${LC_ALL:-}" == C ]] || { printf 'localized timestamp\\n'; return; }
+        printf '  Tue Sep  8 17:15:40 2026    \\n'
+      else command ps "$@"; fi
+    }
+    source "$1" --no-modify-path
+  `,
+    installer,
+  );
+  assert.equal(result.status, 0, result.stderr);
+  assert.ok(existsSync(join(f.home, ".local/bin/lore")));
   assert.deepEqual(readdirSync(join(f.home, ".lore")).sort(), [
     "channel",
     "install-path",

--- a/packages/website/scripts/test-install-script-portability.mjs
+++ b/packages/website/scripts/test-install-script-portability.mjs
@@ -1,0 +1,332 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { spawnSync } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+import { gzipSync } from "node:zlib";
+
+// No workspace dependencies: CI runs this with stock /bin/bash and real BSD
+// utilities on macOS. Linux also emulates devfs's misleading path metadata.
+const installer =
+  process.env.LORE_TEST_INSTALLER ??
+  fileURLToPath(new URL("../public/install", import.meta.url));
+const source = readFileSync(installer, "utf8");
+const boundary = source.indexOf("\ncanonical_home=");
+assert.ok(boundary > 0);
+const functions = source.slice(0, boundary);
+const bash = "/bin/bash";
+const executable = (path, body) =>
+  writeFileSync(path, `#!/bin/bash\nset -eu\n${body}\n`, { mode: 0o755 });
+
+function fixture(t, drift = "both") {
+  const root = mkdtempSync(join(tmpdir(), "lore-installer-portability-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const home = join(root, "home");
+  const bin = join(root, "bin");
+  mkdirSync(home, { mode: 0o700 });
+  mkdirSync(bin);
+  const binary = Buffer.from('#!/bin/sh\necho "1.2.3"\n');
+  const archive = gzipSync(binary);
+  writeFileSync(join(root, "archive"), archive);
+  const sha = (bytes) => createHash("sha256").update(bytes).digest("hex");
+  const checksums =
+    ["x64", "arm64"]
+      .flatMap((arch) => [
+        `${sha(binary)}  lore-darwin-${arch}`,
+        `${sha(archive)}  lore-darwin-${arch}.gz`,
+      ])
+      .join("\n") + "\n";
+  writeFileSync(join(root, "checksums"), checksums);
+  writeFileSync(
+    join(root, "release"),
+    JSON.stringify({
+      tag_name: "1.2.3",
+      assets: [
+        {
+          name: "lore-checksums.txt",
+          digest: `sha256:${sha(checksums)}`,
+          browser_download_url:
+            "https://github.com/BYK/loreai/releases/download/1.2.3/lore-checksums.txt",
+        },
+      ],
+    }),
+  );
+  executable(
+    join(bin, "curl"),
+    `case "$*" in
+    *api.github.com*) cat "$TEST_ROOT/release" ;;
+    *lore-checksums.txt*) cat "$TEST_ROOT/checksums" ;;
+    *.gz*) cat "$TEST_ROOT/archive" ;;
+    *) exit 1 ;;
+  esac`,
+  );
+  executable(join(bin, "sync"), ":");
+  if (process.platform !== "darwin") {
+    executable(
+      join(bin, "date"),
+      `
+      if [[ "$1" == -r ]]; then
+        seconds=$2; shift 2
+        exec /usr/bin/date -d "@$seconds" "$@"
+      fi
+      exec /usr/bin/date "$@"`,
+    );
+    executable(
+      join(bin, "uname"),
+      `case "$1" in
+      -s) echo Darwin ;; -m) echo arm64 ;; *) exit 1 ;; esac`,
+    );
+    executable(
+      join(bin, "stat"),
+      `
+      flags=$1 format=$2
+      shift 2
+      format=\${format//%Lp/%a}
+      format=\${format//%z/%s}
+      format=\${format//%m/%Y}
+      format=\${format//%c/%Z}
+      if [[ "$format" == %p ]]; then format=%a; fi
+      if [[ $# == 0 ]]; then
+        # BSD stat with no pathname uses fstat(0), even for a write-only fd.
+        exec /usr/bin/stat -Lc "$format" /dev/fd/0
+      fi
+      if [[ "$1" == /dev/fd/* ]]; then
+        if [[ "$TEST_DRIFT" != mode && "$format" == %d:%i ]]; then
+          printf '999999:%s\\n' "$(/usr/bin/stat -Lc %i "$1")"
+          exit
+        fi
+        if [[ "$format" == %a ]]; then echo 400; exit; fi
+      fi
+      case "$flags" in
+        -Lf) exec /usr/bin/stat -Lc "$format" "$@" ;;
+        -f) exec /usr/bin/stat -c "$format" "$@" ;;
+        *) exit 1 ;;
+      esac`,
+    );
+    // A devfs node is not the target inode for pathname chmod either.
+    executable(
+      join(bin, "chmod"),
+      `
+      case "\${2:-}" in /dev/fd/*) exit 0 ;; esac
+      exec /usr/bin/chmod "$@"`,
+    );
+  }
+  return {
+    home,
+    env: {
+      ...process.env,
+      HOME: home,
+      PATH: `${bin}:${process.env.PATH}`,
+      TEST_ROOT: root,
+      TEST_DRIFT: drift,
+      LORE_VERSION: "1.2.3",
+    },
+  };
+}
+
+await test("retains full device identity and fails closed on unavailable fd metadata", (t) => {
+  const f = fixture(t);
+  const state = join(f.home, ".lore");
+  mkdirSync(state, { mode: 0o700 });
+  const result = run(
+    f,
+    `${functions}
+    trap - EXIT
+    exec 8<"$HOME/.lore"
+    expected=$(stable_file_identity "$HOME/.lore")
+    [[ "$(stable_fd_identity 8)" == "$expected" ]]
+    exec 8<&-
+    if stable_fd_identity 8; then exit 31; fi
+    if fd_has_exact_mode 8 700; then exit 32; fi
+    exec 8<"$HOME/.lore"
+    stat() {
+      if [[ $# == 2 && "$2" == %d:%i ]]; then
+        printf '999999:%s\\n' "$(command stat -f %i "$HOME/.lore")"
+      else command stat "$@"; fi
+    }
+    secure_lifecycle_state_dir "$HOME/.lore"
+  `,
+  );
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /changed while it was opened/);
+  assert.deepEqual(readdirSync(state), []);
+});
+
+await test("fd and path exact-mode checks reject special permission bits", (t) => {
+  const f = fixture(t);
+  const result = run(
+    f,
+    `${functions}
+    trap - EXIT
+    mkdir -m 1700 "$HOME/private"
+    exec 8<"$HOME/private"
+    if path_has_exact_mode "$HOME/private" 700; then exit 31; fi
+    if fd_has_exact_mode 8 700; then exit 32; fi
+    chmod 700 "$HOME/private"
+    path_has_exact_mode "$HOME/private" 700
+    fd_has_exact_mode 8 700
+  `,
+  );
+  assert.equal(result.status, 0, result.stderr);
+});
+
+await test("nested subshell cleanup cannot release the parent's lock", (t) => {
+  const f = fixture(t);
+  const result = run(
+    f,
+    `${functions}
+    unset BASHPID
+    canonical_home=$(pwd -P)
+    acquire_lifecycle_lock
+    (release_lifecycle_lock; release_lifecycle_initialization_claim)
+    [[ -f "$HOME/.lore/lifecycle.lock/owner.json" ]]
+    release_lifecycle_lock
+    [[ ! -e "$HOME/.lore/lifecycle.lock" ]]
+  `,
+  );
+  assert.equal(result.status, 0, result.stderr);
+});
+
+for (const renameDuringGuard of [false, true]) {
+  await test(`stale lock guards stay in their original directory (rename=${renameDuringGuard})`, (t) => {
+    const f = fixture(t);
+    const state = join(f.home, ".lore");
+    const lock = join(state, "lifecycle.lock");
+    const token = "a".repeat(64);
+    mkdirSync(state, { mode: 0o700 });
+    mkdirSync(lock, { mode: 0o700 });
+    writeFileSync(
+      join(lock, "owner.json"),
+      JSON.stringify({
+        version: 1,
+        token,
+        pid: 2147483647,
+        operation: "hosted-install",
+        createdAt: "2026-08-12T00:00:00.000Z",
+        processStartedAt: "2026-08-12T00:00:00.000Z",
+        processIdentity: `unverified:${token}`,
+      }) + "\n",
+      { mode: 0o600 },
+    );
+    const injection = renameDuringGuard
+      ? `
+      cd() {
+        builtin cd "$@" || return 1
+        if [[ "$PWD" == "$HOME/.lore/lifecycle.lock" ]]; then
+          command mv "$HOME/.lore/lifecycle.lock" "$HOME/.lore/old-lock"
+          command mkdir -m 700 "$HOME/.lore/lifecycle.lock"
+        fi
+      }
+    `
+      : "";
+    const result = run(
+      f,
+      `${functions}
+      ${injection}
+      canonical_home=$(pwd -P)
+      acquire_lifecycle_lock
+      release_lifecycle_lock
+    `,
+    );
+    if (renameDuringGuard) {
+      assert.notEqual(result.status, 0);
+      assert.deepEqual(readdirSync(lock), []);
+      assert.ok(existsSync(join(state, "old-lock/lifecycle.lock")));
+    } else {
+      assert.equal(result.status, 0, result.stderr);
+      assert.equal(existsSync(lock), false);
+      assert.ok(
+        existsSync(
+          join(state, `.lifecycle.lock.claim.${token}/lifecycle.lock`),
+        ),
+      );
+    }
+  });
+}
+
+function run(f, code, ...args) {
+  return spawnSync(bash, ["-c", code, "installer-test", ...args], {
+    cwd: f.home,
+    env: f.env,
+    encoding: "utf8",
+    timeout: 30_000,
+  });
+}
+
+for (const drift of ["both", "mode"]) {
+  await test(`installs with real descriptor identity/mode (${drift})`, (t) => {
+    const f = fixture(t, drift);
+    mkdirSync(join(f.home, ".lore"), { mode: 0o755 });
+    const result = run(f, 'source "$1" --no-modify-path', installer);
+    assert.equal(result.status, 0, result.stderr);
+    assert.ok(existsSync(join(f.home, ".local/bin/lore")));
+    assert.match(
+      readFileSync(join(f.home, ".lore/install-path"), "utf8"),
+      /^lore-install-receipt-v3\n/,
+    );
+    assert.equal(statSync(join(f.home, ".lore")).mode & 0o777, 0o700);
+    assert.deepEqual(readdirSync(join(f.home, ".lore")).sort(), [
+      "channel",
+      "install-path",
+    ]);
+  });
+}
+
+await test("installs and releases locks without Bash 4 BASHPID", (t) => {
+  const f = fixture(t);
+  const result = run(
+    f,
+    'unset BASHPID; source "$1" --no-modify-path',
+    installer,
+  );
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(readdirSync(join(f.home, ".lore")).sort(), [
+    "channel",
+    "install-path",
+  ]);
+});
+
+for (const when of ["before-cd", "during-chmod"]) {
+  await test(`rejects directory replacement ${when} without chmod of successor`, (t) => {
+    const f = fixture(t);
+    const state = join(f.home, ".lore");
+    mkdirSync(state, { mode: 0o755 });
+    const injection =
+      when === "before-cd"
+        ? `cd() {
+          command mv "$TEST_STATE" "$TEST_STATE.old"
+          command mkdir -m 755 "$TEST_STATE"
+          builtin cd "$@"
+        }`
+        : `chmod() {
+          command mv "$TEST_STATE" "$TEST_STATE.old"
+          command mkdir -m 755 "$TEST_STATE"
+          command chmod "$@"
+        }`;
+    f.env.TEST_STATE = state;
+    const result = run(
+      f,
+      `${functions}\n${injection}\nsecure_lifecycle_state_dir "$TEST_STATE"`,
+    );
+    assert.notEqual(result.status, 0);
+    assert.ok(existsSync(`${state}.old`), result.stderr);
+    assert.equal(statSync(state).mode & 0o777, 0o755);
+    assert.equal(
+      statSync(`${state}.old`).mode & 0o777,
+      when === "before-cd" ? 0o755 : 0o700,
+    );
+    assert.deepEqual(readdirSync(state), []);
+  });
+}

--- a/packages/website/scripts/test-install-script-portability.mjs
+++ b/packages/website/scripts/test-install-script-portability.mjs
@@ -7,6 +7,7 @@ import {
   mkdtempSync,
   readFileSync,
   readdirSync,
+  realpathSync,
   rmSync,
   statSync,
   writeFileSync,
@@ -31,7 +32,9 @@ const executable = (path, body) =>
   writeFileSync(path, `#!/bin/bash\nset -eu\n${body}\n`, { mode: 0o755 });
 
 function fixture(t, drift = "both") {
-  const root = mkdtempSync(join(tmpdir(), "lore-installer-portability-"));
+  const root = realpathSync(
+    mkdtempSync(join(tmpdir(), "lore-installer-portability-")),
+  );
   t.after(() => rmSync(root, { recursive: true, force: true }));
   const home = join(root, "home");
   const bin = join(root, "bin");
@@ -179,6 +182,62 @@ await test("fd and path exact-mode checks reject special permission bits", (t) =
     path_has_exact_mode "$HOME/private" 700
     fd_has_exact_mode 8 700
   `,
+  );
+  assert.equal(result.status, 0, result.stderr);
+});
+
+await test("owner records retain exact token and process identity length limits", (t) => {
+  const f = fixture(t);
+  const cases = [
+    ...[31, 32, 255, 256, 257].map((length) => ({
+      token: "a".repeat(length),
+      identity: `unverified:${"a".repeat(length)}`,
+      valid: length >= 32 && length <= 256,
+    })),
+    ...[255, 256, 1020, 1024, 1025].map((length) => ({
+      token: "a".repeat(32),
+      identity: `linux:boot:${"1".repeat(length - 11)}`,
+      valid: length <= 1024,
+    })),
+  ];
+  const args = cases.flatMap(({ token, identity, valid }, index) => {
+    const path = join(f.home, `owner-${index}.json`);
+    writeFileSync(
+      path,
+      JSON.stringify({
+        version: 1,
+        token,
+        pid: 123,
+        operation: "hosted-install",
+        createdAt: "2026-08-12T00:00:00.000Z",
+        processStartedAt: "2026-08-12T00:00:00.000Z",
+        processIdentity: identity,
+      }) + "\n",
+      { mode: 0o600 },
+    );
+    return [path, valid ? "true" : "false", token, identity];
+  });
+  const result = run(
+    f,
+    `owner_cases=("$@")
+    set --
+    ${functions}
+    set -- "\${owner_cases[@]}"
+    checked=0
+    while (( $# > 0 )); do
+      if inspect_lifecycle_owner_record "$1"; then
+        [[ "$2" == true ]] || exit 31
+        [[ "$inspected_lock_token" == "$3" && "$inspected_lock_pid" == 123 &&
+           "$inspected_lock_process_identity" == "$4" ]] || exit 32
+      else
+        [[ "$2" == false ]] || exit 33
+      fi
+      checked=$((checked + 1))
+      shift 4
+    done
+    [[ $checked == ${cases.length} ]]
+  `,
+    ...args,
   );
   assert.equal(result.status, 0, result.stderr);
 });

--- a/packages/website/scripts/test-install-script-portability.mjs
+++ b/packages/website/scripts/test-install-script-portability.mjs
@@ -74,6 +74,7 @@ function fixture(t, drift = "both") {
   );
   executable(join(bin, "sync"), ":");
   if (process.platform !== "darwin") {
+    executable(join(bin, "wc"), `printf '%8s\\n' "$(/usr/bin/wc "$@")"`);
     executable(
       join(bin, "date"),
       `
@@ -199,7 +200,7 @@ await test("nested subshell cleanup cannot release the parent's lock", (t) => {
   assert.equal(result.status, 0, result.stderr);
 });
 
-for (const renameDuringGuard of [false, true]) {
+for (const renameDuringGuard of ["none", "before-cd", "after-cd"]) {
   await test(`stale lock guards stay in their original directory (rename=${renameDuringGuard})`, (t) => {
     const f = fixture(t);
     const state = join(f.home, ".lore");
@@ -220,17 +221,19 @@ for (const renameDuringGuard of [false, true]) {
       }) + "\n",
       { mode: 0o600 },
     );
-    const injection = renameDuringGuard
-      ? `
+    const injection =
+      renameDuringGuard !== "none"
+        ? `
       cd() {
-        builtin cd "$@" || return 1
-        if [[ "$PWD" == "$HOME/.lore/lifecycle.lock" ]]; then
+        ${renameDuringGuard === "after-cd" ? 'builtin cd "$@" || return 1' : ""}
+        if [[ "$*" == *"$HOME/.lore/lifecycle.lock" ]]; then
           command mv "$HOME/.lore/lifecycle.lock" "$HOME/.lore/old-lock"
           command mkdir -m 700 "$HOME/.lore/lifecycle.lock"
         fi
+        ${renameDuringGuard === "before-cd" ? 'builtin cd "$@" || return 1' : ""}
       }
     `
-      : "";
+        : "";
     const result = run(
       f,
       `${functions}
@@ -240,10 +243,13 @@ for (const renameDuringGuard of [false, true]) {
       release_lifecycle_lock
     `,
     );
-    if (renameDuringGuard) {
+    if (renameDuringGuard !== "none") {
       assert.notEqual(result.status, 0);
       assert.deepEqual(readdirSync(lock), []);
-      assert.ok(existsSync(join(state, "old-lock/lifecycle.lock")));
+      assert.equal(
+        existsSync(join(state, "old-lock/lifecycle.lock")),
+        renameDuringGuard === "after-cd",
+      );
     } else {
       assert.equal(result.status, 0, result.stderr);
       assert.equal(existsSync(lock), false);
@@ -296,6 +302,46 @@ await test("installs and releases locks without Bash 4 BASHPID", (t) => {
     "channel",
     "install-path",
   ]);
+});
+
+await test("installs when Bash reads the script from a pipe", (t) => {
+  const f = fixture(t);
+  const result = spawnSync(bash, ["-s", "--", "--no-modify-path"], {
+    cwd: f.home,
+    env: f.env,
+    input: source,
+    encoding: "utf8",
+    timeout: 30_000,
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(readdirSync(join(f.home, ".lore")).sort(), [
+    "channel",
+    "install-path",
+  ]);
+});
+
+await test("owner descriptor validation failure retains its diagnostic and cleans up", (t) => {
+  const f = fixture(t);
+  const result = run(
+    f,
+    `${functions}
+    stat() {
+      if [[ $# == 2 && "$2" == %p ]]; then
+        mode=$(command stat "$@") || return 1
+        if (( (8#$mode & 07777) == 0600 )); then
+          printf '100644\\n'
+          return 0
+        fi
+      fi
+      command stat "$@"
+    }
+    canonical_home=$(pwd -P)
+    acquire_lifecycle_lock
+  `,
+  );
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /Could not stage Lore lifecycle lock owner/);
+  assert.deepEqual(readdirSync(join(f.home, ".lore")), []);
 });
 
 for (const when of ["before-cd", "during-chmod"]) {


### PR DESCRIPTION
macOS users cannot complete installation because several lifecycle checks assume GNU utilities or newer Bash behavior. Fixes #1690's installer failure.

The installer now reads held descriptors with BSD stat's stdin/fstat mode, preserves full device/inode identity, and changes directory permissions or creates stale-lock guards only within a verified, pinned working directory. Exclusive owner-file creation and exact permission checks remain enforced.

It also uses Bash 3.2's BASH_SUBSHELL for cleanup ownership, normalizes BSD wc output and padded process timestamps, keeps regex repetition bounds within Darwin's limit of 255 while preserving the original field length limits, and retains diagnostics when owner-file validation fails.

A dependency-free suite exercises stock Bash and real BSD utilities on macOS, plus deterministic devfs and BSD-utility emulation on Linux. Both platforms now gate CI Status.

Validation:
- All 15 portability tests pass locally, including piped installation, descriptor metadata, directory replacement races, subshell ownership, parser length boundaries, padded/localized process timestamps, and failure cleanup.
- Original installer failures reproduced before the fixes. Independent correctness and security reviews found no remaining defects; focused mutants verify the identity, permissions, race, ownership, count, diagnostic, and parser guards.
- Typecheck, lint, formatting, Bash syntax/compatibility, and ten runs of the sync property suite pass.
- Local existing installer suite: 26 pass; three process-visibility cases fail identically on base and fix. Full local tests are blocked by this environment's IPC/process limitations; hosted CI supplies that gate.
- Native macOS and Linux portability jobs both pass all 15 tests on b367252b. Typecheck, lint, and formatting also pass on this commit. Its full hosted suite is still running; the earlier bf15030e revision passed 9,991 tests (224 skipped).
- Seer's final annotation was independently verified as a false positive against Apple stat's implementation, documented, and resolved.

The separate runtime ON CONFLICT message in the issue comments is outside this installer fix.

Implementation references: [Apple stat fstat behavior](https://github.com/apple-oss-distributions/file_cmds/blob/main/stat/stat.c), [Apple regex repetition limit](https://github.com/apple-oss-distributions/Libc/blob/main/regex/TRE/lib/tre.h).