### PR TITLE
fix(gateway): preserve provider usage limits across response transformations

### DIFF
--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -14902,6 +14902,11 @@ async function handlePassthrough(
     abortScope.signal,
   );
 
+  const withLimits = (response: Response): Response => {
+    copyUsageLimitHeaders(upstreamResponse.headers, response.headers);
+    return response;
+  };
+
   // Meta/side-channel calls must preserve provider errors as ordinary HTTP
   // responses. Running a 4xx/429 body through an SSE validator would launder
   // it into status 200 or a synthetic stream failure.
@@ -14925,11 +14930,13 @@ async function handlePassthrough(
   // to a different protocol (e.g., OpenAI client → Anthropic upstream).
   if (wireProtocol === req.protocol) {
     if (req.stream && upstreamResponse.body) {
-      return validatedMetaStream(
-        upstreamResponse,
-        wireProtocol,
-        req.codex === true,
-        abortScope.signal,
+      return withLimits(
+        validatedMetaStream(
+          upstreamResponse,
+          wireProtocol,
+          req.codex === true,
+          abortScope.signal,
+        ),
       );
     }
     const body = await readForegroundBody(
@@ -14963,22 +14970,28 @@ async function handlePassthrough(
         },
       });
       if (req.protocol === "openai") {
-        return translateAnthropicStreamToOpenAI(anthropicSSE, {
-          strict: true,
-          signal: abortScope.signal,
-        });
+        return withLimits(
+          translateAnthropicStreamToOpenAI(anthropicSSE, {
+            strict: true,
+            signal: abortScope.signal,
+          }),
+        );
       }
       if (req.protocol === "openai-responses") {
-        return translateAnthropicStreamToResponses(anthropicSSE, {
-          strict: true,
-          signal: abortScope.signal,
-        });
+        return withLimits(
+          translateAnthropicStreamToResponses(anthropicSSE, {
+            strict: true,
+            signal: abortScope.signal,
+          }),
+        );
       }
       if (req.protocol === "gemini") {
-        return translateAnthropicStreamToGemini(anthropicSSE, {
-          strict: true,
-          signal: abortScope.signal,
-        });
+        return withLimits(
+          translateAnthropicStreamToGemini(anthropicSSE, {
+            strict: true,
+            signal: abortScope.signal,
+          }),
+        );
       }
     }
     // Other cross-protocol streaming combos: accumulate + re-emit
@@ -15009,12 +15022,14 @@ async function handlePassthrough(
                 stopAtTerminal: true,
               }),
     );
-    return nonStreamHttpResponse(
-      resp,
-      req.protocol,
-      req.stream,
-      undefined,
-      requestEnablesLongContext(req),
+    return withLimits(
+      nonStreamHttpResponse(
+        resp,
+        req.protocol,
+        req.stream,
+        undefined,
+        requestEnablesLongContext(req),
+      ),
     );
   }
 
@@ -15027,12 +15042,14 @@ async function handlePassthrough(
       abortScope.signal,
     ),
   );
-  return nonStreamHttpResponse(
-    resp,
-    req.protocol,
-    req.stream,
-    undefined,
-    requestEnablesLongContext(req),
+  return withLimits(
+    nonStreamHttpResponse(
+      resp,
+      req.protocol,
+      req.stream,
+      undefined,
+      requestEnablesLongContext(req),
+    ),
   );
 }
 
@@ -15159,13 +15176,15 @@ async function handleProvisionalConversationTurn(
       requestCredentialFingerprint(req.rawHeaders, config) ?? undefined,
     );
     if (error.status === "incomplete" && !hasRecallToolUse(error.response)) {
-      return nonStreamHttpResponse(
+      const response = nonStreamHttpResponse(
         error.response,
         req.protocol,
         req.stream,
         undefined,
         requestEnablesLongContext(req),
       );
+      copyUsageLimitHeaders(upstreamResponse.headers, response.headers);
+      return response;
     }
     return errorResponse(502, "Gateway request failed");
   }
@@ -17876,6 +17895,15 @@ async function handleConversationTurn(
 
       // Update for next iteration
       currentModifiedReq = followUp;
+      // Recall can consume another quota window or omit quota metadata entirely.
+      // Keep this turn's ordered updates so the rebuilt stream reports every
+      // bucket, with newer updates following older ones.
+      if (currentResp.codexRateLimits?.length) {
+        continuationResp.codexRateLimits = [
+          ...currentResp.codexRateLimits,
+          ...(continuationResp.codexRateLimits ?? []),
+        ];
+      }
       currentResp = continuationResp;
       // Loop continues — hasRecallToolUse checked at top
     }

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -11,6 +11,7 @@
  *  2. Meta requests (title gen, summaries, etc.) → forwarded transparently, no Lore processing.
  *  3. Normal conversation turns → full pipeline.
  */
