### PR TITLE
fix(embeddings): decouple cancellation from worker lifetime

### DIFF
--- a/packages/core/src/embedding-worker-types.ts
+++ b/packages/core/src/embedding-worker-types.ts
@@ -53,6 +53,15 @@ export interface EmbedResult {
   vectors: Float32Array[];
 }
 
+/** The worker has finished model initialization and is starting this request's
+ * token preparation/inference. Lets the host switch from its init watchdog to
+ * the independent execution watchdog. */
+export interface EmbedStarted {
+  type: "started";
+  /** Matches the request ID. */
+  id: number;
+}
+
 /** A single embed request failed (ONNX error, etc.). */
 export interface EmbedError {
   type: "error";
@@ -95,6 +104,7 @@ export interface InitNeedsWasm {
 }
 
 export type WorkerOutbound =
+  | EmbedStarted
   | EmbedResult
   | EmbedError
   | InitError

--- a/packages/core/src/embedding-worker.ts
+++ b/packages/core/src/embedding-worker.ts
@@ -740,6 +740,7 @@ async function processEmbed(req: EmbedRequest): Promise<void> {
   inflight++;
   try {
     await ensurePipeline();
+    post({ type: "started", id: req.id });
 
     // Truncate to the main-thread-owned token cap BEFORE the single inference
     // attempt. The cap is memory-aware and is lowered ×0.7 per fresh-heap

--- a/packages/core/src/embedding.ts
+++ b/packages/core/src/embedding.ts
@@ -14,7 +14,7 @@
  */
 
 import { freemem } from "node:os";
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { performance } from "node:perf_hooks";
 import {
   databaseInTransaction,
@@ -650,13 +650,23 @@ export class LocalProviderUnavailableError extends Error {
   }
 }
 
-/** A caller cancelled one local worker request. The pool retires only the
- * assigned worker before surfacing this error, so no abandoned inference or
- * pending-map entry survives behind a released admission slot. */
+/** A caller stopped waiting for an embedding request. */
 export class EmbeddingRequestAbortedError extends Error {
   constructor() {
     super("Embedding request aborted");
     this.name = "EmbeddingRequestAbortedError";
+  }
+}
+
+/** The worker exceeded its own initialization or execution lifetime. This is
+ * independent of every caller's deadline and retires only the affected slot. */
+export class EmbeddingWorkerWatchdogError extends Error {
+  readonly stage: "init" | "execution";
+
+  constructor(stage: "init" | "execution") {
+    super(`Embedding worker ${stage} watchdog expired`);
+    this.name = "EmbeddingWorkerWatchdogError";
+    this.stage = stage;
   }
 }
 
@@ -993,6 +1003,7 @@ class LocalProvider implements EmbeddingProvider {
       /** Original request payload, retained so it can be re-submitted to a
        *  freshly respawned worker after an OOM backoff (fresh WASM heap). */
       payload: EmbedRequest;
+      onExecutionStart?: () => void;
     }
   >();
   private nextRequestId = 0;
@@ -1214,6 +1225,10 @@ class LocalProvider implements EmbeddingProvider {
       this.worker.on("message", (msg: WorkerOutbound) => {
         if (this.worker !== spawned) return; // superseded worker — ignore
         switch (msg.type) {
+          case "started": {
+            this.pendingRequests.get(msg.id)?.onExecutionStart?.();
+            break;
+          }
           case "result": {
             const pending = this.pendingRequests.get(msg.id);
             if (pending) {
@@ -1660,6 +1675,7 @@ class LocalProvider implements EmbeddingProvider {
     texts: string[],
     inputType: "document" | "query",
     signal?: AbortSignal,
+    onExecutionStart?: () => void,
   ): Promise<Float32Array[]> {
     if (signal?.aborted) throw new EmbeddingRequestAbortedError();
     await this.ensureWorker();
@@ -1726,6 +1742,7 @@ class LocalProvider implements EmbeddingProvider {
         resolve: resolveRequest,
         reject: rejectRequest,
         payload,
+        onExecutionStart,
       });
       signal?.addEventListener("abort", onAbort, { once: true });
       if (signal?.aborted) {
@@ -1849,16 +1866,74 @@ export function _setPoolFreememForTest(bytes: number | null): void {
   testPoolFreememBytes = bytes;
 }
 
-/** One worker slot: a {@link LocalProvider} and the number of embed requests the
- *  pool currently has in flight against it. The pool is the sole caller of each
- *  provider's `embed()`, so it tracks in-flight itself — no LocalProvider surface
- *  change. `inflight` stays accurate across a provider's OOM respawn because the
- *  original `embed()` promise stays pending until the resubmit finally settles. */
+/** One worker slot and its actual execution count. Host queueing keeps this at
+ * zero or one. It stays occupied after caller cancellation and across an OOM
+ * respawn until the underlying provider operation settles. */
 interface EmbedSlot {
   provider: LocalProvider;
   inflight: number;
   healthy: boolean;
   recoveryGeneration: number | null;
+  retirement: Promise<void> | null;
+}
+
+type PoolOperationState = "queued" | "running" | "completed";
+
+interface PoolWaiter {
+  settled: boolean;
+  signal?: AbortSignal;
+  onAbort?: () => void;
+  resolve: (vectors: Float32Array[]) => void;
+  reject: (error: Error) => void;
+}
+
+interface PoolOperation {
+  key: string;
+  texts: string[];
+  inputType: "document" | "query";
+  priority: "high" | "normal";
+  state: PoolOperationState;
+  waiters: Set<PoolWaiter>;
+  retainResult?: boolean;
+  vectors?: Float32Array[];
+  completedAt?: number;
+}
+
+/** Keep a successful orphan result long enough for a durable scheduler's
+ * bounded retry to reclaim it without running the same native inference twice. */
+const COMPLETED_EMBED_REUSE_MS = 5 * 60_000;
+const MAX_COMPLETED_EMBED_RESULTS = 8;
+const DEFAULT_EMBED_INIT_WATCHDOG_MS = 10 * 60_000;
+const DEFAULT_EMBED_EXECUTION_WATCHDOG_MS = 5 * 60_000;
+let embedInitWatchdogMs = DEFAULT_EMBED_INIT_WATCHDOG_MS;
+let embedExecutionWatchdogMs = DEFAULT_EMBED_EXECUTION_WATCHDOG_MS;
+
+/** Test seam for independent worker-owned watchdogs. */
+export function _setEmbeddingWorkerWatchdogsForTest(
+  initMs: number | null,
+  executionMs: number | null,
+): void {
+  embedInitWatchdogMs = initMs ?? DEFAULT_EMBED_INIT_WATCHDOG_MS;
+  embedExecutionWatchdogMs = executionMs ?? DEFAULT_EMBED_EXECUTION_WATCHDOG_MS;
+}
+
+function embeddingOperationKey(
+  texts: string[],
+  inputType: "document" | "query",
+): string {
+  const hash = createHash("sha256");
+  hash.update(inputType);
+  for (const value of texts) {
+    hash.update("\0");
+    hash.update(String(Buffer.byteLength(value)));
+    hash.update(":");
+    hash.update(value);
+  }
+  return hash.digest("hex");
+}
+
+function cloneEmbeddingVectors(vectors: Float32Array[]): Float32Array[] {
+  return vectors.map((vector) => vector.slice());
 }
 
 /**
@@ -1867,14 +1942,13 @@ interface EmbedSlot {
  * `vector-pool.ts`, but over the stateful embedding provider rather than raw
  * workers — each LocalProvider keeps its full, tested per-worker lifecycle (OOM
  * ×0.7 backoff + respawn + resubmit, corrupt-model self-heal, WASM-fatal latch,
- * cap re-probe, bounded shutdown). This class adds ONLY cross-worker dispatch.
+ * cap re-probe, bounded shutdown).
  *
- * Dispatch: least-busy live provider. Query jump-ahead is preserved by the
- * existing IN-WORKER priority queue (`embedding-worker.ts`) — a high-priority
- * single-text query floats ahead of any backfill batches queued in whichever
- * worker it lands on. With an idle worker available (the common query-vs-backfill
- * case) a query waits zero; worst case it waits one in-flight batch (token-area
- * ≤ 4096 → sub-second), versus today's unbounded cross-session serialization.
+ * The host owns a priority queue and posts at most one request to each worker.
+ * A cancelled queued request is removed without reaching the worker. A caller
+ * that cancels running work detaches promptly while execution remains accounted
+ * for until completion or a worker-owned watchdog retires the slot. Identical
+ * retries join running work or reclaim its bounded cached result.
  *
  * Growth is LAZY and MEMORY-GATED: worker 0 spawns on the first embed (today's
  * behavior); a secondary spawns only under genuine concurrent demand, below the
@@ -1894,6 +1968,11 @@ class EmbeddingPool implements EmbeddingProvider {
   private readonly ceiling: number;
   private readonly slots: EmbedSlot[] = [];
   private readonly retiredShutdowns = new Set<Promise<void>>();
+  /** Queue on the host so at most one native batch is posted to each worker.
+   * Caller cancellation can then detach without changing worker lifetime. */
+  private readonly queue: PoolOperation[] = [];
+  private readonly operations = new Map<string, PoolOperation>();
+  private dispatching = false;
   private closing = false;
   private shutdownPromise: Promise<void> | null = null;
 
@@ -2015,17 +2094,20 @@ class EmbeddingPool implements EmbeddingProvider {
       inflight: 0,
       healthy: false,
       recoveryGeneration: recoveryProbe ? localInitFailureGeneration : null,
+      retirement: null,
     };
     this.slots.push(slot);
     return slot;
   }
 
   private retireSlot(slot: EmbedSlot): Promise<void> {
+    if (slot.retirement) return slot.retirement;
     const index = this.slots.indexOf(slot);
     if (index === -1) return Promise.resolve();
     this.slots.splice(index, 1);
     this.preserveHealthyServiceAfterExhaustion();
     const retirement = slot.provider.shutdown().catch(() => {});
+    slot.retirement = retirement;
     this.retiredShutdowns.add(retirement);
     void retirement.finally(() => this.retiredShutdowns.delete(retirement));
     return retirement;
@@ -2044,53 +2126,292 @@ class EmbeddingPool implements EmbeddingProvider {
     localProviderErrorLogged = false;
   }
 
-  async embed(
+  private settleWaiter(
+    operation: PoolOperation,
+    waiter: PoolWaiter,
+    outcome: { vectors: Float32Array[] } | { error: Error },
+  ): void {
+    if (waiter.settled) return;
+    waiter.settled = true;
+    operation.waiters.delete(waiter);
+    if (waiter.signal && waiter.onAbort) {
+      waiter.signal.removeEventListener("abort", waiter.onAbort);
+    }
+    if ("vectors" in outcome) {
+      waiter.resolve(cloneEmbeddingVectors(outcome.vectors));
+    } else {
+      waiter.reject(outcome.error);
+    }
+  }
+
+  private dropUnobservedQueuedOperation(operation: PoolOperation): void {
+    if (operation.state !== "queued" || operation.waiters.size > 0) return;
+    const index = this.queue.indexOf(operation);
+    if (index !== -1) this.queue.splice(index, 1);
+    if (this.operations.get(operation.key) === operation) {
+      this.operations.delete(operation.key);
+    }
+    operation.texts = [];
+  }
+
+  private attachWaiter(
+    operation: PoolOperation,
+    signal?: AbortSignal,
+  ): Promise<Float32Array[]> {
+    if (signal?.aborted) {
+      return Promise.reject(new EmbeddingRequestAbortedError());
+    }
+    if (operation.state === "completed" && operation.vectors) {
+      const vectors = cloneEmbeddingVectors(operation.vectors);
+      if (this.operations.get(operation.key) === operation) {
+        this.operations.delete(operation.key);
+      }
+      operation.vectors = undefined;
+      return Promise.resolve(vectors);
+    }
+
+    return new Promise<Float32Array[]>((resolve, reject) => {
+      const waiter: PoolWaiter = { settled: false, signal, resolve, reject };
+      const onAbort = (): void => {
+        this.settleWaiter(operation, waiter, {
+          error: new EmbeddingRequestAbortedError(),
+        });
+        if (operation.state === "running" && operation.waiters.size === 0) {
+          operation.retainResult = true;
+        }
+        this.dropUnobservedQueuedOperation(operation);
+      };
+      waiter.onAbort = onAbort;
+      operation.waiters.add(waiter);
+      signal?.addEventListener("abort", onAbort, { once: true });
+      if (signal?.aborted) onAbort();
+    });
+  }
+
+  private enqueueOperation(operation: PoolOperation): void {
+    if (operation.priority === "high") {
+      let insertAt = 0;
+      while (
+        insertAt < this.queue.length &&
+        this.queue[insertAt].priority === "high"
+      ) {
+        insertAt++;
+      }
+      this.queue.splice(insertAt, 0, operation);
+      return;
+    }
+    this.queue.push(operation);
+  }
+
+  private pruneCompletedOperations(now = Date.now()): void {
+    const completed: PoolOperation[] = [];
+    for (const [key, operation] of this.operations) {
+      if (operation.state !== "completed") continue;
+      if (
+        operation.completedAt === undefined ||
+        now - operation.completedAt > COMPLETED_EMBED_REUSE_MS
+      ) {
+        this.operations.delete(key);
+        operation.vectors = undefined;
+      } else {
+        completed.push(operation);
+      }
+    }
+    completed.sort((a, b) => (a.completedAt ?? 0) - (b.completedAt ?? 0));
+    while (completed.length > MAX_COMPLETED_EMBED_RESULTS) {
+      const operation = completed.shift();
+      if (!operation) break;
+      if (this.operations.get(operation.key) === operation) {
+        this.operations.delete(operation.key);
+      }
+      operation.vectors = undefined;
+    }
+  }
+
+  private recordSlotSuccess(slot: EmbedSlot): void {
+    slot.healthy = true;
+    if (
+      slot.recoveryGeneration !== null &&
+      slot.recoveryGeneration === localInitFailureGeneration
+    ) {
+      slot.recoveryGeneration = null;
+      if (localInitFailures > 0) {
+        log.info(
+          `local embedding provider recovered after ${localInitFailures} failed init attempt(s)`,
+        );
+      }
+      localInitFailures = 0;
+      localInitRetryAt = 0;
+      if (localProviderFailureCause === "transient-init-exhausted") {
+        clearLocalProviderLatch();
+      }
+      localProviderErrorLogged = false;
+      return;
+    }
+
+    slot.recoveryGeneration = null;
+    // An already in-flight sibling proves service is still available, but must
+    // not erase another slot's retry debt or admit immediate respawns.
+    this.preserveHealthyServiceAfterExhaustion();
+  }
+
+  private async runOperation(
+    operation: PoolOperation,
+    slot: EmbedSlot,
+  ): Promise<void> {
+    let watchdogTimer: ReturnType<typeof setTimeout> | undefined;
+    let rejectWatchdog!: (error: Error) => void;
+    const watchdog = new Promise<never>((_resolve, reject) => {
+      rejectWatchdog = reject;
+    });
+    const armWatchdog = (
+      stage: "init" | "execution",
+      timeoutMs: number,
+    ): void => {
+      if (watchdogTimer) clearTimeout(watchdogTimer);
+      watchdogTimer = setTimeout(
+        () => {
+          log.error(
+            `embedding worker watchdog expired: stage=${stage} timeout_ms=${timeoutMs}`,
+          );
+          rejectWatchdog(new EmbeddingWorkerWatchdogError(stage));
+        },
+        Math.max(1, timeoutMs),
+      );
+      watchdogTimer.unref?.();
+    };
+    armWatchdog("init", embedInitWatchdogMs);
+
+    try {
+      // Deliberately omit every caller's AbortSignal. The operation owns the
+      // worker slot until native inference settles; callers only own waiters.
+      const vectors = await Promise.race([
+        slot.provider.embed(
+          operation.texts,
+          operation.inputType,
+          undefined,
+          () => armWatchdog("execution", embedExecutionWatchdogMs),
+        ),
+        watchdog,
+      ]);
+      this.recordSlotSuccess(slot);
+      const retainResult =
+        operation.retainResult === true && operation.waiters.size === 0;
+      operation.state = "completed";
+      operation.completedAt = Date.now();
+      operation.vectors = retainResult
+        ? cloneEmbeddingVectors(vectors)
+        : undefined;
+      operation.texts = [];
+      for (const waiter of operation.waiters) {
+        this.settleWaiter(operation, waiter, { vectors });
+      }
+      if (retainResult) {
+        this.pruneCompletedOperations(operation.completedAt);
+      } else if (this.operations.get(operation.key) === operation) {
+        this.operations.delete(operation.key);
+      }
+    } catch (error) {
+      if (this.operations.get(operation.key) === operation) {
+        this.operations.delete(operation.key);
+      }
+      operation.texts = [];
+      operation.vectors = undefined;
+      const ownedError =
+        error instanceof Error
+          ? error
+          : new Error("embedding worker operation failed");
+      for (const waiter of operation.waiters) {
+        this.settleWaiter(operation, waiter, { error: ownedError });
+      }
+      if (
+        error instanceof LocalProviderUnavailableError ||
+        error instanceof EmbeddingWorkerWatchdogError
+      ) {
+        await this.retireSlot(slot);
+      }
+    } finally {
+      if (watchdogTimer) clearTimeout(watchdogTimer);
+      slot.inflight--;
+      this.dispatch();
+    }
+  }
+
+  private dispatch(): void {
+    if (this.closing || this.dispatching) return;
+    this.dispatching = true;
+    try {
+      while (this.queue.length > 0) {
+        const operation = this.queue[0];
+        if (operation.waiters.size === 0) {
+          this.dropUnobservedQueuedOperation(operation);
+          continue;
+        }
+
+        let slot: EmbedSlot;
+        try {
+          slot = this.pickSlot();
+        } catch (error) {
+          this.queue.shift();
+          if (this.operations.get(operation.key) === operation) {
+            this.operations.delete(operation.key);
+          }
+          const ownedError =
+            error instanceof Error
+              ? error
+              : new LocalProviderUnavailableError();
+          for (const waiter of operation.waiters) {
+            this.settleWaiter(operation, waiter, { error: ownedError });
+          }
+          continue;
+        }
+        if (slot.inflight > 0) break;
+
+        this.queue.shift();
+        operation.state = "running";
+        slot.inflight++;
+        void this.runOperation(operation, slot);
+      }
+    } finally {
+      this.dispatching = false;
+    }
+  }
+
+  embed(
     texts: string[],
     inputType: "document" | "query",
     signal?: AbortSignal,
   ): Promise<Float32Array[]> {
-    const slot = this.pickSlot();
-    slot.inflight++;
-    try {
-      const vectors = await slot.provider.embed(texts, inputType, signal);
-      slot.healthy = true;
-      if (
-        slot.recoveryGeneration !== null &&
-        slot.recoveryGeneration === localInitFailureGeneration
-      ) {
-        slot.recoveryGeneration = null;
-        if (localInitFailures > 0) {
-          log.info(
-            `local embedding provider recovered after ${localInitFailures} failed init attempt(s)`,
-          );
-        }
-        localInitFailures = 0;
-        localInitRetryAt = 0;
-        if (localProviderFailureCause === "transient-init-exhausted") {
-          clearLocalProviderLatch();
-        }
-        localProviderErrorLogged = false;
-      } else {
-        slot.recoveryGeneration = null;
-        // An already in-flight sibling proves service is still available, but
-        // must not erase another slot's retry debt or admit immediate respawns.
-        this.preserveHealthyServiceAfterExhaustion();
-      }
-      return vectors;
-    } catch (error) {
-      if (
-        error instanceof LocalProviderUnavailableError ||
-        error instanceof EmbeddingRequestAbortedError
-      ) {
-        // A transient init failure belongs to this worker, not every slot in the
-        // pool. Retire it so a sibling's successful recovery cannot leave the
-        // failed slot eligible for later backfill or lint requests.
-        await this.retireSlot(slot);
-      }
-      throw error;
-    } finally {
-      slot.inflight--;
+    if (signal?.aborted) {
+      return Promise.reject(new EmbeddingRequestAbortedError());
     }
+    if (this.closing) {
+      return Promise.reject(
+        new LocalProviderUnavailableError("embedding pool is unavailable"),
+      );
+    }
+
+    this.pruneCompletedOperations();
+    const ownedTexts = texts.slice();
+    const key = embeddingOperationKey(ownedTexts, inputType);
+    const existing = this.operations.get(key);
+    if (existing) return this.attachWaiter(existing, signal);
+
+    const operation: PoolOperation = {
+      key,
+      texts: ownedTexts,
+      inputType,
+      priority: isRecallEmbed(ownedTexts, inputType) ? "high" : "normal",
+      state: "queued",
+      waiters: new Set(),
+    };
+    this.operations.set(key, operation);
+    const result = this.attachWaiter(operation, signal);
+    if (operation.waiters.size > 0) {
+      this.enqueueOperation(operation);
+      this.dispatch();
+    }
+    return result;
   }
 
   hasHealthySlot(): boolean {
@@ -2102,6 +2423,18 @@ class EmbeddingPool implements EmbeddingProvider {
   shutdown(): Promise<void> {
     if (this.shutdownPromise) return this.shutdownPromise;
     this.closing = true;
+    const shutdownError = new LocalProviderUnavailableError(
+      "embedding pool shut down",
+    );
+    for (const operation of this.operations.values()) {
+      for (const waiter of operation.waiters) {
+        this.settleWaiter(operation, waiter, { error: shutdownError });
+      }
+      operation.texts = [];
+      operation.vectors = undefined;
+    }
+    this.queue.length = 0;
+    this.operations.clear();
     const providers = this.slots.splice(0).map((s) => s.provider);
     this.shutdownPromise = (async () => {
       await Promise.all(providers.map((p) => p.shutdown()));
@@ -2565,8 +2898,8 @@ export async function ensureEmbeddingReady(
  * A single-text `query` embed is a recall lookup — the latency-sensitive
  * request path (the recall tool and forSession LTM ranking), as opposed to
  * batch/document writes. This is the single source of truth for that
- * classification: the worker uses it to assign "high" priority (see
- * {@link LocalProvider.embed}) and {@link embed} uses it to track in-flight
+ * classification: the pool uses it to assign "high" priority and {@link embed}
+ * uses it to track in-flight
  * recall load for the temporal backfill's idle-gate. Both sites call this one
  * predicate so the "mirrors the worker" invariant can never silently drift.
  */

--- a/packages/core/src/embedding.ts
+++ b/packages/core/src/embedding.ts
@@ -1965,6 +1965,18 @@ function cloneEmbeddingVectors(vectors: Float32Array[]): Float32Array[] {
   return vectors.map((vector) => vector.slice());
 }
 
+/** Internal dispatch signal: the provider can recover at `retryAt`, so queued
+ * work must remain owned instead of being rejected as permanently unavailable. */
+class EmbeddingWorkerRetryCooldownError extends LocalProviderUnavailableError {
+  readonly retryAt: number;
+
+  constructor(retryAt: number) {
+    super("embedding worker retry cooldown is active");
+    this.name = "EmbeddingWorkerRetryCooldownError";
+    this.retryAt = retryAt;
+  }
+}
+
 /**
  * A pool of {@link LocalProvider} workers so concurrent embeds run in parallel
  * instead of serializing through a single worker (#999). Mirrors
@@ -2007,6 +2019,8 @@ class EmbeddingPool implements EmbeddingProvider {
     TokenBatchCheckpoint
   >();
   private dispatching = false;
+  private retryDispatchTimer: ReturnType<typeof setTimeout> | null = null;
+  private retryDispatchAt = 0;
   private closing = false;
   private shutdownPromise: Promise<void> | null = null;
 
@@ -2051,9 +2065,7 @@ class EmbeddingPool implements EmbeddingProvider {
     // protects a constrained host — identical to today's single worker).
     if (this.slots.length === 0) {
       if (localInitRetryAt > now) {
-        throw new LocalProviderUnavailableError(
-          "embedding worker retry cooldown is active",
-        );
+        throw new EmbeddingWorkerRetryCooldownError(localInitRetryAt);
       }
       // Admit exactly one recovery probe after the cooldown. The outstanding
       // failure debt below prevents pool growth until this slot succeeds.
@@ -2249,7 +2261,33 @@ class EmbeddingPool implements EmbeddingProvider {
     if (operation) {
       this.queuedBytes = Math.max(0, this.queuedBytes - operation.byteSize);
     }
+    if (this.queue.length === 0) this.clearRetryDispatchTimer();
     return operation;
+  }
+
+  private clearRetryDispatchTimer(): void {
+    if (this.retryDispatchTimer) clearTimeout(this.retryDispatchTimer);
+    this.retryDispatchTimer = null;
+    this.retryDispatchAt = 0;
+  }
+
+  /** Resume the host queue when a transient provider cooldown expires. Keeping
+   * this timer pool-owned avoids a cascade of false terminal rejections while
+   * still bounding retained work through the normal queue limits. */
+  private scheduleRetryDispatch(retryAt: number): void {
+    if (this.retryDispatchTimer && this.retryDispatchAt === retryAt) return;
+    this.clearRetryDispatchTimer();
+    this.retryDispatchAt = retryAt;
+    const timer = setTimeout(
+      () => {
+        if (this.retryDispatchTimer !== timer) return;
+        this.retryDispatchTimer = null;
+        this.retryDispatchAt = 0;
+        this.dispatch();
+      },
+      Math.max(0, retryAt - Date.now()),
+    );
+    this.retryDispatchTimer = timer;
   }
 
   private canEnqueueOperation(
@@ -2475,6 +2513,10 @@ class EmbeddingPool implements EmbeddingProvider {
         try {
           slot = this.pickSlot();
         } catch (error) {
+          if (error instanceof EmbeddingWorkerRetryCooldownError) {
+            this.scheduleRetryDispatch(error.retryAt);
+            break;
+          }
           this.removeQueuedOperation(0);
           if (this.operations.get(operation.key) === operation) {
             this.operations.delete(operation.key);
@@ -2488,6 +2530,7 @@ class EmbeddingPool implements EmbeddingProvider {
           }
           continue;
         }
+        this.clearRetryDispatchTimer();
         if (slot.inflight > 0) break;
 
         this.removeQueuedOperation(0);
@@ -2555,6 +2598,7 @@ class EmbeddingPool implements EmbeddingProvider {
   shutdown(): Promise<void> {
     if (this.shutdownPromise) return this.shutdownPromise;
     this.closing = true;
+    this.clearRetryDispatchTimer();
     const shutdownError = new LocalProviderUnavailableError(
       "embedding pool shut down",
     );

--- a/packages/core/src/embedding.ts
+++ b/packages/core/src/embedding.ts
@@ -658,6 +658,15 @@ export class EmbeddingRequestAbortedError extends Error {
   }
 }
 
+/** The host-owned local queue hit its bounded count or byte budget. The
+ * provider remains healthy; durable callers should retry with backoff. */
+export class EmbeddingQueueCapacityError extends Error {
+  constructor() {
+    super("Embedding queue capacity exceeded");
+    this.name = "EmbeddingQueueCapacityError";
+  }
+}
+
 /** The worker exceeded its own initialization or execution lifetime. This is
  * independent of every caller's deadline and retires only the affected slot. */
 export class EmbeddingWorkerWatchdogError extends Error {
@@ -1890,6 +1899,7 @@ interface PoolWaiter {
 interface PoolOperation {
   key: string;
   texts: string[];
+  byteSize: number;
   inputType: "document" | "query";
   priority: "high" | "normal";
   state: PoolOperationState;
@@ -1899,10 +1909,29 @@ interface PoolOperation {
   completedAt?: number;
 }
 
+/** Successfully completed prefix of one interrupted token-batched call. The
+ * next durable temporal retry consumes it once and resumes at `nextIndex`. */
+interface TokenBatchCheckpoint {
+  nextIndex: number;
+  vectors: Float32Array[];
+  updatedAt: number;
+}
+
 /** Keep a successful orphan result long enough for a durable scheduler's
  * bounded retry to reclaim it without running the same native inference twice. */
 const COMPLETED_EMBED_REUSE_MS = 5 * 60_000;
 const MAX_COMPLETED_EMBED_RESULTS = 8;
+/** Bound raw input retained by the host queue and the O(n) cancellation scan.
+ * Normal background work stops below the hard ceiling so latency-sensitive
+ * recall can still enter a saturated queue. In-flight work is separately
+ * bounded by the four-worker absolute pool ceiling. */
+const MAX_QUEUED_EMBED_OPERATIONS = 256;
+const MAX_QUEUED_EMBED_BYTES = 8 * 1024 * 1024;
+const MAX_NORMAL_QUEUED_EMBED_OPERATIONS = 240;
+const MAX_NORMAL_QUEUED_EMBED_BYTES = 7 * 1024 * 1024;
+/** Deduplication must not turn one bounded operation into an unbounded listener
+ * set under a same-input flood. The operation cap bounds the aggregate. */
+const MAX_WAITERS_PER_EMBED_OPERATION = 64;
 const DEFAULT_EMBED_INIT_WATCHDOG_MS = 10 * 60_000;
 const DEFAULT_EMBED_EXECUTION_WATCHDOG_MS = 5 * 60_000;
 let embedInitWatchdogMs = DEFAULT_EMBED_INIT_WATCHDOG_MS;
@@ -1971,7 +2000,12 @@ class EmbeddingPool implements EmbeddingProvider {
   /** Queue on the host so at most one native batch is posted to each worker.
    * Caller cancellation can then detach without changing worker lifetime. */
   private readonly queue: PoolOperation[] = [];
+  private queuedBytes = 0;
   private readonly operations = new Map<string, PoolOperation>();
+  private readonly tokenBatchCheckpoints = new Map<
+    string,
+    TokenBatchCheckpoint
+  >();
   private dispatching = false;
   private closing = false;
   private shutdownPromise: Promise<void> | null = null;
@@ -2049,7 +2083,7 @@ class EmbeddingPool implements EmbeddingProvider {
     const canGrow =
       healthySlots.length > 0 &&
       best.inflight > 0 &&
-      this.slots.length < this.ceiling &&
+      this.slots.length + this.retiredShutdowns.size < this.ceiling &&
       this.liveFreemem() >= PER_WORKER_MEM_BUDGET_BYTES;
     if (canGrow) {
       if (localInitRetryAt > 0) {
@@ -2109,7 +2143,10 @@ class EmbeddingPool implements EmbeddingProvider {
     const retirement = slot.provider.shutdown().catch(() => {});
     slot.retirement = retirement;
     this.retiredShutdowns.add(retirement);
-    void retirement.finally(() => this.retiredShutdowns.delete(retirement));
+    void retirement.finally(() => {
+      this.retiredShutdowns.delete(retirement);
+      this.dispatch();
+    });
     return retirement;
   }
 
@@ -2147,7 +2184,7 @@ class EmbeddingPool implements EmbeddingProvider {
   private dropUnobservedQueuedOperation(operation: PoolOperation): void {
     if (operation.state !== "queued" || operation.waiters.size > 0) return;
     const index = this.queue.indexOf(operation);
-    if (index !== -1) this.queue.splice(index, 1);
+    if (index !== -1) this.removeQueuedOperation(index);
     if (this.operations.get(operation.key) === operation) {
       this.operations.delete(operation.key);
     }
@@ -2169,6 +2206,9 @@ class EmbeddingPool implements EmbeddingProvider {
       operation.vectors = undefined;
       return Promise.resolve(vectors);
     }
+    if (operation.waiters.size >= MAX_WAITERS_PER_EMBED_OPERATION) {
+      return Promise.reject(new EmbeddingQueueCapacityError());
+    }
 
     return new Promise<Float32Array[]>((resolve, reject) => {
       const waiter: PoolWaiter = { settled: false, signal, resolve, reject };
@@ -2189,6 +2229,7 @@ class EmbeddingPool implements EmbeddingProvider {
   }
 
   private enqueueOperation(operation: PoolOperation): void {
+    this.queuedBytes += operation.byteSize;
     if (operation.priority === "high") {
       let insertAt = 0;
       while (
@@ -2201,6 +2242,33 @@ class EmbeddingPool implements EmbeddingProvider {
       return;
     }
     this.queue.push(operation);
+  }
+
+  private removeQueuedOperation(index: number): PoolOperation | undefined {
+    const [operation] = this.queue.splice(index, 1);
+    if (operation) {
+      this.queuedBytes = Math.max(0, this.queuedBytes - operation.byteSize);
+    }
+    return operation;
+  }
+
+  private canEnqueueOperation(
+    priority: PoolOperation["priority"],
+    byteSize: number,
+  ): boolean {
+    const maxOperations =
+      priority === "high"
+        ? MAX_QUEUED_EMBED_OPERATIONS
+        : MAX_NORMAL_QUEUED_EMBED_OPERATIONS;
+    const maxBytes =
+      priority === "high"
+        ? MAX_QUEUED_EMBED_BYTES
+        : MAX_NORMAL_QUEUED_EMBED_BYTES;
+    return (
+      byteSize <= maxBytes &&
+      this.queue.length < maxOperations &&
+      this.queuedBytes <= maxBytes - byteSize
+    );
   }
 
   private pruneCompletedOperations(now = Date.now()): void {
@@ -2226,6 +2294,55 @@ class EmbeddingPool implements EmbeddingProvider {
       }
       operation.vectors = undefined;
     }
+  }
+
+  private pruneTokenBatchCheckpoints(now = Date.now()): void {
+    const retained = [...this.tokenBatchCheckpoints.entries()]
+      .filter(([, checkpoint]) => {
+        if (now - checkpoint.updatedAt <= COMPLETED_EMBED_REUSE_MS) return true;
+        checkpoint.vectors = [];
+        return false;
+      })
+      .sort((a, b) => a[1].updatedAt - b[1].updatedAt);
+    this.tokenBatchCheckpoints.clear();
+    for (const [key, checkpoint] of retained.slice(
+      -MAX_COMPLETED_EMBED_RESULTS,
+    )) {
+      this.tokenBatchCheckpoints.set(key, checkpoint);
+    }
+    for (const [, checkpoint] of retained.slice(
+      0,
+      -MAX_COMPLETED_EMBED_RESULTS,
+    )) {
+      checkpoint.vectors = [];
+    }
+  }
+
+  /** Consume one interrupted call's successful prefix. */
+  takeTokenBatchCheckpoint(key: string): TokenBatchCheckpoint | undefined {
+    this.pruneTokenBatchCheckpoints();
+    const checkpoint = this.tokenBatchCheckpoints.get(key);
+    if (!checkpoint) return undefined;
+    this.tokenBatchCheckpoints.delete(key);
+    return {
+      ...checkpoint,
+      vectors: cloneEmbeddingVectors(checkpoint.vectors),
+    };
+  }
+
+  /** Retain bounded progress only after an interrupted durable drain. */
+  storeTokenBatchCheckpoint(
+    key: string,
+    nextIndex: number,
+    vectors: Float32Array[],
+  ): void {
+    if (this.closing || nextIndex <= 0 || vectors.length !== nextIndex) return;
+    this.tokenBatchCheckpoints.set(key, {
+      nextIndex,
+      vectors: cloneEmbeddingVectors(vectors),
+      updatedAt: Date.now(),
+    });
+    this.pruneTokenBatchCheckpoints();
   }
 
   private recordSlotSuccess(slot: EmbedSlot): void {
@@ -2348,11 +2465,17 @@ class EmbeddingPool implements EmbeddingProvider {
           continue;
         }
 
+        // A retiring worker still owns its native model/heap until confirmed
+        // exit. Do not replace the last active slot (or exceed the ceiling via
+        // pool growth) while that memory remains live. Retirement completion
+        // re-enters dispatch above.
+        if (this.slots.length === 0 && this.retiredShutdowns.size > 0) break;
+
         let slot: EmbedSlot;
         try {
           slot = this.pickSlot();
         } catch (error) {
-          this.queue.shift();
+          this.removeQueuedOperation(0);
           if (this.operations.get(operation.key) === operation) {
             this.operations.delete(operation.key);
           }
@@ -2367,7 +2490,7 @@ class EmbeddingPool implements EmbeddingProvider {
         }
         if (slot.inflight > 0) break;
 
-        this.queue.shift();
+        this.removeQueuedOperation(0);
         operation.state = "running";
         slot.inflight++;
         void this.runOperation(operation, slot);
@@ -2396,12 +2519,21 @@ class EmbeddingPool implements EmbeddingProvider {
     const key = embeddingOperationKey(ownedTexts, inputType);
     const existing = this.operations.get(key);
     if (existing) return this.attachWaiter(existing, signal);
+    const priority = isRecallEmbed(ownedTexts, inputType) ? "high" : "normal";
+    const byteSize = ownedTexts.reduce(
+      (total, text) => total + Buffer.byteLength(text),
+      0,
+    );
+    if (!this.canEnqueueOperation(priority, byteSize)) {
+      return Promise.reject(new EmbeddingQueueCapacityError());
+    }
 
     const operation: PoolOperation = {
       key,
       texts: ownedTexts,
+      byteSize,
       inputType,
-      priority: isRecallEmbed(ownedTexts, inputType) ? "high" : "normal",
+      priority,
       state: "queued",
       waiters: new Set(),
     };
@@ -2434,7 +2566,12 @@ class EmbeddingPool implements EmbeddingProvider {
       operation.vectors = undefined;
     }
     this.queue.length = 0;
+    this.queuedBytes = 0;
     this.operations.clear();
+    for (const checkpoint of this.tokenBatchCheckpoints.values()) {
+      checkpoint.vectors = [];
+    }
+    this.tokenBatchCheckpoints.clear();
     const providers = this.slots.splice(0).map((s) => s.provider);
     this.shutdownPromise = (async () => {
       await Promise.all(providers.map((p) => p.shutdown()));
@@ -2877,6 +3014,13 @@ export async function ensureEmbeddingReady(
       return;
     } catch (error) {
       if (error instanceof EmbeddingAbortError) throw error;
+      // Worker watchdogs are an internal lifecycle classification. Keep the
+      // public readiness contract provider-shaped so orchestration that already
+      // handles an unavailable local provider does not need to know which
+      // worker-owned deadline expired.
+      if (error instanceof EmbeddingWorkerWatchdogError) {
+        throw new LocalProviderUnavailableError(error);
+      }
       if (!(error instanceof LocalProviderUnavailableError)) throw error;
       throwIfEmbeddingAborted(guard);
       if (localProviderFailureCause !== null || localInitRetryAt <= 0) {
@@ -2963,6 +3107,18 @@ export async function embed(
 ): Promise<Float32Array[]> {
   const provider = getProvider();
   if (!provider) throw new Error("No embedding provider available");
+  return await embedWithProvider(provider, texts, inputType, signal);
+}
+
+/** Run one request against a fixed provider instance. Keeping provider capture
+ * explicit lets a multi-batch operation survive config/reset races without
+ * silently moving later batches to a different model. */
+async function embedWithProvider(
+  provider: EmbeddingProvider,
+  texts: string[],
+  inputType: "document" | "query",
+  signal?: AbortSignal,
+): Promise<Float32Array[]> {
   // A single-text query embed is a recall lookup (see isRecallEmbed — the same
   // predicate the worker uses for high priority). Track it in flight so the
   // temporal re-chunk backfill can yield the shared worker while recall is
@@ -3190,6 +3346,13 @@ function trackDocEmbed(p: Promise<unknown>): void {
   void p.finally(() => _docEmbedsInFlight.delete(p));
 }
 
+function isExpectedBestEffortEmbeddingError(error: unknown): boolean {
+  return (
+    error instanceof LocalProviderUnavailableError ||
+    error instanceof EmbeddingQueueCapacityError
+  );
+}
+
 /**
  * Await all in-flight fire-and-forget document embeds (knowledge / distillation
  * / entity). Loops so embeds spawned while draining (rare) are also awaited.
@@ -3253,7 +3416,7 @@ export function embedKnowledgeEntry(
         storeEmbedding(db(), "knowledge", id, vec);
       })
       .catch((err) => {
-        if (err instanceof LocalProviderUnavailableError) return;
+        if (isExpectedBestEffortEmbeddingError(err)) return;
         log.error("embedding failed for knowledge entry", id, ":", err);
       }),
   );
@@ -3291,7 +3454,7 @@ export function embedEntity(
         storeEmbedding(db(), "entities", id, vec);
       })
       .catch((err) => {
-        if (err instanceof LocalProviderUnavailableError) return;
+        if (isExpectedBestEffortEmbeddingError(err)) return;
         log.error("embedding failed for entity", id, ":", err);
       }),
   );
@@ -3310,7 +3473,7 @@ export function embedDistillation(id: string, observations: string): void {
         storeEmbedding(db(), "distillations", id, vec);
       })
       .catch((err) => {
-        if (err instanceof LocalProviderUnavailableError) return;
+        if (isExpectedBestEffortEmbeddingError(err)) return;
         log.error("embedding failed for distillation", id, ":", err);
       }),
   );
@@ -3333,7 +3496,7 @@ export function warmupEmbedding(): void {
   if (!isAvailable()) return;
   if (config().search.embeddings.provider !== "local") return;
   void embed(["warmup"], "document").catch((err) => {
-    if (err instanceof LocalProviderUnavailableError) return;
+    if (isExpectedBestEffortEmbeddingError(err)) return;
     log.error("embedding warmup failed:", err);
   });
 }
@@ -3359,28 +3522,56 @@ export { MAX_TEMPORAL_CHUNKS_PER_MESSAGE } from "./embedding-units";
  * MAX_BATCH_TOKEN_AREA, mirroring the backfill paths. All-or-nothing: a failure
  * in any batch rejects before the caller stores, so a partial chunk set is never
  * written (storeTemporalChunks DELETEs-then-INSERTs the complete set).
+ *
+ * A signal-driven local call checkpoints only its successfully completed prefix
+ * when interrupted. Queued/current native work retains the pool's normal
+ * cancellation semantics; no future sub-batch starts for the abandoned caller.
+ * An identical durable retry on the same pool consumes the bounded checkpoint
+ * once and resumes from that prefix instead of repeating successful inference.
  */
 export async function embedInTokenBatches(
   texts: string[],
   inputType: "document" | "query",
   signal?: AbortSignal,
 ): Promise<Float32Array[]> {
+  const provider = getProvider();
+  if (!provider) throw new Error("No embedding provider available");
+  const localPool =
+    provider instanceof EmbeddingPool && signal ? provider : undefined;
+  const checkpointKey = localPool
+    ? embeddingOperationKey(texts, inputType)
+    : undefined;
+  const checkpoint =
+    localPool && checkpointKey
+      ? localPool.takeTokenBatchCheckpoint(checkpointKey)
+      : undefined;
   const items = texts.map((text) => ({ text }));
-  const out: Float32Array[] = [];
-  for (let i = 0; i < items.length;) {
-    const batch = nextBatch(items, i);
-    i += batch.length;
-    const vecs = await embed(
-      batch.map((b) => b.text),
-      inputType,
-      signal,
-    );
-    if (vecs.length !== batch.length) {
-      throw new Error("embedding provider returned an unexpected vector count");
+  const out = checkpoint?.vectors ?? [];
+  let nextIndex = checkpoint?.nextIndex ?? 0;
+  try {
+    while (nextIndex < items.length) {
+      const batch = nextBatch(items, nextIndex);
+      const vecs = await embedWithProvider(
+        provider,
+        batch.map((b) => b.text),
+        inputType,
+        signal,
+      );
+      if (vecs.length !== batch.length) {
+        throw new Error(
+          "embedding provider returned an unexpected vector count",
+        );
+      }
+      out.push(...vecs);
+      nextIndex += batch.length;
     }
-    out.push(...vecs);
+    return out;
+  } catch (error) {
+    if (localPool && checkpointKey && nextIndex > 0) {
+      localPool.storeTokenBatchCheckpoint(checkpointKey, nextIndex, out);
+    }
+    throw error;
   }
-  return out;
 }
 
 // ---------------------------------------------------------------------------
@@ -3983,6 +4174,10 @@ export async function backfillEmbeddings(
       // not a bug — check before log.error so captureException doesn't fire
       // and create Sentry noise (LOREAI-GATEWAY-Q).
       if (err instanceof EmbeddingAbortError) throw err;
+      if (err instanceof EmbeddingQueueCapacityError) {
+        log.info("embedding backfill stopped: queue saturated");
+        break;
+      }
       if (err instanceof LocalProviderUnavailableError) {
         log.info("embedding backfill stopped: provider unavailable");
         break;
@@ -4053,6 +4248,10 @@ export async function backfillDistillationEmbeddings(): Promise<number> {
       // Provider shutdown / unavailability is expected graceful degradation,
       // not a bug — check before log.error so captureException doesn't fire
       // and create Sentry noise (LOREAI-GATEWAY-Q).
+      if (err instanceof EmbeddingQueueCapacityError) {
+        log.info("distillation embedding backfill stopped: queue saturated");
+        break;
+      }
       if (err instanceof LocalProviderUnavailableError) {
         log.info(
           "distillation embedding backfill stopped: provider unavailable",
@@ -4142,6 +4341,10 @@ export async function backfillEntityEmbeddings(): Promise<number> {
       // Provider shutdown / unavailability is expected graceful degradation,
       // not a bug — check before log.error so captureException doesn't fire
       // and create Sentry noise (LOREAI-GATEWAY-Q).
+      if (err instanceof EmbeddingQueueCapacityError) {
+        log.info("entity embedding backfill stopped: queue saturated");
+        break;
+      }
       if (err instanceof LocalProviderUnavailableError) {
         log.info("entity embedding backfill stopped: provider unavailable");
         break;

--- a/packages/core/src/pattern-echo.ts
+++ b/packages/core/src/pattern-echo.ts
@@ -101,6 +101,10 @@ export function detectPatternEchoes(input: {
 }): Promise<void> {
   const cooldownOwner = Symbol(input.sessionID);
   const p = _detect({ ...input, cooldownOwner }).catch((err) => {
+    // Saturation is expected transient backpressure. This fire-and-forget path
+    // leaves the distillation unembedded for startup backfill; reporting every
+    // occurrence as a Sentry error would turn one full queue into a log storm.
+    if (err instanceof embedding.EmbeddingQueueCapacityError) return;
     if (input.signal?.aborted) {
       if (lastExtraction.get(input.sessionID)?.owner === cooldownOwner) {
         lastExtraction.delete(input.sessionID);

--- a/packages/core/src/temporal-embedding-queue.ts
+++ b/packages/core/src/temporal-embedding-queue.ts
@@ -373,6 +373,9 @@ function failureReason(error: unknown, diagnostics: DrainDiagnostics): string {
   if (diagnostics.abortReason === "deadline") return "deadline";
   // Even instanceof can throw for an untrusted Proxy rejection value.
   try {
+    if (error instanceof embedding.EmbeddingQueueCapacityError) {
+      return "queue-capacity";
+    }
     if (error instanceof embedding.LocalProviderUnavailableError) {
       return "provider-unavailable";
     }

--- a/packages/core/test/embedding-backfill.test.ts
+++ b/packages/core/test/embedding-backfill.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { db, ensureProject } from "../src/db";
 import {
   _restoreProvider,
@@ -6,9 +6,15 @@ import {
   backfillDistillationEmbeddings,
   backfillEmbeddings,
   backfillEntityEmbeddings,
+  embedDistillation,
+  embedEntity,
+  embedKnowledgeEntry,
   EmbeddingAbortError,
+  EmbeddingQueueCapacityError,
   fromBlob,
+  settleDocumentEmbeds,
 } from "../src/embedding";
+import * as log from "../src/log";
 
 const PROJECT = "/test/embedding-backfill";
 
@@ -51,6 +57,7 @@ describe("backfill writes embeddings through storeEmbedding (blob layout)", () =
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     _restoreProvider(token);
   });
 
@@ -145,5 +152,71 @@ describe("backfill writes embeddings through storeEmbedding (blob layout)", () =
     const blob = embeddingOf("entities", "be");
     expect(blob).not.toBeNull();
     expect(Array.from(fromBlob(blob as Buffer))).toEqual(Array.from(VEC));
+  });
+
+  test("fire-and-forget writes suppress expected queue backpressure", async () => {
+    const error = vi.spyOn(log, "error").mockImplementation(() => {});
+    const providerEmbed = vi.fn(async () => {
+      throw new EmbeddingQueueCapacityError();
+    });
+    _restoreProvider({
+      provider: { maxBatchSize: 8, embed: providerEmbed },
+    });
+
+    embedKnowledgeEntry("capacity-k", "title", "content");
+    embedDistillation("capacity-d", "observations");
+    embedEntity("capacity-e", "entity", ["alias"]);
+    await settleDocumentEmbeds();
+
+    expect(providerEmbed).toHaveBeenCalledTimes(3);
+    expect(error).not.toHaveBeenCalled();
+  });
+
+  test("every sequential backfill stops at its first queue-capacity failure", async () => {
+    const now = Date.now();
+    for (let i = 0; i < 9; i++) {
+      const longText = `${i}-${"x".repeat(9_000)}`;
+      db()
+        .query(
+          "INSERT INTO knowledge (id, project_id, category, title, content, created_at, updated_at, logical_id) VALUES (?, ?, 'test', ?, ?, ?, ?, ?)",
+        )
+        .run(
+          `capacity-k-${i}`,
+          pid,
+          `title-${i}`,
+          longText,
+          now,
+          now,
+          `capacity-k-${i}`,
+        );
+      db()
+        .query(
+          "INSERT INTO distillations (id, project_id, session_id, narrative, facts, observations, source_ids, generation, token_count, created_at, archived) VALUES (?, ?, 's', '', '', ?, '', 0, 0, ?, 0)",
+        )
+        .run(`capacity-d-${i}`, pid, longText, now);
+      db()
+        .query(
+          "INSERT INTO entities (id, project_id, entity_type, canonical_name, cross_project, created_at, updated_at) VALUES (?, ?, 'tool', ?, 0, ?, ?)",
+        )
+        .run(`capacity-e-${i}`, pid, longText, now, now);
+    }
+    const error = vi.spyOn(log, "error").mockImplementation(() => {});
+
+    for (const backfill of [
+      backfillEmbeddings,
+      backfillDistillationEmbeddings,
+      backfillEntityEmbeddings,
+    ]) {
+      const providerEmbed = vi.fn(async () => {
+        throw new EmbeddingQueueCapacityError();
+      });
+      _restoreProvider({
+        provider: { maxBatchSize: 8, embed: providerEmbed },
+      });
+
+      await expect(backfill()).resolves.toBe(0);
+      expect(providerEmbed).toHaveBeenCalledOnce();
+    }
+    expect(error).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/test/embedding-init-retry.test.ts
+++ b/packages/core/test/embedding-init-retry.test.ts
@@ -27,7 +27,9 @@ class FakeWorker extends EventEmitter {
   readonly posted: PostedMsg[] = [];
   terminated = false;
   postMessage(msg: unknown): void {
-    this.posted.push({ ...(msg as PostedMsg) });
+    const posted = { ...(msg as PostedMsg) };
+    this.posted.push(posted);
+    if (posted.type === "shutdown") this.emit("exit", 0);
   }
   ref(): void {}
   unref(): void {}

--- a/packages/core/test/embedding-optional-stack.test.ts
+++ b/packages/core/test/embedding-optional-stack.test.ts
@@ -91,7 +91,11 @@ describe("isMissingLocalStackError", () => {
 /** Minimal stand-in for a node:worker_threads Worker (mirrors the seam used by
  *  embedding-oom-recovery.test.ts) so we can emit "message" deterministically. */
 class FakeWorker extends EventEmitter {
-  postMessage(): void {}
+  postMessage(message: unknown): void {
+    if ((message as { type?: string }).type === "shutdown") {
+      this.emit("exit", 0);
+    }
+  }
   ref(): void {}
   unref(): void {}
   terminate(): Promise<number> {

--- a/packages/core/test/embedding-pool-memory.test.ts
+++ b/packages/core/test/embedding-pool-memory.test.ts
@@ -49,6 +49,15 @@ class CapturingWorker extends EventEmitter {
     if (!m) throw new Error("fake worker received no message");
     return m;
   }
+  completeNext(): void {
+    const id = this.posted.at(-1)?.id;
+    if (id === undefined) return;
+    this.emit("message", {
+      type: "result",
+      id,
+      vectors: [new Float32Array([1, 0, 0])],
+    });
+  }
 }
 
 function installCapturingWorkers(): CapturingWorker[] {
@@ -140,10 +149,14 @@ describe("embedding pool memory sizing (OOM regression)", () => {
 
     // Construct + first request while free memory is ample.
     _setContainerFreeForTest(6 * GB);
-    void settle(embed(["first request while memory is ample"], "document"));
+    const first = settle(
+      embed(["first request while memory is ample"], "document"),
+    );
     await flush();
     expect(fakes).toHaveLength(1);
     const firstCap = fakes[0].lastPosted().maxTokens;
+    fakes[0].completeNext();
+    await first;
 
     // Free memory collapses (sibling workers + live sessions allocate). The next
     // request must be sized DOWN to what's now available — a construction-time

--- a/packages/core/test/embedding-pool.test.ts
+++ b/packages/core/test/embedding-pool.test.ts
@@ -4,6 +4,7 @@ import type { Worker } from "node:worker_threads";
 import {
   embed,
   EmbeddingRequestAbortedError,
+  EmbeddingWorkerWatchdogError,
   ensureEmbeddingReady,
   isAvailable,
   LocalProviderUnavailableError,
@@ -16,6 +17,7 @@ import {
   _saveAndClearProvider,
   _setConstrainedMemoryForTest,
   _setEmbedPoolSizeForTest,
+  _setEmbeddingWorkerWatchdogsForTest,
   _setLocalInitCooldownMsForTest,
   _setLocalInitRetryAtForTest,
   _setPoolFreememForTest,
@@ -72,6 +74,24 @@ class FakeWorker extends EventEmitter {
         vectors: [new Float32Array([1, 0, 0])],
       });
     }
+  }
+
+  /** Resolve the oldest embed request posted so far. */
+  completeNext(): void {
+    const id = this.embedIds.shift();
+    if (id === undefined) return;
+    this.emit("message", {
+      type: "result",
+      id,
+      vectors: [new Float32Array([1, 0, 0])],
+    });
+  }
+
+  /** Mark the oldest posted request as entering tokenization/inference. */
+  startNext(): void {
+    const id = this.embedIds[0];
+    if (id === undefined) return;
+    this.emit("message", { type: "started", id });
   }
 
   /** Simulate a fatal model-init failure (permanent per-provider break). */
@@ -154,6 +174,7 @@ describe("EmbeddingPool dispatch (#999)", () => {
   afterEach(() => {
     _setTestWorkerFactory(null);
     _setEmbedPoolSizeForTest(null);
+    _setEmbeddingWorkerWatchdogsForTest(null, null);
     _setLocalInitCooldownMsForTest(null);
     _setPoolFreememForTest(null);
     _setConstrainedMemoryForTest(null);
@@ -170,7 +191,7 @@ describe("EmbeddingPool dispatch (#999)", () => {
     else delete process.env.NODE_ENV;
   });
 
-  it("serializes cold bootstrap before dispatching concurrent embeds in parallel", async () => {
+  it("serializes cold bootstrap before enabling parallel dispatch", async () => {
     _setEmbedPoolSizeForTest(2);
     _setPoolFreememForTest(64 * GB); // ample → growth allowed
     const fakes = installFakeWorkers();
@@ -179,13 +200,16 @@ describe("EmbeddingPool dispatch (#999)", () => {
     const p2 = embed(["beta"], "query");
     await flush();
 
-    // Until a real result proves model readiness, all cold requests share one
-    // worker so sibling initializers cannot race the shared model cache.
+    // Until a real result proves model readiness, only one native batch is
+    // dispatched so sibling initializers cannot race the shared model cache.
     expect(fakes).toHaveLength(1);
-    expect(fakes[0].embedIds).toHaveLength(2);
+    expect(fakes[0].embedIds).toHaveLength(1);
 
-    fakes[0].completeAll();
+    fakes[0].completeNext();
     expect(await p1).toHaveLength(1);
+    await flush();
+    expect(fakes[0].embedIds).toHaveLength(1);
+    fakes[0].completeNext();
     expect(await p2).toHaveLength(1);
 
     // After bootstrap, genuine concurrent demand grows the pool as before.
@@ -220,31 +244,201 @@ describe("EmbeddingPool dispatch (#999)", () => {
     expect(await p2).toHaveLength(1);
   });
 
-  it("retires only an aborted request's assigned worker before releasing it", async () => {
-    _setEmbedPoolSizeForTest(2);
+  it("removes a cancelled queued request without restarting its worker", async () => {
+    _setEmbedPoolSizeForTest(1);
     _setPoolFreememForTest(64 * GB);
     const fakes = installFakeWorkers();
     await warmPool(fakes);
 
+    const blocked = embed(["blocked"], "document");
     const abort = new AbortController();
-    const abandoned = settle(embed(["abandoned"], "document", abort.signal));
-    const sibling = embed(["sibling"], "document");
+    const cancelled = settle(embed(["cancelled"], "document", abort.signal));
     await flush();
-    expect(fakes).toHaveLength(2);
+    expect(fakes).toHaveLength(1);
     expect(fakes[0].embedIds).toHaveLength(1);
-    expect(fakes[1].embedIds).toHaveLength(1);
 
     abort.abort();
-    const outcome = await abandoned;
+    const outcome = await cancelled;
     expect(outcome).toEqual({
       ok: false,
       err: expect.any(EmbeddingRequestAbortedError),
     });
-    expect(fakes[0].gotShutdown).toBe(true);
-    expect(fakes[1].gotShutdown).toBe(false);
+    expect(fakes[0].gotShutdown).toBe(false);
 
-    fakes[1].completeAll();
-    await expect(sibling).resolves.toHaveLength(1);
+    fakes[0].completeNext();
+    await expect(blocked).resolves.toHaveLength(1);
+
+    const reused = embed(["reused"], "document");
+    await flush();
+    expect(fakes).toHaveLength(1);
+    expect(fakes[0].embedIds).toHaveLength(1);
+    fakes[0].completeNext();
+    await expect(reused).resolves.toHaveLength(1);
+  });
+
+  it("settles an executing caller without releasing capacity or restarting the worker", async () => {
+    _setEmbedPoolSizeForTest(1);
+    const fakes = installFakeWorkers();
+    await warmPool(fakes);
+
+    const abort = new AbortController();
+    const cancelled = settle(embed(["executing"], "document", abort.signal));
+    const queued = embed(["queued"], "document");
+    await flush();
+    expect(fakes[0].embedIds).toHaveLength(1);
+
+    abort.abort();
+    await expect(cancelled).resolves.toEqual({
+      ok: false,
+      err: expect.any(EmbeddingRequestAbortedError),
+    });
+    expect(fakes[0].gotShutdown).toBe(false);
+    expect(fakes[0].embedIds).toHaveLength(1);
+
+    fakes[0].completeNext();
+    await flush();
+    expect(fakes[0].embedIds).toHaveLength(1);
+    fakes[0].completeNext();
+    await expect(queued).resolves.toHaveLength(1);
+  });
+
+  it("detaches a cold initialization waiter while initialization continues", async () => {
+    _setEmbedPoolSizeForTest(1);
+    const fakes = installFakeWorkers();
+    const abort = new AbortController();
+    const cancelled = settle(embed(["cold first"], "document", abort.signal));
+    const remaining = embed(["cold second"], "document");
+    await flush();
+    expect(fakes).toHaveLength(1);
+    expect(fakes[0].embedIds).toHaveLength(1);
+
+    abort.abort();
+    await expect(cancelled).resolves.toEqual({
+      ok: false,
+      err: expect.any(EmbeddingRequestAbortedError),
+    });
+    expect(fakes[0].gotShutdown).toBe(false);
+
+    fakes[0].completeNext();
+    await flush();
+    expect(fakes[0].embedIds).toHaveLength(1);
+    fakes[0].completeNext();
+    await expect(remaining).resolves.toHaveLength(1);
+    expect(fakes).toHaveLength(1);
+  });
+
+  it("reattaches an identical retry to abandoned execution instead of duplicating inference", async () => {
+    _setEmbedPoolSizeForTest(1);
+    const fakes = installFakeWorkers();
+    await warmPool(fakes);
+
+    const abort = new AbortController();
+    const first = settle(
+      embed(["same durable input"], "document", abort.signal),
+    );
+    await flush();
+    expect(fakes[0].embedIds).toHaveLength(1);
+
+    abort.abort();
+    await first;
+    const retry = embed(["same durable input"], "document");
+    await flush();
+    expect(fakes[0].embedIds).toHaveLength(1);
+
+    fakes[0].completeNext();
+    await expect(retry).resolves.toHaveLength(1);
+    expect(fakes[0].gotShutdown).toBe(false);
+  });
+
+  it("reuses a completed orphan result when a durable retry arrives", async () => {
+    _setEmbedPoolSizeForTest(1);
+    const fakes = installFakeWorkers();
+    await warmPool(fakes);
+
+    const abort = new AbortController();
+    const first = settle(
+      embed(["late durable result"], "document", abort.signal),
+    );
+    await flush();
+    abort.abort();
+    await first;
+
+    fakes[0].completeNext();
+    await flush();
+    expect(fakes[0].embedIds).toHaveLength(0);
+
+    await expect(
+      embed(["late durable result"], "document"),
+    ).resolves.toHaveLength(1);
+    expect(fakes[0].embedIds).toHaveLength(0);
+    expect(fakes[0].gotShutdown).toBe(false);
+  });
+
+  it("cancels one coalesced waiter without cancelling the shared operation", async () => {
+    _setEmbedPoolSizeForTest(1);
+    const fakes = installFakeWorkers();
+    await warmPool(fakes);
+
+    const abort = new AbortController();
+    const cancelled = settle(embed(["shared"], "document", abort.signal));
+    const remaining = embed(["shared"], "document");
+    await flush();
+    expect(fakes[0].embedIds).toHaveLength(1);
+
+    abort.abort();
+    await expect(cancelled).resolves.toEqual({
+      ok: false,
+      err: expect.any(EmbeddingRequestAbortedError),
+    });
+    fakes[0].completeNext();
+    await expect(remaining).resolves.toHaveLength(1);
+    expect(fakes[0].gotShutdown).toBe(false);
+  });
+
+  it("already-aborted input creates no worker", async () => {
+    _setEmbedPoolSizeForTest(1);
+    const fakes = installFakeWorkers();
+    const abort = new AbortController();
+    abort.abort();
+
+    await expect(
+      embed(["cancelled"], "document", abort.signal),
+    ).rejects.toBeInstanceOf(EmbeddingRequestAbortedError);
+    await flush();
+    expect(fakes).toHaveLength(0);
+  });
+
+  it("retires and replaces a worker whose initialization watchdog expires", async () => {
+    _setEmbedPoolSizeForTest(1);
+    _setEmbeddingWorkerWatchdogsForTest(10, 60_000);
+    const fakes = installFakeWorkers();
+
+    await expect(embed(["stuck init"], "document")).rejects.toMatchObject({
+      name: "EmbeddingWorkerWatchdogError",
+      stage: "init",
+    } satisfies Partial<EmbeddingWorkerWatchdogError>);
+    expect(fakes[0].gotShutdown).toBe(true);
+
+    const recovered = embed(["fresh worker"], "document");
+    await flush();
+    expect(fakes).toHaveLength(2);
+    fakes[1].completeNext();
+    await expect(recovered).resolves.toHaveLength(1);
+  });
+
+  it("uses a separate execution watchdog after worker start", async () => {
+    _setEmbedPoolSizeForTest(1);
+    _setEmbeddingWorkerWatchdogsForTest(60_000, 10);
+    const fakes = installFakeWorkers();
+
+    const stuck = embed(["stuck inference"], "document");
+    await flush();
+    fakes[0].startNext();
+    await expect(stuck).rejects.toMatchObject({
+      name: "EmbeddingWorkerWatchdogError",
+      stage: "execution",
+    } satisfies Partial<EmbeddingWorkerWatchdogError>);
+    expect(fakes[0].gotShutdown).toBe(true);
   });
 
   it("stays at a single worker under concurrency when memory is tight", async () => {
@@ -256,12 +450,15 @@ describe("EmbeddingPool dispatch (#999)", () => {
     const p2 = embed(["beta"], "query");
     await flush();
 
-    // Both requests queue on the one worker rather than loading a second model.
+    // The second request remains host-queued behind the one native batch.
     expect(fakes).toHaveLength(1);
-    expect(fakes[0].embedIds).toHaveLength(2);
+    expect(fakes[0].embedIds).toHaveLength(1);
 
-    fakes[0].completeAll();
+    fakes[0].completeNext();
     expect(await p1).toHaveLength(1);
+    await flush();
+    expect(fakes[0].embedIds).toHaveLength(1);
+    fakes[0].completeNext();
     expect(await p2).toHaveLength(1);
   });
 
@@ -281,10 +478,13 @@ describe("EmbeddingPool dispatch (#999)", () => {
     // Clamped to 256 MiB (< one per-worker budget), the pool must NOT load a
     // second model despite the ceiling and the host's 64 GiB free figure.
     expect(fakes).toHaveLength(1);
-    expect(fakes[0].embedIds).toHaveLength(2);
+    expect(fakes[0].embedIds).toHaveLength(1);
 
-    fakes[0].completeAll();
+    fakes[0].completeNext();
     expect(await p1).toHaveLength(1);
+    await flush();
+    expect(fakes[0].embedIds).toHaveLength(1);
+    fakes[0].completeNext();
     expect(await p2).toHaveLength(1);
   });
 
@@ -433,6 +633,9 @@ describe("EmbeddingPool dispatch (#999)", () => {
     expect(fakes).toHaveLength(3);
     fakes[0].completeAll();
     fakes[2].completeAll();
+    await flush();
+    fakes[0].completeAll();
+    fakes[2].completeAll();
     await Promise.all([duringCooldown, alsoDuringCooldown, recovery]);
   });
 
@@ -466,7 +669,9 @@ describe("EmbeddingPool dispatch (#999)", () => {
         const alsoCooling = embed([`cooldown-busy-${attempt}`], "document");
         await flush();
         expect(fakes).toHaveLength(attempt + 1);
-        fakes[0].completeAll();
+        fakes[0].completeNext();
+        await flush();
+        fakes[0].completeNext();
         await Promise.all([stillCooling, alsoCooling]);
       }
     }
@@ -477,7 +682,9 @@ describe("EmbeddingPool dispatch (#999)", () => {
     const queuedAfterExhaustion = embed(["still healthy only"], "document");
     await flush();
     expect(fakes).toHaveLength(4);
-    fakes[0].completeAll();
+    fakes[0].completeNext();
+    await flush();
+    fakes[0].completeNext();
     await Promise.all([afterExhaustion, queuedAfterExhaustion]);
   });
 
@@ -522,7 +729,9 @@ describe("EmbeddingPool dispatch (#999)", () => {
     const queued = embed(["no immediate replacement"], "document");
     await flush();
     expect(fakes).toHaveLength(4);
-    fakes[3].completeAll();
+    fakes[3].completeNext();
+    await flush();
+    fakes[3].completeNext();
     await Promise.all([after, queued]);
   });
 
@@ -737,7 +946,9 @@ describe("EmbeddingPool dispatch (#999)", () => {
 
     // Invalid env → undefined → default ceiling of 1 in test mode.
     expect(fakes).toHaveLength(1);
-    fakes[0].completeAll();
+    fakes[0].completeNext();
+    await flush();
+    fakes[0].completeNext();
     await Promise.all([p1, p2]);
   });
 
@@ -805,7 +1016,9 @@ describe("EmbeddingPool dispatch (#999)", () => {
     await flush();
 
     expect(fakes).toHaveLength(1);
-    fakes[0].completeAll();
+    fakes[0].completeNext();
+    await flush();
+    fakes[0].completeNext();
     await Promise.all([p1, p2]);
   });
 

--- a/packages/core/test/embedding-pool.test.ts
+++ b/packages/core/test/embedding-pool.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { EventEmitter } from "node:events";
 import type { Worker } from "node:worker_threads";
 import {
@@ -133,6 +133,13 @@ async function flush(): Promise<void> {
   for (let i = 0; i < 8; i++) await Promise.resolve();
 }
 
+/** Flush worker/provider microtasks while Vitest owns the timer queue. */
+async function flushFakeTimers(): Promise<void> {
+  for (let i = 0; i < 8; i++) await Promise.resolve();
+  await vi.advanceTimersByTimeAsync(0);
+  for (let i = 0; i < 8; i++) await Promise.resolve();
+}
+
 /** Attach handlers immediately so an expected rejection isn't flagged unhandled. */
 function settle<T>(
   p: Promise<T>,
@@ -193,6 +200,7 @@ describe("EmbeddingPool dispatch (#999)", () => {
     // Restore NODE_ENV (a couple of tests flip it to exercise the production path).
     if (savedNodeEnv !== undefined) process.env.NODE_ENV = savedNodeEnv;
     else delete process.env.NODE_ENV;
+    vi.useRealTimers();
   });
 
   it("serializes cold bootstrap before enabling parallel dispatch", async () => {
@@ -834,20 +842,169 @@ describe("EmbeddingPool dispatch (#999)", () => {
     expect(fakes).toHaveLength(1);
     fakes[0].initError("transient one");
     expect((await first).ok).toBe(false);
-    expect((await second).ok).toBe(false);
     await flush();
+    let secondSettled = false;
+    void second.then(() => {
+      secondSettled = true;
+    });
+    expect(secondSettled).toBe(false);
     expect(_getLocalInitRetryAtForTest()).toBeGreaterThan(Date.now());
 
-    const cooling = await settle(embed(["too soon"], "document"));
-    expect(cooling.ok).toBe(false);
+    const coolingController = new AbortController();
+    const cooling = settle(
+      embed(["too soon"], "document", coolingController.signal),
+    );
+    let coolingSettled = false;
+    void cooling.then(() => {
+      coolingSettled = true;
+    });
+    await flush();
+    expect(coolingSettled).toBe(false);
     expect(fakes).toHaveLength(1);
+    coolingController.abort();
+    const coolingOutcome = await cooling;
+    expect(coolingOutcome.ok).toBe(false);
+    if (!coolingOutcome.ok) {
+      expect(coolingOutcome.err).toBeInstanceOf(EmbeddingRequestAbortedError);
+    }
 
     _setLocalInitRetryAtForTest(Date.now() - 1);
     const retry = embed(["after cooldown"], "document");
     await flush();
     expect(fakes).toHaveLength(2);
-    fakes[1].completeAll();
+    fakes[1].completeNext();
+    await flush();
+    expect((await second).ok).toBe(true);
+    fakes[1].completeNext();
     expect(await retry).toHaveLength(1);
+  });
+
+  it("keeps queued operations pending and resumes them after an init cooldown", async () => {
+    vi.useFakeTimers();
+    _setEmbedPoolSizeForTest(1);
+    _setLocalInitCooldownMsForTest(1_000);
+    const fakes = installFakeWorkers();
+
+    const failed = settle(embed(["failed"], "document"));
+    const queued1 = settle(embed(["queued-1"], "document"));
+    const queued2 = settle(embed(["queued-2"], "document"));
+    await flushFakeTimers();
+    expect(fakes).toHaveLength(1);
+    expect(fakes[0].embedIds).toHaveLength(1);
+
+    const scheduledTimers: Array<ReturnType<typeof setTimeout>> = [];
+    const fakeSetTimeout = globalThis.setTimeout;
+    const timeoutSpy = vi
+      .spyOn(globalThis, "setTimeout")
+      .mockImplementation((handler, timeout, ...args) => {
+        const timer = fakeSetTimeout(handler, timeout, ...args);
+        scheduledTimers.push(timer);
+        return timer;
+      });
+    fakes[0].initError("transient init failure");
+    await flushFakeTimers();
+    expect((await failed).ok).toBe(false);
+    const retryTimer = scheduledTimers.at(-1);
+    expect(retryTimer).toBeDefined();
+    expect(retryTimer?.hasRef()).toBe(true);
+    timeoutSpy.mockRestore();
+
+    let queued1Settled = false;
+    let queued2Settled = false;
+    void queued1.then(() => {
+      queued1Settled = true;
+    });
+    void queued2.then(() => {
+      queued2Settled = true;
+    });
+    await flushFakeTimers();
+    expect(queued1Settled).toBe(false);
+    expect(queued2Settled).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(999);
+    expect(fakes).toHaveLength(1);
+    await vi.advanceTimersByTimeAsync(1);
+    await flushFakeTimers();
+    expect(fakes).toHaveLength(2);
+    expect(fakes[1].embedIds).toHaveLength(1);
+
+    fakes[1].completeNext();
+    await flushFakeTimers();
+    expect((await queued1).ok).toBe(true);
+    expect(fakes[1].embedIds).toHaveLength(1);
+    fakes[1].completeNext();
+    await flushFakeTimers();
+    expect((await queued2).ok).toBe(true);
+  });
+
+  it("drains every queued operation when provider failure is terminal", async () => {
+    _setEmbedPoolSizeForTest(1);
+    const fakes = installFakeWorkers();
+
+    const running = settle(embed(["running"], "document"));
+    const queued1 = settle(embed(["queued-1"], "document"));
+    const queued2 = settle(embed(["queued-2"], "document"));
+    await flush();
+
+    fakes[0].initError("Cannot find module 'onnxruntime-node'");
+    await flush();
+    for (const outcome of await Promise.all([running, queued1, queued2])) {
+      expect(outcome.ok).toBe(false);
+      if (!outcome.ok) {
+        expect(outcome.err).toBeInstanceOf(LocalProviderUnavailableError);
+      }
+    }
+  });
+
+  it("cancels a pending cooldown wake-up when the pool shuts down", async () => {
+    vi.useFakeTimers();
+    _setEmbedPoolSizeForTest(1);
+    _setLocalInitCooldownMsForTest(1_000);
+    const fakes = installFakeWorkers();
+
+    const running = settle(embed(["running"], "document"));
+    const queued = settle(embed(["queued"], "document"));
+    await flushFakeTimers();
+    fakes[0].initError("transient init failure");
+    await flushFakeTimers();
+    expect((await running).ok).toBe(false);
+    expect(vi.getTimerCount()).toBe(1);
+
+    await resetProvider();
+    const queuedOutcome = await queued;
+    expect(queuedOutcome.ok).toBe(false);
+    if (!queuedOutcome.ok) {
+      expect(queuedOutcome.err).toBeInstanceOf(LocalProviderUnavailableError);
+    }
+    expect(vi.getTimerCount()).toBe(0);
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(fakes).toHaveLength(1);
+  });
+
+  it("cancels the cooldown wake-up with its last queued waiter", async () => {
+    vi.useFakeTimers();
+    _setEmbedPoolSizeForTest(1);
+    _setLocalInitCooldownMsForTest(1_000);
+    const fakes = installFakeWorkers();
+    const controller = new AbortController();
+
+    const running = settle(embed(["running"], "document"));
+    const queued = settle(embed(["queued"], "document", controller.signal));
+    await flushFakeTimers();
+    fakes[0].initError("transient init failure");
+    await flushFakeTimers();
+    expect((await running).ok).toBe(false);
+    expect(vi.getTimerCount()).toBe(1);
+
+    controller.abort();
+    const queuedOutcome = await queued;
+    expect(queuedOutcome.ok).toBe(false);
+    if (!queuedOutcome.ok) {
+      expect(queuedOutcome.err).toBeInstanceOf(EmbeddingRequestAbortedError);
+    }
+    expect(vi.getTimerCount()).toBe(0);
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(fakes).toHaveLength(1);
   });
 
   it("applies the same bounded cooldown to worker errors", async () => {
@@ -861,10 +1018,24 @@ describe("EmbeddingPool dispatch (#999)", () => {
     expect((await first).ok).toBe(false);
     await flush();
 
-    const cooling = await settle(embed(["too soon"], "document"));
-    expect(cooling.ok).toBe(false);
+    const coolingController = new AbortController();
+    const cooling = settle(
+      embed(["too soon"], "document", coolingController.signal),
+    );
+    let coolingSettled = false;
+    void cooling.then(() => {
+      coolingSettled = true;
+    });
+    await flush();
+    expect(coolingSettled).toBe(false);
     expect(fakes).toHaveLength(1);
     expect(_getLocalInitRetryAtForTest()).toBeGreaterThan(Date.now());
+    coolingController.abort();
+    const coolingOutcome = await cooling;
+    expect(coolingOutcome.ok).toBe(false);
+    if (!coolingOutcome.ok) {
+      expect(coolingOutcome.err).toBeInstanceOf(EmbeddingRequestAbortedError);
+    }
 
     for (let attempt = 2; attempt <= 3; attempt++) {
       _setLocalInitRetryAtForTest(Date.now() - 1);

--- a/packages/core/test/embedding-pool.test.ts
+++ b/packages/core/test/embedding-pool.test.ts
@@ -3,6 +3,8 @@ import { EventEmitter } from "node:events";
 import type { Worker } from "node:worker_threads";
 import {
   embed,
+  embedInTokenBatches,
+  EmbeddingQueueCapacityError,
   EmbeddingRequestAbortedError,
   EmbeddingWorkerWatchdogError,
   ensureEmbeddingReady,
@@ -38,6 +40,7 @@ const GB = 1024 * 1024 * 1024;
  *  embed requests posted to it and only completes them when the test says so. */
 class FakeWorker extends EventEmitter {
   readonly embedIds: number[] = [];
+  embedPostCount = 0;
   gotShutdown = false;
   terminated = false;
   exitOnShutdown = true;
@@ -50,6 +53,7 @@ class FakeWorker extends EventEmitter {
         this.throwOnNextEmbed = false;
         throw new Error("worker died before postMessage");
       }
+      this.embedPostCount++;
       this.embedIds.push(m.id);
     } else if (m.type === "shutdown") {
       this.gotShutdown = true;
@@ -350,6 +354,234 @@ describe("EmbeddingPool dispatch (#999)", () => {
     expect(fakes[0].gotShutdown).toBe(false);
   });
 
+  it("resumes a token-batched retry without restarting its completed prefix", async () => {
+    _setEmbedPoolSizeForTest(1);
+    const fakes = installFakeWorkers();
+    await warmPool(fakes);
+    const baselinePosts = fakes[0].embedPostCount;
+    const texts = ["a".repeat(9_000), "b".repeat(9_000)];
+    const abort = new AbortController();
+    const first = settle(embedInTokenBatches(texts, "document", abort.signal));
+
+    await flush();
+    expect(fakes[0].embedPostCount).toBe(baselinePosts + 1);
+    fakes[0].completeNext();
+    await flush();
+    expect(fakes[0].embedPostCount).toBe(baselinePosts + 2);
+
+    abort.abort();
+    await expect(first).resolves.toEqual({
+      ok: false,
+      err: expect.any(EmbeddingRequestAbortedError),
+    });
+    const retrySignal = new AbortController();
+    const retry = embedInTokenBatches(texts, "document", retrySignal.signal);
+    await flush();
+    expect(fakes[0].embedPostCount).toBe(baselinePosts + 2);
+
+    fakes[0].completeNext();
+    await expect(retry).resolves.toHaveLength(2);
+    expect(fakes[0].embedPostCount).toBe(baselinePosts + 2);
+  });
+
+  it("removes a queued token batch when its caller cancels", async () => {
+    _setEmbedPoolSizeForTest(1);
+    const fakes = installFakeWorkers();
+    await warmPool(fakes);
+    const baselinePosts = fakes[0].embedPostCount;
+
+    const blocked = embed(["occupy worker"], "document");
+    await flush();
+    expect(fakes[0].embedPostCount).toBe(baselinePosts + 1);
+
+    const abort = new AbortController();
+    const cancelled = settle(
+      embedInTokenBatches(["x".repeat(9_000)], "document", abort.signal),
+    );
+    await flush();
+    expect(fakes[0].embedPostCount).toBe(baselinePosts + 1);
+
+    abort.abort();
+    await expect(cancelled).resolves.toEqual({
+      ok: false,
+      err: expect.any(EmbeddingRequestAbortedError),
+    });
+
+    fakes[0].completeNext();
+    await blocked;
+    await flush();
+    expect(fakes[0].embedPostCount).toBe(baselinePosts + 1);
+  });
+
+  it("bounds queued operations while reserving capacity for recall", async () => {
+    _setEmbedPoolSizeForTest(1);
+    const fakes = installFakeWorkers();
+    await warmPool(fakes);
+
+    const blocked = embed(["occupy bounded queue worker"], "document");
+    await flush();
+    const controllers = Array.from(
+      { length: 240 },
+      () => new AbortController(),
+    );
+    const queued = controllers.map((controller, index) =>
+      settle(embed([`normal-queued-${index}`], "document", controller.signal)),
+    );
+    await flush();
+
+    await expect(embed(["normal-overflow"], "document")).rejects.toBeInstanceOf(
+      EmbeddingQueueCapacityError,
+    );
+
+    // The normal-work ceiling leaves 16 hard-cap slots for recall, even when
+    // background document work has saturated its allocation.
+    const recallControllers = Array.from(
+      { length: 16 },
+      () => new AbortController(),
+    );
+    const recalls = recallControllers.map((controller, index) =>
+      settle(
+        embed(
+          [`latency-sensitive-recall-${index}`],
+          "query",
+          controller.signal,
+        ),
+      ),
+    );
+    await flush();
+    await expect(embed(["hard-cap-overflow"], "query")).rejects.toBeInstanceOf(
+      EmbeddingQueueCapacityError,
+    );
+
+    for (const controller of recallControllers) controller.abort();
+    for (const controller of controllers) controller.abort();
+    const outcomes = await Promise.all([...queued, ...recalls]);
+    expect(outcomes.every((outcome) => !outcome.ok)).toBe(true);
+    fakes[0].completeNext();
+    await blocked;
+  });
+
+  it("bounds identical waiters and reopens admission after one cancels", async () => {
+    _setEmbedPoolSizeForTest(1);
+    const fakes = installFakeWorkers();
+    await warmPool(fakes);
+    const baselinePosts = fakes[0].embedPostCount;
+    const controllers = Array.from({ length: 64 }, () => new AbortController());
+    const waiters = controllers.map((controller) =>
+      settle(embed(["identical flood"], "document", controller.signal)),
+    );
+    await flush();
+
+    await expect(embed(["identical flood"], "document")).rejects.toBeInstanceOf(
+      EmbeddingQueueCapacityError,
+    );
+    expect(fakes[0].embedPostCount).toBe(baselinePosts + 1);
+
+    controllers[0].abort();
+    await expect(waiters[0]).resolves.toEqual({
+      ok: false,
+      err: expect.any(EmbeddingRequestAbortedError),
+    });
+    const replacementController = new AbortController();
+    const replacement = settle(
+      embed(["identical flood"], "document", replacementController.signal),
+    );
+    replacementController.abort();
+    for (const controller of controllers.slice(1)) controller.abort();
+    const outcomes = await Promise.all([...waiters.slice(1), replacement]);
+    expect(outcomes.every((outcome) => !outcome.ok)).toBe(true);
+
+    fakes[0].completeNext();
+    await flush();
+    expect(fakes[0].embedPostCount).toBe(baselinePosts + 1);
+  });
+
+  it("reopens cumulative queued-byte capacity after cancellation", async () => {
+    _setEmbedPoolSizeForTest(1);
+    const fakes = installFakeWorkers();
+    await warmPool(fakes);
+    const baselinePosts = fakes[0].embedPostCount;
+    const blocked = embed(["occupy byte-bounded queue worker"], "document");
+    await flush();
+    const firstText = "a".repeat(4 * 1024 * 1024);
+    const secondText = "b".repeat(4 * 1024 * 1024);
+    const firstController = new AbortController();
+    const first = settle(
+      embed([firstText], "document", firstController.signal),
+    );
+    await flush();
+
+    // Each request is below 7 MiB, but their cumulative queued bytes are not.
+    await expect(embed([secondText], "document")).rejects.toBeInstanceOf(
+      EmbeddingQueueCapacityError,
+    );
+
+    firstController.abort();
+    await expect(first).resolves.toEqual({
+      ok: false,
+      err: expect.any(EmbeddingRequestAbortedError),
+    });
+
+    const secondController = new AbortController();
+    const second = settle(
+      embed([secondText], "document", secondController.signal),
+    );
+    await flush();
+    secondController.abort();
+    await expect(second).resolves.toEqual({
+      ok: false,
+      err: expect.any(EmbeddingRequestAbortedError),
+    });
+
+    expect(fakes[0].embedPostCount).toBe(baselinePosts + 1);
+    fakes[0].completeNext();
+    await blocked;
+  });
+
+  it("enforces the hard queued-byte cap across normal and recall work", async () => {
+    _setEmbedPoolSizeForTest(1);
+    const fakes = installFakeWorkers();
+    await warmPool(fakes);
+    const blocked = embed(["occupy hard-byte-cap worker"], "document");
+    await flush();
+
+    const normalController = new AbortController();
+    const normal = settle(
+      embed(
+        ["n".repeat(7 * 1024 * 1024 - 256 * 1024)],
+        "document",
+        normalController.signal,
+      ),
+    );
+    const firstRecallController = new AbortController();
+    const firstRecall = settle(
+      embed(["q".repeat(1024 * 1024)], "query", firstRecallController.signal),
+    );
+    await flush();
+
+    const secondRecallText = "r".repeat(512 * 1024);
+    await expect(embed([secondRecallText], "query")).rejects.toBeInstanceOf(
+      EmbeddingQueueCapacityError,
+    );
+
+    firstRecallController.abort();
+    await expect(firstRecall).resolves.toEqual({
+      ok: false,
+      err: expect.any(EmbeddingRequestAbortedError),
+    });
+    const replacementController = new AbortController();
+    const replacement = settle(
+      embed([secondRecallText], "query", replacementController.signal),
+    );
+    replacementController.abort();
+    normalController.abort();
+    const outcomes = await Promise.all([normal, replacement]);
+    expect(outcomes.every((outcome) => !outcome.ok)).toBe(true);
+
+    fakes[0].completeNext();
+    await blocked;
+  });
+
   it("reuses a completed orphan result when a durable retry arrives", async () => {
     _setEmbedPoolSizeForTest(1);
     const fakes = installFakeWorkers();
@@ -439,6 +671,62 @@ describe("EmbeddingPool dispatch (#999)", () => {
       stage: "execution",
     } satisfies Partial<EmbeddingWorkerWatchdogError>);
     expect(fakes[0].gotShutdown).toBe(true);
+  });
+
+  it("counts a retiring worker against the capacity ceiling until exit", async () => {
+    _setEmbedPoolSizeForTest(2);
+    _setPoolFreememForTest(64 * GB);
+    _setEmbeddingWorkerWatchdogsForTest(60_000, 10);
+    const fakes = installFakeWorkers();
+    await warmPool(fakes);
+
+    const healthy = embed(["healthy sibling"], "document");
+    const stuck = settle(embed(["stuck sibling"], "document"));
+    await flush();
+    expect(fakes).toHaveLength(2);
+    fakes[1].exitOnShutdown = false;
+    fakes[1].startNext();
+    await expect(stuck).resolves.toMatchObject({
+      ok: false,
+      err: { name: "EmbeddingWorkerWatchdogError", stage: "execution" },
+    });
+    expect(fakes[1].gotShutdown).toBe(true);
+
+    const firstQueued = embed(["first queued"], "document");
+    const secondQueued = embed(["second queued"], "document");
+    fakes[0].completeNext();
+    await expect(healthy).resolves.toHaveLength(1);
+    await flush();
+
+    // The surviving slot accepts one job, but the retiring model prevents a
+    // replacement from temporarily becoming a third resident worker.
+    expect(fakes).toHaveLength(2);
+    expect(fakes[0].embedIds).toHaveLength(1);
+
+    fakes[1].exit();
+    await flush();
+    expect(fakes).toHaveLength(3);
+    expect(fakes[2].embedIds).toHaveLength(1);
+    fakes[0].completeNext();
+    fakes[2].completeNext();
+    await Promise.all([firstQueued, secondQueued]);
+  });
+
+  it("normalizes an initialization watchdog at the readiness boundary", async () => {
+    _setEmbedPoolSizeForTest(1);
+    _setEmbeddingWorkerWatchdogsForTest(10, 60_000);
+    installFakeWorkers();
+
+    const outcome = await settle(ensureEmbeddingReady({ deadlineMs: 1_000 }));
+    expect(outcome.ok).toBe(false);
+    if (!outcome.ok) {
+      expect(outcome.err).toBeInstanceOf(LocalProviderUnavailableError);
+      expect(outcome.err).not.toBeInstanceOf(EmbeddingWorkerWatchdogError);
+      expect((outcome.err as Error & { cause?: unknown }).cause).toMatchObject({
+        name: "EmbeddingWorkerWatchdogError",
+        stage: "init",
+      });
+    }
   });
 
   it("stays at a single worker under concurrency when memory is tight", async () => {

--- a/packages/core/test/pattern-echo.test.ts
+++ b/packages/core/test/pattern-echo.test.ts
@@ -6,6 +6,7 @@ import {
   detectPatternEchoes,
   PATTERN_COOLDOWN_MS,
 } from "../src/pattern-echo";
+import * as log from "../src/log";
 import type { LLMClient } from "../src/types";
 
 // pattern-echo runs two jobs at the gen-0 distillation hook: (1) embed + store
@@ -154,6 +155,29 @@ describe("pattern-echo cooldown", () => {
     // The embed recovers on the next segment → detection runs (not rate-limited).
     await detectPatternEchoes({ ...base, distillId: "f2" });
     expect(searchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats queue saturation as expected backpressure without error logging or cooldown", async () => {
+    const error = vi.spyOn(log, "error").mockImplementation(() => {});
+    const pid = ensureProject(PROJECT);
+    insertDistill("q1", pid, "s-capacity");
+    insertDistill("q2", pid, "s-capacity");
+    const base = {
+      observations: "private observations",
+      projectPath: PROJECT,
+      sessionID: "s-capacity",
+      llm: stubLLM(),
+    };
+
+    embedSpy.mockRejectedValueOnce(new embedding.EmbeddingQueueCapacityError());
+    await detectPatternEchoes({ ...base, distillId: "q1" });
+    expect(error).not.toHaveBeenCalled();
+    expect(searchSpy).not.toHaveBeenCalled();
+
+    // Capacity reopening must allow the next segment to attempt detection;
+    // saturation happened before the cooldown was armed.
+    await detectPatternEchoes({ ...base, distillId: "q2" });
+    expect(searchSpy).toHaveBeenCalledOnce();
   });
 
   it("rolls back its cooldown when cancellation interrupts an armed attempt", async () => {

--- a/packages/core/test/temporal-embedding-queue.test.ts
+++ b/packages/core/test/temporal-embedding-queue.test.ts
@@ -11,6 +11,7 @@ import {
 import {
   _restoreProvider,
   _saveAndClearProvider,
+  EmbeddingQueueCapacityError,
   LocalProviderUnavailableError,
   type EmbeddingProvider,
 } from "../src/embedding";
@@ -437,6 +438,29 @@ describe("durable temporal embedding scheduler", () => {
     await vi.advanceTimersByTimeAsync(1);
     expect(embed).toHaveBeenCalledTimes(2);
     expect(JSON.stringify(error.mock.calls)).not.toContain("secret model path");
+  });
+
+  test("queue saturation uses transient backpressure retry without exposing content", async () => {
+    vi.useFakeTimers();
+    const error = vi.spyOn(log, "error").mockImplementation(() => {});
+    const embed = vi.fn(async () => {
+      throw new EmbeddingQueueCapacityError();
+    });
+    installProvider({ maxBatchSize: 8, embed });
+    const content = "private queued input must not appear in capacity logs";
+    insertMessage(content);
+
+    startTemporalEmbeddingScheduler();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(error.mock.calls[0]?.[0]).toContain(
+      "reason=queue-capacity stage=embed",
+    );
+    expect(error.mock.calls[0]?.[0]).toContain("retry_ms=1000");
+    expect(JSON.stringify(error.mock.calls)).not.toContain(content);
+    await vi.advanceTimersByTimeAsync(999);
+    expect(embed).toHaveBeenCalledOnce();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(embed).toHaveBeenCalledTimes(2);
   });
 
   test("shutdown cancellation stays quiet and restart waits for the old provider slot", async () => {


### PR DESCRIPTION
## Why

A temporal drain's 60-second caller deadline used to abort `LocalProvider.embed()`, and `EmbeddingPool` responded by retiring the assigned worker. That destroyed a healthy loaded model, rejected unrelated work, and let the durable scheduler repeatedly restart the same batch.

## What changed

- Move local embedding admission and priority queue ownership into `EmbeddingPool`; post at most one native batch to each worker.
- Separate caller waiters from worker execution ownership:
  - already-aborted requests start no work;
  - queued cancellation removes only that operation and releases its retained input;
  - executing cancellation settles only that caller while native work remains accounted;
  - identical retries join running work or consume one bounded orphan result.
- Add a worker `started` acknowledgement and independent initialization/execution watchdogs.
- Retire slots only for provider failure or a worker-owned watchdog. Retiring workers remain counted against the memory/capacity ceiling until confirmed exit.
- Resume an interrupted local token-batched retry from its successfully completed prefix without starting future sub-batches for an abandoned caller.
- Bound host state:
  - hard queue: 256 operations / 8 MiB;
  - normal-work queue: 240 operations / 7 MiB, reserving recall headroom;
  - deduplicated fan-in: 64 waiters per operation;
  - completed results/checkpoints: 8 entries / 5 minutes.
- Classify queue saturation as transient backpressure. Temporal work retries; best-effort writers and pattern echo avoid Sentry storms; sequential backfills stop instead of spinning.
- Normalize internal worker-watchdog failures at `ensureEmbeddingReady()` to the established `LocalProviderUnavailableError` contract (Seer review finding).

## Result

The temporal scheduler may still report its own deadline, but ordinary caller cancellation no longer reloads or replaces a healthy worker. A retry cannot duplicate the same executing native batch, completed prefix work is reused, retained inputs/waiters are bounded, and retirement cannot temporarily oversubscribe model memory.

## Validation

- Embedding/temporal/pattern battery: **420 passed, 6 skipped**.
- Adversarial focused battery: **128/128 passed**.
- Lifecycle/property stability: **10/10 runs**, 92 tests per run.
- Core, core eval, gateway, OpenCode, and Pi TypeScript checks pass.
- Full type-aware lint, full format check, `git diff --check`, and gateway bundle pass.
- Six apply/revert mutants were killed by their targeted regressions: retirement capacity, readiness normalization, completed-prefix checkpointing, queued-byte release, backfill stop, and pattern-echo suppression.
- Exact-final full suite: **10,176 passed, 230 skipped**. Seven unrelated baseline/environment failures remain in cache-stability E2E, compact integration, installer timezone/PID/`/proc` assumptions, and unavailable optional CUDA/TensorRT package assets.
- Independent adversarial correctness review: **MERGE**.
- Independent security/pentest review: **MERGE**.

Closes #1745
Relates #1708
Relates #1734
Follow-up hard process isolation: #1753