### PR TITLE
fix(upgrade): bind nightly patch source versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1015,6 +1015,8 @@ jobs:
   generate-patches:
     name: Generate Delta Patches
     needs: [changes, test, build-nightly-binaries, build-nightly-darwin]
+    outputs:
+      from-version: ${{ steps.delta.outputs.from-version }}
     if: >-
       needs.changes.outputs.code == 'true' &&
       github.ref == 'refs/heads/main' && github.event_name == 'push'
@@ -1132,6 +1134,7 @@ jobs:
           artifacts-dir: artifacts
           binaries-dir: binaries
           patches-dir: .delta-patches
+          from-version: ${{ needs.generate-patches.outputs.from-version }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
   # ---------------------------------------------------------------------------

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1076,6 +1076,11 @@ jobs:
   publish-nightly:
     name: Publish Nightly to GHCR
     needs: [changes, test, build-nightly-binaries, build-nightly-darwin, generate-patches]
+    # Serialize the rolling-tag read/compare/write window across nightly
+    # workflows. The action also refuses to move it backwards by version.
+    concurrency:
+      group: nightly-ghcr-publish
+      cancel-in-progress: false
     if: >-
       needs.changes.outputs.code == 'true' &&
       github.ref == 'refs/heads/main' && github.event_name == 'push'

--- a/packages/binpatch/action/README.md
+++ b/packages/binpatch/action/README.md
@@ -19,7 +19,7 @@ generate/publish job graph without reshaping it.
 | `mode` | What it does |
 |---|---|
 | `generate-ghcr` | Diff freshly built binaries against the previous **GHCR nightly**, size-gate the patches, leave them in `.delta-patches/` for a later publish step. |
-| `publish-ghcr` | Push the compressed binaries to the registry (`:<nightly-tag>`), create the immutable `<nightly-tag-prefix><version>` tag, and push the patch manifest (`:<patch-tag-prefix><version>`) with the integrity annotations the client reads. Only patches with a matching binary in `binaries-dir` are pushed. |
+| `publish-ghcr` | Push the compressed binaries to the registry (`:<nightly-tag>`), create the immutable `<nightly-tag-prefix><version>` tag, and push the patch manifest (`:<patch-tag-prefix><version>`) with the integrity annotations the client reads. Only patches with a matching binary in `binaries-dir` are pushed; their `from-version` must be forwarded from `generate-ghcr`. |
 | `generate-release` | Diff freshly built binaries against the previous stable **GitHub Release**, size-gate, leave them in `.delta-patches/` for a release-artifact upload (e.g. consumed by Craft). |
 
 ## Wire contract (defaults)
@@ -30,7 +30,8 @@ generate/publish job graph without reshaping it.
   filenames** (push runs from inside `artifacts-dir`).
 - **Patches:** manifest tag `<repo>:<patch-tag-prefix><version>` (default
   `patch-<version>`), artifact-type `<artifact-type-prefix>.patch`, annotations:
-  - `from-version=<prevVersion>` — the chain back-pointer.
+  - `from-version=<prevVersion>` — the chain back-pointer captured while the
+    patch was generated, not rediscovered during publishing.
   - `sha256-<binaryName>=<hex>` — the target integrity anchor, computed from the
     **uncompressed** binary. This is the sole trust anchor the client verifies
     after applying a chain.
@@ -64,6 +65,7 @@ overridden ones:
 | `artifacts-dir` | `artifacts` | (publish) `.gz` layers to push. |
 | `patches-dir` | `patches` | Where patches are written / read. |
 | `binary-glob` | `*` | Selects binaries to diff (e.g. `lore-*`). |
+| `from-version` | `""` | `publish-ghcr`: exact source version emitted by `generate-ghcr`; required to publish staged patches. |
 | `max-ratio` | `50` | Size-gate percentage. |
 | `zig-bsdiff-version` / `zig-bsdiff-sha256` | pinned | Encoder, SHA-verified. |
 | `oras-version` / `oras-sha256` | pinned | OCI client, SHA-verified. |

--- a/packages/binpatch/action/README.md
+++ b/packages/binpatch/action/README.md
@@ -19,7 +19,7 @@ generate/publish job graph without reshaping it.
 | `mode` | What it does |
 |---|---|
 | `generate-ghcr` | Diff freshly built binaries against the previous **GHCR nightly**, size-gate the patches, leave them in `.delta-patches/` for a later publish step. |
-| `publish-ghcr` | Push the compressed binaries to the registry (`:<nightly-tag>`), create the immutable `<nightly-tag-prefix><version>` tag, and push the patch manifest (`:<patch-tag-prefix><version>`) with the integrity annotations the client reads. Only patches with a matching binary in `binaries-dir` are pushed; their `from-version` must be forwarded from `generate-ghcr`. |
+| `publish-ghcr` | Push the compressed binaries directly to the immutable `<nightly-tag-prefix><version>` tag, advance the mutable `:<nightly-tag>` pointer, and push the patch manifest (`:<patch-tag-prefix><version>`) with the integrity annotations the client reads. Only patches with a matching binary in `binaries-dir` are pushed; their `from-version` must be forwarded from `generate-ghcr`. |
 | `generate-release` | Diff freshly built binaries against the previous stable **GitHub Release**, size-gate, leave them in `.delta-patches/` for a release-artifact upload (e.g. consumed by Craft). |
 
 ## Wire contract (defaults)
@@ -34,7 +34,12 @@ generate/publish job graph without reshaping it.
     patch was generated, not rediscovered during publishing.
   - `sha256-<binaryName>=<hex>` — the target integrity anchor, computed from the
     **uncompressed** binary. This is the sole trust anchor the client verifies
-    after applying a chain.
+  after applying a chain.
+
+When using `publish-ghcr`, serialize publishers targeting the same rolling
+nightly tag. The action compares versions before advancing that tag, and Lore's
+CI uses a job-level `nightly-ghcr-publish` concurrency group so an older
+workflow cannot overwrite a newer nightly.
 - **Size gate:** a patch larger than `max-ratio`% (default 50) of the gzipped
   binary is dropped (kept under the client's 60% `SIZE_THRESHOLD_RATIO` with
   margin).

--- a/packages/binpatch/action/action.yml
+++ b/packages/binpatch/action/action.yml
@@ -30,6 +30,12 @@ inputs:
       which discovers the previous version from the GitHub Releases API.
     required: false
     default: ""
+  from-version:
+    description: >-
+      publish-ghcr: exact source version used to generate the staged patches.
+      Passed from generate-ghcr; never rediscovered while publishing.
+    required: false
+    default: ""
   registry:
     description: "OCI registry base host, e.g. ghcr.io (ghcr modes only)."
     required: false
@@ -224,15 +230,12 @@ runs:
 
         echo "${GH_TOKEN_IN}" | oras login "${REGISTRY}" -u "${ACTOR}" --password-stdin
 
-        # Newest versioned nightly tag strictly older than the one being built.
-        TAGS=$(oras repo tags "${FULL_REPO}" 2>/dev/null | grep "^${NIGHTLY_TAG_PREFIX}[0-9]" | sort -V || echo "")
-        PREV_TAG=""
-        for tag in $TAGS; do
-          if [ "$tag" = "${NIGHTLY_TAG_PREFIX}${VERSION}" ]; then
-            break
-          fi
-          PREV_TAG="$tag"
-        done
+        # The target's immutable tag is deliberately not present yet. A newer
+        # workflow may have published first, so choose by strict version order
+        # rather than relying on where the target appears in the tag listing.
+        source "${{ github.action_path }}/nightly-tags.sh"
+        TAGS=$(oras repo tags "${FULL_REPO}" 2>/dev/null || echo "")
+        PREV_TAG=$(select_previous_nightly_tag "$TAGS" "$NIGHTLY_TAG_PREFIX" "$VERSION")
 
         if [ -z "$PREV_TAG" ]; then
           echo "No previous versioned nightly found, skipping patches"
@@ -415,11 +418,11 @@ runs:
         VERSION: ${{ inputs.version }}
         REGISTRY: ${{ inputs.registry }}
         REPO: ${{ inputs.repo }}
-        NIGHTLY_TAG_PREFIX: ${{ inputs.nightly-tag-prefix }}
         PATCH_TAG_PREFIX: ${{ inputs.patch-tag-prefix }}
         ARTIFACT_TYPE_PREFIX: ${{ inputs.artifact-type-prefix }}
         PATCHES_DIR: ${{ inputs.patches-dir }}
         BINARIES_DIR: ${{ inputs.binaries-dir }}
+        PATCH_FROM_VERSION: ${{ inputs.from-version }}
         PATCH_PUSH_FATAL: ${{ inputs.patch-push-fatal }}
       run: |
         set -uo pipefail
@@ -460,29 +463,29 @@ runs:
             return 0
           fi
 
-          # Find from-version by listing versioned nightly tags.
-          local TAGS PREV_TAG="" tag PREV_VERSION
-          TAGS=$(oras repo tags "${FULL_REPO}" 2>/dev/null | grep "^${NIGHTLY_TAG_PREFIX}[0-9]" | sort -V || echo "")
-          for tag in $TAGS; do
-            if [ "$tag" = "${NIGHTLY_TAG_PREFIX}${VERSION}" ]; then break; fi
-            PREV_TAG="$tag"
-          done
-
-          if [ -z "$PREV_TAG" ]; then
-            echo "No previous nightly tag found, skipping patch push"
+          # The patch bytes and chain pointer are one atomic fact. This exact
+          # value comes from generate-ghcr via the workflow job output; do not
+          # rediscover it after publishing the target tag, which can race a
+          # newer workflow and corrupt the patch chain.
+          if [ -z "$PATCH_FROM_VERSION" ]; then
+            echo "::warning::No generated patch source version, skipping patch push"
             return 0
           fi
-          PREV_VERSION="${PREV_TAG#"${NIGHTLY_TAG_PREFIX}"}"
+          source "${{ github.action_path }}/nightly-tags.sh"
+          if ! version_is_before "$PATCH_FROM_VERSION" "$VERSION"; then
+            echo "::error::Generated patch source ${PATCH_FROM_VERSION} is not older than target ${VERSION}"
+            return 1
+          fi
 
           cd "${PATCHES_DIR}" || return 1
           eval oras push "${FULL_REPO}:${PATCH_TAG_PREFIX}${VERSION}" \
             --artifact-type "${ARTIFACT_TYPE_PREFIX}.patch" \
-            --annotation "from-version=${PREV_VERSION}" \
+            --annotation "from-version=${PATCH_FROM_VERSION}" \
             "${ANNOTATIONS}" \
             "${PATCH_FILES}"
           local rc=$?
           if [ "$rc" -eq 0 ]; then
-            echo "Pushed patch manifest: ${PATCH_TAG_PREFIX}${VERSION} (from ${PREV_VERSION})"
+            echo "Pushed patch manifest: ${PATCH_TAG_PREFIX}${VERSION} (from ${PATCH_FROM_VERSION})"
           fi
           return "$rc"
         }