+import { copyUsageLimitHeaders } from "./usage-limit-headers";
 import { storeTurnTemporal, type TurnTemporalInput } from "./turn-temporal";
 import {
   PreparationTiming,
@@ -11331,6 +11332,7 @@ function boundedRetryAfterMs(value: string): string | undefined {
 
 function sanitizedUpstreamErrorResponse(response: Response): Response {
   const headers = new Headers({ "content-type": "application/json" });
+  copyUsageLimitHeaders(response.headers, headers);
   const retryAfter = response.headers.get("retry-after");
   const retryAfterMs = response.headers.get("retry-after-ms");
   const boundedRetryAfterValue = retryAfter
@@ -14941,10 +14943,9 @@ async function handlePassthrough(
         JSON.parse(body) as Record<string, unknown>,
       );
     }
-    return new Response(body, {
-      status: upstreamResponse.status,
-      headers: { "content-type": "application/json" },
-    });
+    const headers = new Headers({ "content-type": "application/json" });
+    copyUsageLimitHeaders(upstreamResponse.headers, headers);
+    return new Response(body, { status: upstreamResponse.status, headers });
   }
 
   // Cross-protocol: accumulate the upstream response and re-emit in the
@@ -15182,6 +15183,7 @@ async function handleProvisionalConversationTurn(
     undefined,
     requestEnablesLongContext(req),
   );
+  copyUsageLimitHeaders(upstreamResponse.headers, response.headers);
 
   const commit = async (): Promise<boolean> => {
     if (
@@ -17482,6 +17484,7 @@ async function handleConversationTurn(
   const finishForeground = (response: Response): Response => {
     if (foregroundOwnershipTransferred) return response;
     foregroundOwnershipTransferred = true;
+    copyUsageLimitHeaders(upstreamResponse.headers, response.headers);
     return wrapBodyWithCleanup(
       response,
       releaseForeground,

--- a/packages/gateway/src/stream/openai-responses.ts
+++ b/packages/gateway/src/stream/openai-responses.ts
@@ -56,6 +56,8 @@ export interface ResponsesAccState {
     | "response.failed";
   /** Final upstream response snapshot, used when rebuilding transformed SSE. */
   terminalResponse?: Record<string, unknown>;
+  /** Subscription metadata retained across buffered Responses reconstruction. */
+  codexRateLimits?: Array<Record<string, unknown>>;
   /** Original upstream output items, retained for terminal rebuilds. */
   rawItems: Map<number, Record<string, unknown>>;
   /** Strict-mode identity indexes. Each identity belongs to one output item. */
@@ -583,6 +585,23 @@ export function applyResponsesEvent(
   parsed: Record<string, unknown>,
 ): void {
   switch (event) {
+    case "codex.rate_limits": {
+      // Only the provider's quota event crosses buffered reconstruction. Never
+      // retain arbitrary events or diagnostic fields. The stream's existing
+      // byte/frame limits bound this response-local list.
+      const quota: Record<string, unknown> = { type: "codex.rate_limits" };
+      for (const name of [
+        "plan_type",
+        "rate_limits",
+        "credits",
+        "metered_limit_name",
+        "limit_name",
+      ]) {
+        if (Object.hasOwn(parsed, name)) quota[name] = parsed[name];
+      }
+      (state.codexRateLimits ??= []).push(quota);
+      break;
+    }
     case "response.created":
     case "response.in_progress": {
       const resp = parsed.response as Record<string, unknown> | undefined;
@@ -875,6 +894,9 @@ export function finalizeResponsesAcc(
       .filter((item) => item.type !== "item_reference"),
     stopReason,
     usage: state.usage,
+    ...(state.codexRateLimits
+      ? { codexRateLimits: state.codexRateLimits }
+      : {}),
   };
 }
 

--- a/packages/gateway/src/translate/openai-responses.ts
+++ b/packages/gateway/src/translate/openai-responses.ts
@@ -1232,6 +1232,12 @@ function buildOpenAIResponsesStreamResponse(resp: GatewayResponse): Response {
         },
       });
 
+      // Buffered Codex responses still carry subscription windows and credits.
+      // These values are independent of the token usage Lore may rescale.
+      for (const quota of resp.codexRateLimits ?? []) {
+        emit("codex.rate_limits", quota);
+      }
+
       // response.in_progress
       emit("response.in_progress", {
         type: "response.in_progress",

--- a/packages/gateway/src/translate/types.ts
+++ b/packages/gateway/src/translate/types.ts
@@ -344,6 +344,9 @@ export type GatewayResponse = {
   content: GatewayContentBlock[];
   /** Original Responses output items needed for stateless follow-up requests. */
   rawOutputItems?: Array<Record<string, unknown>>;
+  /** Codex account quota events, independent of model token usage. Response-local
+   * metadata retained only to rebuild the Responses SSE wire format. */
+  codexRateLimits?: Array<Record<string, unknown>>;
   /** Provider stop reason (e.g. `end_turn`, `stop`, `tool_use`, `length`). */
   stopReason: string;
   /**

--- a/packages/gateway/src/usage-limit-headers.ts
+++ b/packages/gateway/src/usage-limit-headers.ts
@@ -1,0 +1,18 @@
+/** Preserve account quota metadata independently of rewritten token usage. */
+export function copyUsageLimitHeaders(source: Headers, target: Headers): void {
+  const connectionHeaders = new Set(
+    (source.get("connection") ?? "")
+      .split(",")
+      .map((name) => name.trim().toLowerCase()),
+  );
+  source.forEach((value, name) => {
+    // Claude Code reads its 5h/7d subscription windows from this namespace.
+    // Never copy arbitrary upstream headers (cookies, framing, credentials).
+    if (
+      name.startsWith("anthropic-ratelimit-") &&
+      !connectionHeaders.has(name)
+    ) {
+      target.set(name, value);
+    }
+  });
+}

--- a/packages/gateway/src/usage-limit-headers.ts
+++ b/packages/gateway/src/usage-limit-headers.ts
@@ -6,10 +6,24 @@ export function copyUsageLimitHeaders(source: Headers, target: Headers): void {
       .map((name) => name.trim().toLowerCase()),
   );
   source.forEach((value, name) => {
-    // Claude Code reads its 5h/7d subscription windows from this namespace.
+    // Preserve provider units and windows verbatim, even across wire formats.
+    // OpenAI-compatible APIs share x-ratelimit-*; gateways may use the
+    // unprefixed fields. Codex has quota windows, named buckets, and credits.
     // Never copy arbitrary upstream headers (cookies, framing, credentials).
     if (
-      name.startsWith("anthropic-ratelimit-") &&
+      (name.startsWith("anthropic-ratelimit-") ||
+        name.startsWith("x-ratelimit-") ||
+        name.startsWith("x-rate-limit-") ||
+        name.startsWith("ratelimit-") ||
+        name === "ratelimit" ||
+        /^x-(?:[a-z0-9]+-)+(?:primary|secondary)-(?:used-percent|window-minutes|reset-at)$/.test(
+          name,
+        ) ||
+        name === "x-codex-limit-name" ||
+        (/^x-[a-z0-9-]+-limit-name$/.test(name) &&
+          source.has(name.replace(/-limit-name$/, "-primary-used-percent"))) ||
+        /^x-codex-credits-(?:has-credits|unlimited|balance)$/.test(name) ||
+        name === "x-codex-rate-limit-reached-type") &&
       !connectionHeaders.has(name)
     ) {
       target.set(name, value);

--- a/packages/gateway/test/claude-usage-headers.test.ts
+++ b/packages/gateway/test/claude-usage-headers.test.ts
@@ -1,0 +1,186 @@
+import { afterEach, expect, it } from "vitest";
+import { createHarness, type Harness } from "./helpers/harness";
+import { makeReplayInterceptor } from "./helpers/replay";
+import {
+  makeConversationFixtures,
+  makeFixtureEntry,
+  DEFAULT_MODEL,
+  DEFAULT_SYSTEM,
+  STANDARD_TOOLS,
+} from "./helpers/fixtures";
+import { setUpstreamInterceptor } from "../src/pipeline";
+
+const quotaHeaders = {
+  "anthropic-ratelimit-unified-5h-utilization": "0.23",
+  "anthropic-ratelimit-unified-5h-reset": "1999999999",
+  "anthropic-ratelimit-unified-7d-utilization": "0.41",
+  "anthropic-ratelimit-unified-7d-reset": "2000500000",
+  "anthropic-ratelimit-unified-status": "allowed",
+};
+let harness: Harness | undefined;
+afterEach(async () => {
+  await harness?.teardown();
+  harness = undefined;
+});
+for (const stream of [true, false]) {
+  it(`preserves subscription windows through a real conversation (stream=${stream})`, async () => {
+    const fixtures = [
+      makeFixtureEntry({
+        seq: 0,
+        requestMessages: [{ role: "user", content: "Hello" }],
+        responseText: "Hello back",
+        inputTokens: 600000,
+      }),
+    ];
+    harness = await createHarness({ fixtures });
+    const replay = makeReplayInterceptor(fixtures);
+    setUpstreamInterceptor(async (...args) => {
+      const response = await replay(...args);
+      for (const [name, value] of Object.entries(quotaHeaders))
+        response.headers.set(name, value);
+      response.headers.set("set-cookie", "upstream-secret=private");
+      response.headers.set("x-private-upstream", "private");
+      response.headers.set(
+        "connection",
+        "keep-alive, Anthropic-Ratelimit-Private-Hop",
+      );
+      response.headers.set("anthropic-ratelimit-private-hop", "not end-to-end");
+      response.headers.set("content-encoding", "gzip");
+      response.headers.set("content-length", "99999999");
+      return response;
+    });
+    const response = await harness.chat({
+      model: DEFAULT_MODEL,
+      max_tokens: 1024,
+      stream,
+      system: DEFAULT_SYSTEM,
+      tools: STANDARD_TOOLS,
+      messages: [{ role: "user", content: "Hello" }],
+    });
+    const body = await response.text();
+    expect(response.status, body).toBe(200);
+    for (const [name, value] of Object.entries(quotaHeaders))
+      expect(response.headers.get(name), name).toBe(value);
+    expect(response.headers.get("set-cookie")).toBeNull();
+    expect(response.headers.get("x-private-upstream")).toBeNull();
+    expect(response.headers.get("anthropic-ratelimit-private-hop")).toBeNull();
+    expect(response.headers.get("content-encoding")).toBeNull();
+    expect(response.headers.get("content-length")).not.toBe("99999999");
+    expect(body).toContain("Hello");
+    const message = stream
+      ? JSON.parse(
+          body
+            .split("\n")
+            .find(
+              (line) =>
+                line.startsWith("data: ") &&
+                line.includes('"type":"message_start"'),
+            )!
+            .slice(6),
+        ).message
+      : JSON.parse(body);
+    expect(message.usage.input_tokens).toBeLessThan(600000);
+  });
+}
+
+for (const stream of [true, false]) {
+  it(`preserves quota exhaustion and reset headers on 429 (stream=${stream})`, async () => {
+    harness = await createHarness({ fixtures: [] });
+    setUpstreamInterceptor(
+      async () =>
+        new Response(
+          JSON.stringify({
+            error: {
+              type: "rate_limit_error",
+              message: "private upstream detail",
+            },
+          }),
+          {
+            status: 429,
+            headers: {
+              ...quotaHeaders,
+              "anthropic-ratelimit-unified-status": "rejected",
+              "retry-after": "30",
+              "set-cookie": "private=secret",
+            },
+          },
+        ),
+    );
+    const response = await harness.chat({
+      model: DEFAULT_MODEL,
+      max_tokens: 1024,
+      stream,
+      system: DEFAULT_SYSTEM,
+      tools: STANDARD_TOOLS,
+      messages: [{ role: "user", content: "Hello" }],
+    });
+    const body = await response.text();
+    expect(response.status).toBe(429);
+    expect(response.headers.get("anthropic-ratelimit-unified-status")).toBe(
+      "rejected",
+    );
+    expect(response.headers.get("anthropic-ratelimit-unified-5h-reset")).toBe(
+      quotaHeaders["anthropic-ratelimit-unified-5h-reset"],
+    );
+    expect(response.headers.get("retry-after")).toBe("30");
+    expect(response.headers.get("set-cookie")).toBeNull();
+    expect(body).not.toContain("private upstream detail");
+  });
+}
+it("preserves quota headers on buffered side-channel requests", async () => {
+  const fixtures = makeConversationFixtures([
+    { userMessage: "Title", assistantText: "A title" },
+  ]);
+  harness = await createHarness({ fixtures });
+  const replay = makeReplayInterceptor(fixtures);
+  setUpstreamInterceptor(async (...args) => {
+    const response = await replay(...args);
+    for (const [name, value] of Object.entries(quotaHeaders))
+      response.headers.set(name, value);
+    return response;
+  });
+  const response = await harness.chat({
+    model: DEFAULT_MODEL,
+    max_tokens: 32,
+    stream: false,
+    messages: [{ role: "user", content: "Title" }],
+  });
+  const body = await response.text();
+  expect(response.status, body).toBe(200);
+  for (const [name, value] of Object.entries(quotaHeaders))
+    expect(response.headers.get(name)).toBe(value);
+});
+it("never reuses another account's quota when an upstream omits it", async () => {
+  const fixtures = makeConversationFixtures([
+    { userMessage: "One", assistantText: "One" },
+    { userMessage: "Two", assistantText: "Two" },
+  ]);
+  harness = await createHarness({ fixtures });
+  const replay = makeReplayInterceptor(fixtures);
+  let calls = 0;
+  setUpstreamInterceptor(async (...args) => {
+    const response = await replay(...args);
+    if (calls++ === 0)
+      for (const [name, value] of Object.entries(quotaHeaders))
+        response.headers.set(name, value);
+    return response;
+  });
+  const request = {
+    model: DEFAULT_MODEL,
+    max_tokens: 1024,
+    stream: false,
+    system: DEFAULT_SYSTEM,
+    tools: STANDARD_TOOLS,
+    messages: [{ role: "user", content: "Hello" }],
+  };
+  const first = await harness.chat(request, "account-one");
+  await first.text();
+  expect(first.headers.get("anthropic-ratelimit-unified-5h-utilization")).toBe(
+    "0.23",
+  );
+  const second = await harness.chat(request, "account-two");
+  await second.text();
+  expect(second.status).toBe(200);
+  for (const name of Object.keys(quotaHeaders))
+    expect(second.headers.get(name)).toBeNull();
+});

--- a/packages/gateway/test/claude-usage-provisional.test.ts
+++ b/packages/gateway/test/claude-usage-provisional.test.ts
@@ -1,0 +1,87 @@
+import { dirname } from "node:path";
+import { afterEach, expect, it } from "vitest";
+import { createHarness, type Harness } from "./helpers/harness";
+import { makeReplayInterceptor } from "./helpers/replay";
+import {
+  makeConversationFixtures,
+  DEFAULT_MODEL,
+  DEFAULT_SYSTEM,
+  STANDARD_TOOLS,
+} from "./helpers/fixtures";
+import { setUpstreamInterceptor } from "../src/pipeline";
+
+let harness: Harness | undefined;
+afterEach(async () => {
+  await harness?.teardown();
+  harness = undefined;
+});
+
+for (const stream of [true, false]) {
+  for (const status of [200, 429]) {
+    it(`preserves quota during real Claude session header migration (stream=${stream}, status=${status})`, async () => {
+      const fixtures = makeConversationFixtures([
+        { userMessage: "Hello", assistantText: "Hello back" },
+        { userMessage: "Continue", assistantText: "Continuing" },
+      ]);
+      harness = await createHarness({ fixtures });
+      const replay = makeReplayInterceptor(fixtures);
+      let calls = 0;
+      setUpstreamInterceptor(async (...args) => {
+        calls++;
+        const response =
+          calls === 2 && status === 429
+            ? new Response("private upstream quota detail", {
+                status,
+                headers: { "retry-after": "30" },
+              })
+            : await replay(...args);
+        response.headers.set(
+          "anthropic-ratelimit-unified-5h-utilization",
+          "0.82",
+        );
+        response.headers.set(
+          "anthropic-ratelimit-unified-7d-reset",
+          "2000500000",
+        );
+        return response;
+      });
+      const request = {
+        model: DEFAULT_MODEL,
+        max_tokens: 1024,
+        stream,
+        system:
+          DEFAULT_SYSTEM + "\nWorking directory: " + dirname(harness.dbPath),
+        tools: STANDARD_TOOLS,
+        messages: [{ role: "user", content: "Hello" }],
+      };
+      const alias = "claude-session-before-plugin";
+      const initial = await harness.chat(request, "account-one", {
+        "x-claude-code-session-id": alias,
+      });
+      expect(initial.status).toBe(200);
+      await initial.text();
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      await new Promise<void>((resolve) => setImmediate(resolve));
+
+      // A newly introduced canonical header must adopt the already-confirmed
+      // Claude alias through the provisional verification path.
+      const response = await harness.chat(request, "account-one", {
+        "x-claude-code-session-id": alias,
+        "x-lore-session-id": "claude-session-after-plugin",
+      });
+      const body = await response.text();
+      expect(calls).toBe(2);
+      expect(response.status, body).toBe(status);
+      expect(
+        response.headers.get("anthropic-ratelimit-unified-5h-utilization"),
+      ).toBe("0.82");
+      expect(response.headers.get("anthropic-ratelimit-unified-7d-reset")).toBe(
+        "2000500000",
+      );
+      if (status === 429) {
+        expect(response.headers.get("retry-after")).toBe("30");
+        expect(body).not.toContain("private upstream quota detail");
+      }
+    });
+  }
+}

--- a/packages/gateway/test/codex-usage-metadata.test.ts
+++ b/packages/gateway/test/codex-usage-metadata.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, test } from "vitest";
+import fc from "fast-check";
+import {
+  accumulateResponsesSSEStream,
+  ResponsesTerminalError,
+  streamResponsesPassthrough,
+} from "../src/stream/openai-responses";
+import { buildOpenAIResponsesResponse } from "../src/translate/openai-responses";
+
+const limits = {
+  type: "codex.rate_limits",
+  plan_type: "pro",
+  rate_limits: {
+    primary: { used_percent: 12.5, window_minutes: 300, reset_at: 2000000000 },
+    secondary: {
+      used_percent: 75,
+      window_minutes: 10080,
+      reset_at: 2000100000,
+    },
+  },
+  credits: { has_credits: true, unlimited: false, balance: "12.34" },
+};
+
+function upstream(
+  events: Record<string, unknown>[],
+  incomplete = false,
+): Response {
+  const status = incomplete ? "incomplete" : "completed";
+  return new Response(
+    [
+      ...events,
+      {
+        type: `response.${status}`,
+        response: {
+          id: "resp_quota",
+          model: "gpt-5",
+          status,
+          output: [],
+          usage: { input_tokens: 600000, output_tokens: 1 },
+          ...(incomplete
+            ? { incomplete_details: { reason: "max_output_tokens" } }
+            : {}),
+        },
+      },
+    ]
+      .map(
+        (data) =>
+          `event: ${String(data.type)}\ndata: ${JSON.stringify(data)}\n\n`,
+      )
+      .join(""),
+    { headers: { "content-type": "text/event-stream" } },
+  );
+}
+
+function quotaEvents(body: string): unknown[] {
+  return body
+    .split("\n\n")
+    .filter((frame) => frame.startsWith("event: codex.rate_limits\n"))
+    .map((frame) => JSON.parse(frame.split("\ndata: ")[1]));
+}
+
+describe("Codex subscription metadata", () => {
+  test("preserves every metered bucket through buffered stream rebuilding", async () => {
+    const events = [limits, { ...limits, metered_limit_name: "codex_spark" }];
+    const response = await accumulateResponsesSSEStream(upstream(events), {
+      validation: "codex",
+      stopAtTerminal: true,
+      requireCompletedTerminal: true,
+    });
+    const body = await buildOpenAIResponsesResponse(response, true).text();
+    expect(quotaEvents(body)).toEqual(events);
+    expect(body.indexOf("codex.rate_limits")).toBeLessThan(
+      body.indexOf("event: response.completed"),
+    );
+  });
+
+  test("preserves metadata on incomplete buffered terminals", async () => {
+    let failure: ResponsesTerminalError | undefined;
+    try {
+      await accumulateResponsesSSEStream(upstream([limits], true), {
+        validation: "codex",
+        stopAtTerminal: true,
+        requireCompletedTerminal: true,
+      });
+    } catch (error) {
+      if (!(error instanceof ResponsesTerminalError)) throw error;
+      failure = error;
+    }
+    expect(failure).toBeInstanceOf(ResponsesTerminalError);
+    const body = await buildOpenAIResponsesResponse(
+      failure!.response,
+      true,
+    ).text();
+    expect(quotaEvents(body)).toEqual([limits]);
+  });
+
+  test("does not retain unrelated event fields or arbitrary events", async () => {
+    const response = await accumulateResponsesSSEStream(
+      upstream([
+        {
+          ...limits,
+          authorization: "private-credential",
+          debug: { secret: "private" },
+        },
+        { type: "codex.private_metadata", secret: "private" },
+      ]),
+      { validation: "codex", stopAtTerminal: true },
+    );
+    const body = await buildOpenAIResponsesResponse(response, true).text();
+    expect(quotaEvents(body)).toEqual([limits]);
+    expect(body).not.toContain("private");
+  });
+
+  test("does not retain metadata across responses or after the terminal", async () => {
+    const first = await accumulateResponsesSSEStream(upstream([limits]), {
+      validation: "codex",
+      stopAtTerminal: true,
+    });
+    expect(
+      quotaEvents(await buildOpenAIResponsesResponse(first, true).text()),
+    ).toEqual([limits]);
+    const second = await accumulateResponsesSSEStream(upstream([]), {
+      validation: "codex",
+      stopAtTerminal: true,
+    });
+    expect(
+      quotaEvents(await buildOpenAIResponsesResponse(second, true).text()),
+    ).toEqual([]);
+    const terminalThenQuota = new Response(
+      `${await upstream([]).text()}event: codex.rate_limits\ndata: ${JSON.stringify(limits)}\n\n`,
+    );
+    const afterTerminal = await accumulateResponsesSSEStream(
+      terminalThenQuota,
+      { validation: "codex", stopAtTerminal: true },
+    );
+    expect(
+      quotaEvents(
+        await buildOpenAIResponsesResponse(afterTerminal, true).text(),
+      ),
+    ).toEqual([]);
+  });
+
+  test("true streaming forwards quota events without duplication", async () => {
+    const response = streamResponsesPassthrough(
+      upstream([limits]),
+      () => {},
+      undefined,
+      "codex",
+    );
+    expect(quotaEvents(await response.text())).toEqual([limits]);
+  });
+
+  test.each(Array.from({ length: 10 }, (_, seed) => seed))(
+    "preserves ordered quota updates without changing consumption (seed %i)",
+    async (seed) => {
+      await fc.assert(
+        fc.asyncProperty(
+          fc.array(
+            fc.record({
+              metered_limit_name: fc.string({ maxLength: 30 }),
+              used_percent: fc.double({ min: 0, max: 100, noNaN: true }),
+              reset_at: fc.integer({ min: 1, max: 2147483647 }),
+            }),
+            { minLength: 1, maxLength: 20 },
+          ),
+          async (updates) => {
+            const events = updates.map(
+              ({ metered_limit_name, ...primary }) => ({
+                type: "codex.rate_limits",
+                metered_limit_name,
+                rate_limits: { primary },
+              }),
+            );
+            const accumulated = await accumulateResponsesSSEStream(
+              upstream(events),
+              {
+                validation: "codex",
+                stopAtTerminal: true,
+              },
+            );
+            expect(accumulated.usage?.inputTokens).toBe(600000);
+            const body = await buildOpenAIResponsesResponse(
+              accumulated,
+              true,
+            ).text();
+            expect(quotaEvents(body)).toEqual(events);
+          },
+        ),
+        { seed, numRuns: 25 },
+      );
+    },
+  );
+});

--- a/packages/gateway/test/codex-usage-provisional.test.ts
+++ b/packages/gateway/test/codex-usage-provisional.test.ts
@@ -1,0 +1,112 @@
+import { dirname } from "node:path";
+import { afterEach, expect, it } from "vitest";
+import { createHarness, type Harness } from "./helpers/harness";
+import { DEFAULT_SYSTEM } from "./helpers/fixtures";
+import { getActiveSessions, setUpstreamInterceptor } from "../src/pipeline";
+import { buildOpenAIResponsesResponse } from "../src/translate/openai-responses";
+
+let harness: Harness | undefined;
+afterEach(async () => {
+  await harness?.teardown();
+  harness = undefined;
+});
+
+for (const incomplete of [false, true]) {
+  it(`preserves current Codex quota during session header migration (incomplete=${incomplete})`, async () => {
+    harness = await createHarness({ fixtures: [] });
+    let calls = 0;
+    const quotaEvents: Record<string, unknown>[] = [];
+    setUpstreamInterceptor(async () => {
+      calls++;
+      const quota = {
+        type: "codex.rate_limits",
+        rate_limits: {
+          primary: {
+            used_percent: calls * 10,
+            window_minutes: 300,
+            reset_at: 2000000000,
+          },
+          secondary: {
+            used_percent: calls * 20,
+            window_minutes: 10080,
+            reset_at: 2000100000,
+          },
+        },
+      };
+      quotaEvents.push(quota);
+      const response = buildOpenAIResponsesResponse(
+        {
+          id: "resp_quota",
+          model: "gpt-5",
+          content: [{ type: "text", text: "Hello quota" }],
+          stopReason: calls === 2 && incomplete ? "max_tokens" : "end_turn",
+          usage: { inputTokens: 600000, outputTokens: 3 },
+        },
+        true,
+      );
+      return new Response(
+        `event: codex.rate_limits\ndata: ${JSON.stringify(quota)}\n\n${await response.text()}`,
+        {
+          headers: {
+            "content-type": "text/event-stream",
+            "x-codex-primary-used-percent": String(calls * 10),
+            "x-codex-secondary-reset-at": "2000100000",
+          },
+        },
+      );
+    });
+    const projectPath = dirname(harness.dbPath);
+    const request = {
+      model: "gpt-5",
+      stream: true,
+      instructions: DEFAULT_SYSTEM + "\nWorking directory: " + projectPath,
+      input: [{ role: "user", content: "Hello" }],
+      tools: ["read", "write", "shell"].map((name) => ({
+        type: "function",
+        name,
+        description: name,
+        parameters: { type: "object", properties: {} },
+      })),
+    };
+    const headers = {
+      "content-type": "application/json",
+      authorization: "Bearer account-one",
+      "x-lore-provider": "openai-codex",
+      "x-lore-project": projectPath,
+      "x-session-id": "codex-before-plugin",
+    };
+    const initial = await harness.request("/v1/codex/responses", {
+      method: "POST",
+      headers,
+      body: JSON.stringify(request),
+    });
+    expect(initial.status).toBe(200);
+    expect(await initial.text()).toContain("Hello quota");
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(getActiveSessions().size).toBe(1);
+
+    const migrated = await harness.request("/v1/codex/responses", {
+      method: "POST",
+      headers: { ...headers, "x-lore-session-id": "codex-after-plugin" },
+      body: JSON.stringify(request),
+    });
+    const body = await migrated.text();
+    expect(migrated.status, body).toBe(200);
+    expect(calls).toBe(2);
+    expect(getActiveSessions().size).toBe(1);
+    expect(migrated.headers.get("x-codex-primary-used-percent")).toBe("20");
+    expect(migrated.headers.get("x-codex-secondary-reset-at")).toBe(
+      "2000100000",
+    );
+    const events = body
+      .split("\n\n")
+      .filter((frame) => frame.startsWith("event: codex.rate_limits\n"))
+      .map((frame) => JSON.parse(frame.split("\ndata: ")[1]));
+    expect(events).toEqual([quotaEvents[1]]);
+    expect(body).toContain(
+      incomplete ? "event: response.incomplete" : "event: response.completed",
+    );
+    expect(body).not.toContain('"input_tokens":600000');
+  });
+}

--- a/packages/gateway/test/provider-usage-headers.test.ts
+++ b/packages/gateway/test/provider-usage-headers.test.ts
@@ -1,0 +1,260 @@
+import { dirname } from "node:path";
+import { afterEach, expect, it } from "vitest";
+import { createHarness, type Harness } from "./helpers/harness";
+import { DEFAULT_SYSTEM } from "./helpers/fixtures";
+import { anthropicMessageToSSE } from "./helpers/replay";
+import { getActiveSessions, setUpstreamInterceptor } from "../src/pipeline";
+import { _setTestVertexTokenProvider } from "../src/vertex-auth";
+import { buildOpenAIResponse } from "../src/translate/openai";
+import { buildOpenAIResponsesResponse } from "../src/translate/openai-responses";
+import { buildGeminiResponse } from "../src/translate/gemini";
+import type { GatewayProtocol, GatewayResponse } from "../src/translate/types";
+
+// Quota namespaces seen on provider/aggregator responses. Gemini's public
+// API does not document quota headers; a proxy can still supply these, and
+// the gateway must not fabricate any when the upstream omits them.
+const limits = {
+  "anthropic-ratelimit-unified-5h-utilization": "0.23",
+  "x-ratelimit-remaining-tokens": "149984",
+  "x-ratelimit-reset-requests": "1s",
+  "x-ratelimit-remaining-tokens-minute": "59990",
+  "x-rate-limit-remaining": "42",
+  "ratelimit-remaining": "99",
+  ratelimit: '"default";r=99;t=30',
+  "ratelimit-policy": '"default";q=100;w=60',
+  "x-codex-primary-used-percent": "12.5",
+  "x-codex-primary-window-minutes": "300",
+  "x-codex-secondary-reset-at": "2000500000",
+  "x-codex-bengalfox-primary-used-percent": "80",
+  "x-codex-bengalfox-limit-name": "model-specific",
+  "x-review-primary-used-percent": "30",
+  "x-review-primary-window-minutes": "300",
+  "x-review-secondary-reset-at": "2000100000",
+  "x-review-limit-name": "review-meter",
+  "x-codex-credits-has-credits": "true",
+  "x-codex-credits-unlimited": "false",
+  "x-codex-credits-balance": "10.25",
+  "x-codex-rate-limit-reached-type": "credits",
+};
+let harness: Harness | undefined;
+afterEach(async () => {
+  await harness?.teardown();
+  harness = undefined;
+  _setTestVertexTokenProvider(null);
+});
+
+type Client = Exclude<GatewayProtocol, "vertex"> | "codex";
+// Keep this exhaustive as wire protocols are added. Native Responses/Gemini
+// ingress accepts an explicit Anthropic override, while other provider headers
+// retain the native protocol. Bedrock uses the Anthropic wire family.
+const clientProtocols = {
+  anthropic: ["anthropic", "openai", "openai-responses", "gemini"],
+  openai: ["anthropic", "openai"],
+  "openai-responses": ["anthropic", "openai", "openai-responses", "codex"],
+  vertex: ["anthropic", "openai"],
+  gemini: ["gemini"],
+} satisfies Record<GatewayProtocol, Client[]>;
+const routes = [
+  ...Object.entries(clientProtocols).flatMap(([upstream, clients]) =>
+    clients.map((client) => ({ upstream, client })),
+  ),
+  { upstream: "bedrock", client: "anthropic" as const },
+];
+
+function upstreamReply(protocol: string, stream: boolean): Response {
+  const response: GatewayResponse = {
+    id: "msg_quota",
+    model: "quota-model",
+    content: [{ type: "text", text: "Hello quota" }],
+    stopReason: "end_turn",
+    usage: { inputTokens: 10, outputTokens: 3 },
+  };
+  if (protocol === "openai") return buildOpenAIResponse(response, stream);
+  if (protocol === "openai-responses")
+    return buildOpenAIResponsesResponse(response, stream);
+  if (protocol === "gemini") return buildGeminiResponse(response, stream);
+  const message = {
+    id: response.id,
+    type: "message",
+    role: "assistant",
+    model: response.model,
+    content: [{ type: "text", text: "Hello quota" }],
+    stop_reason: "end_turn",
+    usage: { input_tokens: 10, output_tokens: 3 },
+  };
+  return stream
+    ? new Response(anthropicMessageToSSE(message), {
+        headers: { "content-type": "text/event-stream" },
+      })
+    : Response.json(message);
+}
+
+function requestBody(client: Client, stream: boolean, meta: boolean) {
+  const system = meta
+    ? ""
+    : DEFAULT_SYSTEM + "\nWorking directory: " + dirname(harness!.dbPath);
+  const maxTokens = meta ? 32 : 1024;
+  const functions = ["read", "write", "shell"].map((name) => ({
+    name,
+    description: name,
+    parameters: { type: "object", properties: {} },
+  }));
+  if (client === "gemini")
+    return {
+      contents: [{ role: "user", parts: [{ text: "Hello" }] }],
+      systemInstruction: { parts: [{ text: system }] },
+      generationConfig: { maxOutputTokens: maxTokens },
+      tools: meta ? [] : [{ functionDeclarations: functions }],
+    };
+  if (client === "openai-responses" || client === "codex")
+    return {
+      model: "gpt-4o",
+      stream,
+      max_output_tokens: maxTokens,
+      instructions: system,
+      input: [{ role: "user", content: "Hello" }],
+      tools: meta ? [] : functions.map((f) => ({ type: "function", ...f })),
+    };
+  if (client === "openai")
+    return {
+      model: "gpt-4o",
+      stream,
+      max_tokens: maxTokens,
+      messages: [
+        { role: "system", content: system },
+        { role: "user", content: "Hello" },
+      ],
+      tools: meta
+        ? []
+        : functions.map((f) => ({ type: "function", function: f })),
+    };
+  return {
+    model: "claude-sonnet-4-6",
+    stream,
+    max_tokens: maxTokens,
+    system,
+    messages: [{ role: "user", content: "Hello" }],
+    tools: meta
+      ? []
+      : functions.map(({ parameters, ...f }) => ({
+          ...f,
+          input_schema: parameters,
+        })),
+  };
+}
+
+function sendRequest(
+  upstream: string,
+  client: Client,
+  stream: boolean,
+  meta: boolean,
+): Promise<Response> {
+  const path =
+    client === "gemini"
+      ? `/v1beta/models/gemini-2.5-pro:${stream ? "streamGenerateContent?alt=sse" : "generateContent"}`
+      : client === "anthropic"
+        ? "/v1/messages"
+        : client === "openai"
+          ? "/v1/chat/completions"
+          : client === "codex"
+            ? "/v1/codex/responses"
+            : "/v1/responses";
+  const provider =
+    upstream === "openai"
+      ? "groq"
+      : upstream === "openai-responses"
+        ? client === "codex"
+          ? "openai-codex"
+          : "openai"
+        : upstream === "gemini"
+          ? "opencode"
+          : upstream;
+  return harness!.request(path, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization: "Bearer test-key",
+      "x-lore-provider": provider,
+      "x-lore-project": dirname(harness!.dbPath),
+    },
+    body: JSON.stringify(requestBody(client, stream, meta)),
+  });
+}
+
+for (const { upstream, client } of routes) {
+  for (const stream of [false, true]) {
+    for (const meta of [false, true]) {
+      it(`${upstream} → ${client}, stream=${stream}, meta=${meta}: preserves quota metadata`, async () => {
+        _setTestVertexTokenProvider(() => Promise.resolve("test-vertex-token"));
+        harness = await createHarness({
+          fixtures: [],
+          configOverrides: {
+            vertexProject: "quota-test",
+            vertexRegion: "global",
+          },
+        });
+        let calls = 0;
+        setUpstreamInterceptor(async (_body, _model, upstreamStream) => {
+          calls++;
+          const response = upstreamReply(upstream, upstreamStream);
+          for (const [name, value] of Object.entries(limits))
+            response.headers.set(name, value);
+          return response;
+        });
+        const response = await sendRequest(upstream, client, stream, meta);
+        const body = await response.text();
+        expect(response.status, body).toBe(200);
+        expect(body).toContain("Hello");
+        expect(calls).toBe(1);
+        expect(getActiveSessions().size).toBe(meta ? 0 : 1);
+        for (const [name, value] of Object.entries(limits))
+          expect(response.headers.get(name), name).toBe(value);
+      });
+    }
+  }
+}
+
+// Exercise HTTP errors through every upstream wire family and Codex, including
+// side-channel errors (which intentionally retain the provider error body).
+for (const { upstream, client } of [
+  { upstream: "anthropic", client: "anthropic" },
+  { upstream: "openai", client: "openai" },
+  { upstream: "openai-responses", client: "codex" },
+  { upstream: "gemini", client: "gemini" },
+  { upstream: "vertex", client: "anthropic" },
+  { upstream: "bedrock", client: "anthropic" },
+] as const) {
+  for (const stream of [false, true]) {
+    for (const meta of [false, true]) {
+      it(`${upstream} 429, stream=${stream}, meta=${meta}: retains quotas and retry hints`, async () => {
+        _setTestVertexTokenProvider(() => Promise.resolve("test-vertex-token"));
+        harness = await createHarness({
+          fixtures: [],
+          configOverrides: {
+            vertexProject: "quota-test",
+            vertexRegion: "global",
+          },
+        });
+        setUpstreamInterceptor(
+          async () =>
+            new Response("private upstream diagnostic", {
+              status: 429,
+              headers: {
+                ...limits,
+                "retry-after": "30",
+                "set-cookie": "private=secret",
+              },
+            }),
+        );
+        const response = await sendRequest(upstream, client, stream, meta);
+        const body = await response.text();
+        expect(response.status).toBe(429);
+        expect(response.headers.get("retry-after")).toBe("30");
+        expect(response.headers.get("set-cookie")).toBeNull();
+        if (!meta) expect(body).not.toContain("private upstream diagnostic");
+        for (const [name, value] of Object.entries(limits))
+          expect(response.headers.get(name), name).toBe(value);
+      });
+    }
+  }
+}

--- a/packages/gateway/test/recall-buffered-transaction.test.ts
+++ b/packages/gateway/test/recall-buffered-transaction.test.ts
@@ -16,6 +16,12 @@ import {
 import type { GatewayRequest } from "../src/translate/types";
 import { parseAnthropicResponseJSON } from "../src/translate/anthropic";
 import {
+  _resetForTest as resetWorkerHealth,
+  _setNowForTest as setWorkerHealthTime,
+  getDegradationWarning,
+  recordWorkerFailure,
+} from "../src/worker-health";
+import {
   buildRecallAnchor,
   recallAnchorContext,
   MAX_RECALL_STORE_ENTRIES,
@@ -29,7 +35,81 @@ afterEach(async () => {
   for (const id of createdKnowledge) ltm.remove(id);
   createdKnowledge.clear();
   vi.restoreAllMocks();
+  resetWorkerHealth();
 });
+
+test.each(["absent", "different-bucket"] as const)(
+  "buffered Codex recall retains prior quota when continuation metadata is %s",
+  async (continuationQuota) => {
+    knowledge();
+    const alias = crypto.randomUUID();
+    const req = request("openai-responses", alias, true);
+    setUpstreamInterceptor(async () =>
+      providerResponse("openai-responses", 1, "answer"),
+    );
+    await (await handleRequest(req, config())).text();
+    await settled();
+    const state = stateFor(alias);
+
+    // A real sustained worker failure causes response warning injection,
+    // selecting the buffered Codex path instead of live recall streaming.
+    let now = 1000000;
+    setWorkerHealthTime(() => now);
+    recordWorkerFailure(state.sessionID, "lore-distill", "rate-limit");
+    now += 31 * 60 * 1000;
+    recordWorkerFailure(state.sessionID, "lore-distill", "rate-limit");
+    expect(getDegradationWarning(state.sessionID)).not.toBeNull();
+
+    const firstQuota = {
+      type: "codex.rate_limits",
+      rate_limits: {
+        primary: {
+          used_percent: 25,
+          window_minutes: 300,
+          reset_at: 2000000000,
+        },
+      },
+    };
+    const nextQuota = { ...firstQuota, metered_limit_name: "codex_spark" };
+    let calls = 0;
+    setUpstreamInterceptor(async () => {
+      calls++;
+      const response = providerResponse(
+        "openai-responses",
+        calls,
+        calls === 1 ? "recall" : "answer",
+        true,
+      );
+      const quota =
+        calls === 1
+          ? firstQuota
+          : continuationQuota === "different-bucket"
+            ? nextQuota
+            : undefined;
+      return new Response(
+        (quota
+          ? `event: codex.rate_limits\ndata: ${JSON.stringify(quota)}\n\n`
+          : "") + (await response.text()),
+        { headers: { "content-type": "text/event-stream" } },
+      );
+    });
+    req.stream = true;
+    const response = await handleRequest(req, config());
+    const body = await response.text();
+    await settled();
+    expect(response.status, body).toBe(200);
+    expect(calls).toBe(2);
+    expect(body).toContain("Unrecovered background-worker failures");
+    expect(body).toContain("Completed answer");
+    const events = body
+      .split("\n\n")
+      .filter((frame) => frame.startsWith("event: codex.rate_limits\n"))
+      .map((frame) => JSON.parse(frame.split("\ndata: ")[1]));
+    expect(events).toEqual(
+      continuationQuota === "absent" ? [firstQuota] : [firstQuota, nextQuota],
+    );
+  },
+);
 
 describe.each(["anthropic", "openai", "openai-responses"] as const)(
   "malformed buffered %s content",

--- a/packages/gateway/test/usage-limit-headers.test.ts
+++ b/packages/gateway/test/usage-limit-headers.test.ts
@@ -1,0 +1,31 @@
+import { expect, it } from "vitest";
+import { copyUsageLimitHeaders } from "../src/usage-limit-headers";
+
+it("copies only quota namespaces and excludes Connection-nominated fields", () => {
+  const source = new Headers({
+    "X-RateLimit-Remaining-Tokens": "99",
+    "x-codex-bengalfox-secondary-used-percent": "80",
+    "x-codex-credits-balance": "10.25",
+    connection:
+      "keep-alive, X-RateLimit-Reset-Tokens, X-Codex-Primary-Used-Percent",
+    "x-ratelimit-reset-tokens": "2s",
+    "x-codex-primary-used-percent": "12.5",
+    "set-cookie": "private=secret",
+    authorization: "Bearer secret",
+    "x-codex-session-id": "private-session",
+    "x-codex-credits-secret": "private-credit",
+    "x-private-limit-name": "not-a-metered-bucket",
+    "x-ratelimitish-secret": "private-prefix",
+    "content-length": "99999",
+    "content-encoding": "gzip",
+  });
+  const target = new Headers({ "content-type": "application/json" });
+  copyUsageLimitHeaders(source, target);
+  expect(Object.fromEntries(target)).toEqual({
+    "content-type": "application/json",
+    "x-ratelimit-remaining-tokens": "99",
+    "x-codex-bengalfox-secondary-used-percent": "80",
+    "x-codex-credits-balance": "10.25",
+  });
+  expect(source.get("set-cookie")).toBe("private=secret");
+});


### PR DESCRIPTION
Lore rebuilt foreground HTTP responses without provider quota metadata, hiding Claude Code's five-hour/seven-day consumption and equivalent limits from other providers. Buffered Codex streams also discarded account quota events.

Preserve quota metadata across all five supported upstream wire protocols: Anthropic, OpenAI Chat Completions, OpenAI Responses/Codex, Gemini, and Vertex (including Bedrock's Anthropic route).

- Forward Anthropic, OpenAI-compatible, gateway RateLimit, and Codex metered-window/credit headers without changing their values or units. Filter by quota namespaces/exact field shapes and exclude Connection-nominated fields.
- Cover conversation responses, same-wire and translated side-channel responses, sanitized errors, and provisional session migration, including incomplete Responses terminals.
- Retain Codex `codex.rate_limits` events through buffered reconstruction and ordered recall continuations, including updates to different metered buckets. Metadata remains local to the current response/turn.
- Keep token scaling, error sanitization, and response framing intact. Providers without quota metadata get no fabricated limits. The protocol matrix is exhaustive at compile time when new wire protocols are added.

Validation:
- **262 tests passed** across seven focused/integration files, including all protocol pairs supported by routing, streaming/buffered responses, 429s, migration, quota-event isolation, and real buffered recall.
- Regressions failed before their fixes; removing quota accumulation/emission killed 14 tests each. Ten property seeds covered 250 generated event sequences.
- Final typecheck, lint, and formatting passed with exit code 0. Independent correctness and security reviews passed; reviewed/published tree hashes match.
- Full local `pnpm test` is blocked at the tsx pretest IPC launcher (EPERM). Full CI passed on the initial Claude-only commit; the expanded commit must pass CI before merge.

Provider references: [Claude statusline](https://code.claude.com/docs/en/statusline), [OpenAI rate-limit headers](https://developers.openai.com/api/docs/guides/rate-limits), [Groq rate-limit headers](https://console.groq.com/docs/rate-limits), [Codex quota parser](https://github.com/openai/codex/blob/main/codex-rs/codex-api/src/rate_limits.rs).

Closes #1630.