--- a/packages/binpatch/action/action.yml
+++ b/packages/binpatch/action/action.yml
@@ -367,10 +367,12 @@ runs:
         ACTOR: ${{ github.actor }}
       run: echo "${GH_TOKEN_IN}" | oras login "${REGISTRY}" -u "${ACTOR}" --password-stdin
 
-    - name: Push binaries to the registry
+    - name: Push immutable versioned nightly to the registry
       # Push from inside the artifacts directory so ORAS records bare filenames
       # (e.g. "lore-linux-x64.gz") as layer titles -- the client matches layers
-      # by bare filename.
+      # by bare filename. Publish the immutable versioned tag directly: another
+      # publisher can move the rolling `nightly` tag at any time, so it must
+      # never be used as the source of a version-specific tag.
       if: inputs.mode == 'publish-ghcr'
       shell: bash
       working-directory: ${{ inputs.artifacts-dir }}
@@ -378,7 +380,7 @@ runs:
         VERSION: ${{ inputs.version }}
         REGISTRY: ${{ inputs.registry }}
         REPO: ${{ inputs.repo }}
-        NIGHTLY_TAG: ${{ inputs.nightly-tag }}
+        NIGHTLY_TAG_PREFIX: ${{ inputs.nightly-tag-prefix }}
         ARTIFACT_TYPE_PREFIX: ${{ inputs.artifact-type-prefix }}
         SOURCE_URL: ${{ github.server_url }}/${{ github.repository }}
       run: |
@@ -386,15 +388,18 @@ runs:
           # lore-checksums.txt is deterministic metadata for every raw and
           # compressed target. Each layer, including this metadata, is itself
           # content-addressed by the resulting OCI manifest.
-          oras push "${REGISTRY}/${REPO}:${NIGHTLY_TAG}" \
+          oras push "${REGISTRY}/${REPO}:${NIGHTLY_TAG_PREFIX}${VERSION}" \
             --artifact-type "${ARTIFACT_TYPE_PREFIX}.nightly" \
             --annotation "org.opencontainers.image.source=${SOURCE_URL}" \
             --annotation "version=${VERSION}" \
             ./*.gz ./lore-checksums.txt
 
-    - name: Tag versioned nightly
-      # Immutable versioned tag via zero-copy `oras tag` so patch-chain
-      # resolution can find specific nightly versions.
+    - name: Update rolling nightly tag
+      # Move the rolling tag from the immutable, version-specific reference.
+      # A concurrent publisher may update `nightly`, but can never make this
+      # versioned tag point at its own binary manifest. The caller serializes
+      # this read/compare/write window, so an older workflow cannot roll it
+      # backwards after a newer one completes.
       if: inputs.mode == 'publish-ghcr'
       shell: bash
       env:
@@ -405,7 +410,9 @@ runs:
         NIGHTLY_TAG_PREFIX: ${{ inputs.nightly-tag-prefix }}
       run: |
         set -euo pipefail
-        oras tag "${REGISTRY}/${REPO}:${NIGHTLY_TAG}" "${NIGHTLY_TAG_PREFIX}${VERSION}"
+        FULL_REPO="${REGISTRY}/${REPO}"
+        source "${{ github.action_path }}/nightly-tags.sh"
+        advance_rolling_nightly "$FULL_REPO" "$NIGHTLY_TAG" "$NIGHTLY_TAG_PREFIX" "$VERSION"
 
     - name: Push delta patches to the registry
       # Upload pre-generated patches as a <patch-tag-prefix><version> manifest
@@ -437,8 +444,8 @@ runs:
         push_patches() {
           # Compute SHA-256 annotations from new binaries and collect patch files.
           shopt -s nullglob
-          local ANNOTATIONS=""
-          local PATCH_FILES=""
+          local -a annotations=()
+          local -a patch_files=()
           local patch_file basename_patch new_binary sha256
           for patch_file in "${PATCHES_DIR}"/*.patch; do
             basename_patch=$(basename "$patch_file" .patch)
@@ -454,11 +461,11 @@ runs:
               continue
             fi
             sha256=$(sha256sum "$new_binary" | cut -d' ' -f1)
-            ANNOTATIONS="${ANNOTATIONS} --annotation sha256-${basename_patch}=${sha256}"
-            PATCH_FILES="${PATCH_FILES} $(basename "$patch_file")"
+            annotations+=(--annotation "sha256-${basename_patch}=${sha256}")
+            patch_files+=("$(basename "$patch_file")")
           done
 
-          if [ -z "$PATCH_FILES" ]; then
+          if [ "${#patch_files[@]}" -eq 0 ]; then
             echo "No patches to push"
             return 0
           fi
@@ -478,11 +485,11 @@ runs:
           fi
 
           cd "${PATCHES_DIR}" || return 1
-          eval oras push "${FULL_REPO}:${PATCH_TAG_PREFIX}${VERSION}" \
+          oras push "${FULL_REPO}:${PATCH_TAG_PREFIX}${VERSION}" \
             --artifact-type "${ARTIFACT_TYPE_PREFIX}.patch" \
             --annotation "from-version=${PATCH_FROM_VERSION}" \
-            "${ANNOTATIONS}" \
-            "${PATCH_FILES}"
+            "${annotations[@]}" \
+            "${patch_files[@]}"
           local rc=$?
           if [ "$rc" -eq 0 ]; then
             echo "Pushed patch manifest: ${PATCH_TAG_PREFIX}${VERSION} (from ${PATCH_FROM_VERSION})"

--- a/packages/binpatch/action/nightly-tags.sh
+++ b/packages/binpatch/action/nightly-tags.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Helpers shared by the nightly delta-patch generation and publish steps.
+#
+# Keep this dependency-free: a composite Action runs before the repository's
+# Node dependencies are installed. `sort -V` is available on the Ubuntu GitHub
+# runners and correctly orders Lore's SemVer dev timestamp versions.
+
+version_is_before() {
+  local left="${1-}"
+  local right="${2-}"
+
+  [ -n "$left" ] && [ -n "$right" ] && [ "$left" != "$right" ] || return 1
+  [ "$(printf '%s\n%s\n' "$left" "$right" | sort -V | sed -n '1p')" = "$left" ]
+}
+
+# Print the greatest versioned-nightly tag strictly below $3. The target tag
+# need not exist yet: generation intentionally happens before publication.
+select_previous_nightly_tag() {
+  local tags="${1-}"
+  local prefix="${2-}"
+  local target_version="${3-}"
+  local tag version previous_tag="" previous_version=""
+
+  [ -n "$prefix" ] && [ -n "$target_version" ] || return 2
+
+  while IFS= read -r tag; do
+    case "$tag" in
+      "${prefix}"*) ;;
+      *) continue ;;
+    esac
+
+    version="${tag#"${prefix}"}"
+    case "$version" in
+      [0-9]*) ;;
+      *) continue ;;
+    esac
+
+    if version_is_before "$version" "$target_version" && {
+      [ -z "$previous_version" ] || version_is_before "$previous_version" "$version";
+    }; then
+      previous_tag="$tag"
+      previous_version="$version"
+    fi
+  done <<< "$tags"
+
+  printf '%s\n' "$previous_tag"
+}

--- a/packages/binpatch/action/nightly-tags.sh
+++ b/packages/binpatch/action/nightly-tags.sh
@@ -13,6 +13,54 @@ version_is_before() {
   [ "$(printf '%s\n%s\n' "$left" "$right" | sort -V | sed -n '1p')" = "$left" ]
 }
 
+# The rolling nightly tag must never move backwards when an older workflow
+# finishes after a newer one. Callers serialize the read/compare/write window;
+# this helper makes the version decision deterministic within that window.
+should_advance_rolling_nightly() {
+  local current_version="${1-}"
+  local candidate_version="${2-}"
+
+  [ -n "$candidate_version" ] || return 2
+  [ -z "$current_version" ] || version_is_before "$current_version" "$candidate_version"
+}
+
+# Advance a rolling nightly tag only when a candidate is strictly newer. The
+# caller must serialize this function across publishers targeting the same
+# registry/tag; registry lookup failures deliberately leave the pointer alone.
+advance_rolling_nightly() {
+  local full_repo="${1-}"
+  local nightly_tag="${2-}"
+  local nightly_tag_prefix="${3-}"
+  local candidate_version="${4-}"
+  local tags current_manifest current_version=""
+
+  [ -n "$full_repo" ] && [ -n "$nightly_tag" ] && [ -n "$nightly_tag_prefix" ] && [ -n "$candidate_version" ] || return 2
+
+  if ! tags=$(oras repo tags "$full_repo"); then
+    echo "::warning::Unable to list tags for ${full_repo}; not advancing rolling nightly"
+    return 0
+  fi
+
+  if grep -Fqx -- "$nightly_tag" <<< "$tags"; then
+    if ! current_manifest=$(oras manifest fetch "${full_repo}:${nightly_tag}"); then
+      echo "::warning::Unable to read ${nightly_tag}; not advancing rolling nightly"
+      return 0
+    fi
+    current_version=$(printf '%s' "$current_manifest" | jq -r '.annotations.version // empty')
+    if [ -z "$current_version" ]; then
+      echo "::warning::${nightly_tag} has no version annotation; not advancing rolling nightly"
+      return 0
+    fi
+  fi
+
+  if ! should_advance_rolling_nightly "$current_version" "$candidate_version"; then
+    echo "Rolling nightly remains at ${current_version}; candidate ${candidate_version} is not newer"
+    return 0
+  fi
+
+  oras tag "${full_repo}:${nightly_tag_prefix}${candidate_version}" "$nightly_tag"
+}
+
 # Print the greatest versioned-nightly tag strictly below $3. The target tag
 # need not exist yet: generation intentionally happens before publication.
 select_previous_nightly_tag() {

--- a/packages/gateway/test/binpatch-action.test.ts
+++ b/packages/gateway/test/binpatch-action.test.ts
@@ -6,7 +6,15 @@
  */
 
 import { execFileSync } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
+import {
+  chmodSync,
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
@@ -32,6 +40,108 @@ function selectPreviousNightlyTag(tags: string, targetVersion: string): string {
       },
     },
   ).trim();
+}
+
+function shouldAdvanceRollingNightly(
+  currentVersion: string,
+  candidateVersion: string,
+): boolean {
+  try {
+    execFileSync(
+      "bash",
+      [
+        "-c",
+        'source "$HELPER"; should_advance_rolling_nightly "$CURRENT" "$CANDIDATE"',
+      ],
+      {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+        env: {
+          ...process.env,
+          HELPER: helperPath,
+          CURRENT: currentVersion,
+          CANDIDATE: candidateVersion,
+        },
+      },
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function advanceRollingNightly({
+  tags,
+  currentVersion = "",
+  failTagLookup = false,
+  failManifestLookup = false,
+}: {
+  tags: string;
+  currentVersion?: string;
+  failTagLookup?: boolean;
+  failManifestLookup?: boolean;
+}): { commands: string[]; output: string } {
+  const fakeBin = mkdtempSync(join(tmpdir(), "lore-binpatch-oras-"));
+  const logPath = join(fakeBin, "oras.log");
+  const fakeOras = join(fakeBin, "oras");
+  writeFileSync(
+    fakeOras,
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> "$ORAS_LOG"
+case "$1" in
+  repo)
+    [ "$2" = tags ] || exit 2
+    [ "$ORAS_FAIL_TAG_LOOKUP" = true ] && exit 1
+    printf '%s\\n' "$ORAS_TAGS"
+    ;;
+  manifest)
+    [ "$2" = fetch ] || exit 2
+    [ "$ORAS_FAIL_MANIFEST_LOOKUP" = true ] && exit 1
+    printf '{"annotations":{"version":"%s"}}\\n' "$ORAS_CURRENT_VERSION"
+    ;;
+  tag) ;;
+  *) exit 2 ;;
+esac
+`,
+  );
+  chmodSync(fakeOras, 0o755);
+
+  try {
+    const output = execFileSync(
+      "bash",
+      [
+        "-c",
+        'source "$HELPER"; advance_rolling_nightly "$FULL_REPO" "$NIGHTLY_TAG" "$PREFIX" "$CANDIDATE"',
+      ],
+      {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          HELPER: helperPath,
+          FULL_REPO: "ghcr.io/byk/loreai",
+          NIGHTLY_TAG: "nightly",
+          PREFIX: "nightly-",
+          CANDIDATE: "0.41.0-dev.1788889012",
+          ORAS_LOG: logPath,
+          ORAS_TAGS: tags,
+          ORAS_CURRENT_VERSION: currentVersion,
+          ORAS_FAIL_TAG_LOOKUP: String(failTagLookup),
+          ORAS_FAIL_MANIFEST_LOOKUP: String(failManifestLookup),
+          PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+        },
+      },
+    );
+    return {
+      commands: readFileSync(logPath, "utf8")
+        .trim()
+        .split("\n")
+        .filter(Boolean),
+      output,
+    };
+  } finally {
+    rmSync(fakeBin, { force: true, recursive: true });
+  }
 }
 
 describe("binpatch nightly publisher", () => {
@@ -91,8 +201,95 @@ describe("binpatch nightly publisher", () => {
       action.indexOf("# ---- surface outputs"),
     );
     expect(publishStep).not.toContain("oras repo tags");
+    expect(publishStep).not.toMatch(/\beval\s+oras\s+push\b/);
+    expect(publishStep).toContain(
+      'oras push "${FULL_REPO}:${PATCH_TAG_PREFIX}${VERSION}"',
+    );
+    expect(publishStep).toContain('"${annotations[@]}"');
+    expect(publishStep).toContain('"${patch_files[@]}"');
     expect(workflow).toContain(
       "from-version: ${{ needs.generate-patches.outputs.from-version }}",
+    );
+  });
+
+  it("publishes the immutable nightly before advancing the rolling tag", () => {
+    const action = readFileSync(join(actionDir, "action.yml"), "utf8");
+    const pushStep = action.slice(
+      action.indexOf(
+        "- name: Push immutable versioned nightly to the registry",
+      ),
+      action.indexOf("- name: Update rolling nightly tag"),
+    );
+    const tagStep = action.slice(
+      action.indexOf("- name: Update rolling nightly tag"),
+      action.indexOf("- name: Push delta patches to the registry"),
+    );
+
+    // Model the bad interleaving explicitly: A writes its immutable manifest,
+    // B publishes next, then A advances `nightly`. A must still tag A's digest,
+    // never whatever B most recently placed at the rolling tag.
+    expect(pushStep).toContain(
+      'oras push "${REGISTRY}/${REPO}:${NIGHTLY_TAG_PREFIX}${VERSION}"',
+    );
+    expect(pushStep).not.toContain(
+      'oras push "${REGISTRY}/${REPO}:${NIGHTLY_TAG}"',
+    );
+    expect(tagStep).toContain(
+      'advance_rolling_nightly "$FULL_REPO" "$NIGHTLY_TAG" "$NIGHTLY_TAG_PREFIX" "$VERSION"',
+    );
+    expect(readFileSync(helperPath, "utf8")).toContain(
+      'oras tag "${full_repo}:${nightly_tag_prefix}${candidate_version}" "$nightly_tag"',
+    );
+  });
+
+  it("never regresses the rolling nightly when an older publisher finishes last", () => {
+    const older = "0.41.0-dev.1788889012";
+    const newer = "0.41.0-dev.1788889080";
+    const action = readFileSync(join(actionDir, "action.yml"), "utf8");
+    const workflow = readFileSync(
+      join(__dirname, "../../../.github/workflows/ci.yml"),
+      "utf8",
+    );
+
+    // The production order was B (newer) first, then A (older). The final
+    // rolling pointer must remain on B, while a later C may advance it.
+    expect(shouldAdvanceRollingNightly(newer, older)).toBe(false);
+    expect(shouldAdvanceRollingNightly(older, newer)).toBe(true);
+    expect(
+      advanceRollingNightly({
+        tags: ["nightly", `nightly-${newer}`].join("\n"),
+        currentVersion: newer,
+      }).commands,
+    ).toEqual([
+      "repo tags ghcr.io/byk/loreai",
+      "manifest fetch ghcr.io/byk/loreai:nightly",
+    ]);
+
+    // An absent tag is a confirmed first-publish condition and can advance;
+    // errors must fail closed rather than looking indistinguishable from absent.
+    expect(
+      advanceRollingNightly({ tags: `nightly-${older}` }).commands,
+    ).toEqual([
+      "repo tags ghcr.io/byk/loreai",
+      "tag ghcr.io/byk/loreai:nightly-0.41.0-dev.1788889012 nightly",
+    ]);
+    expect(
+      advanceRollingNightly({ tags: "", failTagLookup: true }).commands,
+    ).toEqual(["repo tags ghcr.io/byk/loreai"]);
+    expect(
+      advanceRollingNightly({
+        tags: "nightly",
+        failManifestLookup: true,
+      }).commands,
+    ).toEqual([
+      "repo tags ghcr.io/byk/loreai",
+      "manifest fetch ghcr.io/byk/loreai:nightly",
+    ]);
+    expect(action).toContain(
+      'advance_rolling_nightly "$FULL_REPO" "$NIGHTLY_TAG" "$NIGHTLY_TAG_PREFIX" "$VERSION"',
+    );
+    expect(workflow).toContain(
+      "concurrency:\n      group: nightly-ghcr-publish\n      cancel-in-progress: false",
     );
   });
 });

--- a/packages/gateway/test/binpatch-action.test.ts
+++ b/packages/gateway/test/binpatch-action.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Regression coverage for the composite action that produces nightly binary
+ * delta patches. The action executes outside the Node workspace, so exercise
+ * its shell helper directly and verify the workflow carries its source-version
+ * output from generation into publishing.
+ */
+
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const actionDir = join(__dirname, "../../binpatch/action");
+const helperPath = join(actionDir, "nightly-tags.sh");
+
+function selectPreviousNightlyTag(tags: string, targetVersion: string): string {
+  return execFileSync(
+    "bash",
+    [
+      "-c",
+      'source "$HELPER"; select_previous_nightly_tag "$TAGS" "$PREFIX" "$VERSION"',
+    ],
+    {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        HELPER: helperPath,
+        TAGS: tags,
+        PREFIX: "nightly-",
+        VERSION: targetVersion,
+      },
+    },
+  ).trim();
+}
+
+describe("binpatch nightly publisher", () => {
+  it("selects the newest tag below an unpublished target, never a newer racing build", () => {
+    expect(existsSync(helperPath)).toBe(true);
+
+    const target = "0.41.0-dev.1788889012";
+    const tags = [
+      "nightly-0.41.0-dev.1788888006",
+      // This is the exact adversarial order from the production failure: a
+      // newer workflow published before the target workflow reached generate.
+      "nightly-0.41.0-dev.1788889080",
+      "nightly-not-a-version",
+      "stable-0.41.0-dev.1788888999",
+    ].join("\n");
+
+    expect(selectPreviousNightlyTag(tags, target)).toBe(
+      "nightly-0.41.0-dev.1788888006",
+    );
+  });
+
+  it("keeps choosing the immediate predecessor when the target tag already exists", () => {
+    const target = "0.41.0-dev.1788889012";
+    const tags = [
+      "nightly-0.41.0-dev.1788888006",
+      `nightly-${target}`,
+      "nightly-0.41.0-dev.1788889080",
+    ].join("\n");
+
+    expect(selectPreviousNightlyTag(tags, target)).toBe(
+      "nightly-0.41.0-dev.1788888006",
+    );
+  });
+
+  it("returns no source when the registry has no older nightly", () => {
+    expect(
+      selectPreviousNightlyTag(
+        ["nightly-0.41.0-dev.1788889012", "nightly-0.41.0-dev.1788889080"].join(
+          "\n",
+        ),
+        "0.41.0-dev.1788889012",
+      ),
+    ).toBe("");
+  });
+
+  it("carries the generation-time source version into publish rather than rediscovering it", () => {
+    const action = readFileSync(join(actionDir, "action.yml"), "utf8");
+    const workflow = readFileSync(
+      join(__dirname, "../../../.github/workflows/ci.yml"),
+      "utf8",
+    );
+
+    expect(action).toContain("PATCH_FROM_VERSION: ${{ inputs.from-version }}");
+    expect(action).toContain("from-version=${PATCH_FROM_VERSION}");
+    const publishStep = action.slice(
+      action.indexOf("- name: Push delta patches to the registry"),
+      action.indexOf("# ---- surface outputs"),
+    );
+    expect(publishStep).not.toContain("oras repo tags");
+    expect(workflow).toContain(
+      "from-version: ${{ needs.generate-patches.outputs.from-version }}",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Select the greatest versioned nightly strictly below the target even when the target tag has not been published yet.
- Carry that exact generation-time source version through the workflow into the patch manifest instead of rediscovering it during publish.
- Skip patch publication when that source is unavailable, and reject a source that is not older than its target.
- Add a regression test for the observed out-of-order nightly publish race.

## Validation

- `vitest run packages/gateway/test/binpatch-action.test.ts`
- `tsc -p packages/gateway/tsconfig.json --noEmit`
- `oxlint --type-aware packages/gateway/test/binpatch-action.test.ts`
- `oxfmt --check` on changed files
- YAML and shell syntax checks