### PR TITLE
fix(gateway): make recall schema OpenAI strict-compatible

### DIFF
--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -8103,26 +8103,35 @@ export function streamResponsesRecallAware(
         `invalid recall function arguments: unknown property "${unknown}"`,
       );
     }
-    if (record.query !== undefined && typeof record.query !== "string") {
+    // The strict OpenAI tool projection sends every declared property and uses
+    // `null` for values omitted by the selected recall mode.
+    const queryValue = record.query === null ? undefined : record.query;
+    const scopeValue = record.scope === null ? undefined : record.scope;
+    const idValue = record.id === null ? undefined : record.id;
+    const idsValue = record.ids === null ? undefined : record.ids;
+    const detailOffsetValue =
+      record.detailOffset === null ? undefined : record.detailOffset;
+    const detailLimitValue =
+      record.detailLimit === null ? undefined : record.detailLimit;
+    if (queryValue !== undefined && typeof queryValue !== "string") {
       throw new Error(
         "invalid recall function arguments: query must be a string",
       );
     }
     if (
-      record.id !== undefined &&
-      record.id !== null &&
-      (typeof record.id !== "string" ||
-        !record.id ||
-        record.id.length > MAX_RECALL_ID_CHARS)
+      idValue !== undefined &&
+      (typeof idValue !== "string" ||
+        !idValue ||
+        idValue.length > MAX_RECALL_ID_CHARS)
     ) {
       throw new Error("invalid recall function arguments: id must be a string");
     }
     if (
-      record.ids !== undefined &&
-      (!Array.isArray(record.ids) ||
-        record.ids.length === 0 ||
-        record.ids.length > MAX_RECALL_BATCH_IDS ||
-        record.ids.some(
+      idsValue !== undefined &&
+      (!Array.isArray(idsValue) ||
+        idsValue.length === 0 ||
+        idsValue.length > MAX_RECALL_BATCH_IDS ||
+        idsValue.some(
           (id) =>
             typeof id !== "string" || !id || id.length > MAX_RECALL_ID_CHARS,
         ))
@@ -8131,54 +8140,50 @@ export function streamResponsesRecallAware(
         `invalid recall function arguments: ids must contain 1-${MAX_RECALL_BATCH_IDS} strings no longer than ${MAX_RECALL_ID_CHARS} characters`,
       );
     }
-    if (record.id !== undefined && record.ids !== undefined) {
+    if (idValue !== undefined && idsValue !== undefined) {
       throw new Error("invalid recall function arguments: id and ids conflict");
     }
     if (
-      record.detailOffset !== undefined &&
-      (!Number.isSafeInteger(record.detailOffset) ||
-        (record.detailOffset as number) < 0)
+      detailOffsetValue !== undefined &&
+      (!Number.isSafeInteger(detailOffsetValue) ||
+        (detailOffsetValue as number) < 0)
     ) {
       throw new Error(
         "invalid recall function arguments: detailOffset must be non-negative",
       );
     }
     if (
-      record.detailLimit !== undefined &&
-      (!Number.isSafeInteger(record.detailLimit) ||
-        (record.detailLimit as number) < 1 ||
-        (record.detailLimit as number) > 16_000)
+      detailLimitValue !== undefined &&
+      (!Number.isSafeInteger(detailLimitValue) ||
+        (detailLimitValue as number) < 1 ||
+        (detailLimitValue as number) > 16_000)
     ) {
       throw new Error(
         "invalid recall function arguments: detailLimit must be 1-16000",
       );
     }
-    if (
-      record.scope !== undefined &&
-      record.scope !== null &&
-      typeof record.scope !== "string"
-    ) {
+    if (scopeValue !== undefined && typeof scopeValue !== "string") {
       throw new Error(
         "invalid recall function arguments: scope must be a string",
       );
     }
-    const query = record.query ?? "";
-    const id = record.id || undefined;
-    const ids = Array.isArray(record.ids) ? [...record.ids] : undefined;
+    const query = queryValue ?? "";
+    const id = idValue || undefined;
+    const ids = Array.isArray(idsValue) ? [...idsValue] : undefined;
     if (!query.trim() && !id && !ids) {
       throw new Error(
         "invalid recall function arguments: query, id, or ids is required",
       );
     }
     if (
-      (record.detailOffset !== undefined || record.detailLimit !== undefined) &&
+      (detailOffsetValue !== undefined || detailLimitValue !== undefined) &&
       !id
     ) {
       throw new Error(
         "invalid recall function arguments: detail ranges require one id",
       );
     }
-    const scope = record.scope || undefined;
+    const scope = scopeValue || undefined;
     if (
       scope &&
       scope !== "all" &&
@@ -8193,11 +8198,11 @@ export function streamResponsesRecallAware(
       ...(scope ? { scope } : {}),
       ...(id ? { id } : {}),
       ...(ids ? { ids } : {}),
-      ...(typeof record.detailOffset === "number"
-        ? { detailOffset: record.detailOffset }
+      ...(typeof detailOffsetValue === "number"
+        ? { detailOffset: detailOffsetValue }
         : {}),
-      ...(typeof record.detailLimit === "number"
-        ? { detailLimit: record.detailLimit }
+      ...(typeof detailLimitValue === "number"
+        ? { detailLimit: detailLimitValue }
         : {}),
     };
   };

--- a/packages/gateway/src/recall.ts
+++ b/packages/gateway/src/recall.ts
@@ -957,23 +957,34 @@ function parseRecallInput(block: GatewayToolUseBlock): {
   ]);
   const unknown = Object.keys(record).find((key) => !allowed.has(key));
   if (unknown) throw new Error(`Unknown recall property: ${unknown}`);
-  if (record.query !== undefined && typeof record.query !== "string") {
+  // OpenAI strict function schemas require every property to be present. The
+  // wire projection therefore represents omitted optional values as `null`;
+  // normalize those sentinels before applying the provider-neutral contract.
+  const queryValue = record.query === null ? undefined : record.query;
+  const scopeValue = record.scope === null ? undefined : record.scope;
+  const idValue = record.id === null ? undefined : record.id;
+  const idsValue = record.ids === null ? undefined : record.ids;
+  const detailOffsetValue =
+    record.detailOffset === null ? undefined : record.detailOffset;
+  const detailLimitValue =
+    record.detailLimit === null ? undefined : record.detailLimit;
+  if (queryValue !== undefined && typeof queryValue !== "string") {
     throw new Error("Recall query must be a string");
   }
   if (
-    record.id !== undefined &&
-    (typeof record.id !== "string" ||
-      !record.id ||
-      record.id.length > MAX_RECALL_ID_CHARS)
+    idValue !== undefined &&
+    (typeof idValue !== "string" ||
+      !idValue ||
+      idValue.length > MAX_RECALL_ID_CHARS)
   ) {
     throw new Error("Recall id must be a non-empty string");
   }
   if (
-    record.ids !== undefined &&
-    (!Array.isArray(record.ids) ||
-      record.ids.length === 0 ||
-      record.ids.length > MAX_RECALL_BATCH_IDS ||
-      record.ids.some(
+    idsValue !== undefined &&
+    (!Array.isArray(idsValue) ||
+      idsValue.length === 0 ||
+      idsValue.length > MAX_RECALL_BATCH_IDS ||
+      idsValue.some(
         (id) =>
           typeof id !== "string" || !id || id.length > MAX_RECALL_ID_CHARS,
       ))
@@ -982,31 +993,31 @@ function parseRecallInput(block: GatewayToolUseBlock): {
       `Recall ids must contain from 1 to ${MAX_RECALL_BATCH_IDS} non-empty strings`,
     );
   }
-  if (record.id !== undefined && record.ids !== undefined) {
+  if (idValue !== undefined && idsValue !== undefined) {
     throw new Error("Recall id and ids cannot be used together");
   }
   if (
-    record.detailOffset !== undefined &&
-    (!Number.isSafeInteger(record.detailOffset) ||
-      (record.detailOffset as number) < 0)
+    detailOffsetValue !== undefined &&
+    (!Number.isSafeInteger(detailOffsetValue) ||
+      (detailOffsetValue as number) < 0)
   ) {
     throw new Error("Recall detailOffset must be a non-negative integer");
   }
   if (
-    record.detailLimit !== undefined &&
-    (!Number.isSafeInteger(record.detailLimit) ||
-      (record.detailLimit as number) < 1 ||
-      (record.detailLimit as number) > 16_000)
+    detailLimitValue !== undefined &&
+    (!Number.isSafeInteger(detailLimitValue) ||
+      (detailLimitValue as number) < 1 ||
+      (detailLimitValue as number) > 16_000)
   ) {
     throw new Error("Recall detailLimit must be an integer from 1 to 16000");
   }
-  const query = record.query ?? "";
-  if (!query.trim() && !record.id && !record.ids) {
+  const query = queryValue ?? "";
+  if (!query.trim() && !idValue && !idsValue) {
     throw new Error("Recall query, id, or ids is required");
   }
   if (
-    (record.detailOffset !== undefined || record.detailLimit !== undefined) &&
-    typeof record.id !== "string"
+    (detailOffsetValue !== undefined || detailLimitValue !== undefined) &&
+    typeof idValue !== "string"
   ) {
     throw new Error("Recall detail ranges require exactly one id");
   }
@@ -1017,21 +1028,21 @@ function parseRecallInput(block: GatewayToolUseBlock): {
     "knowledge",
   ]);
   if (
-    record.scope !== undefined &&
-    (typeof record.scope !== "string" || !validScopes.has(record.scope))
+    scopeValue !== undefined &&
+    (typeof scopeValue !== "string" || !validScopes.has(scopeValue))
   ) {
     throw new Error("Invalid recall scope");
   }
   return {
     query,
-    scope: (record.scope as RecallScope | undefined) ?? "all",
-    ...(typeof record.id === "string" && record.id ? { id: record.id } : {}),
-    ...(Array.isArray(record.ids) ? { ids: [...record.ids] } : {}),
-    ...(typeof record.detailOffset === "number"
-      ? { detailOffset: record.detailOffset }
+    scope: (scopeValue as RecallScope | undefined) ?? "all",
+    ...(typeof idValue === "string" && idValue ? { id: idValue } : {}),
+    ...(Array.isArray(idsValue) ? { ids: [...idsValue] } : {}),
+    ...(typeof detailOffsetValue === "number"
+      ? { detailOffset: detailOffsetValue }
       : {}),
-    ...(typeof record.detailLimit === "number"
-      ? { detailLimit: record.detailLimit }
+    ...(typeof detailLimitValue === "number"
+      ? { detailLimit: detailLimitValue }
       : {}),
   };
 }

--- a/packages/gateway/src/translate/openai-responses.ts
+++ b/packages/gateway/src/translate/openai-responses.ts
@@ -841,6 +841,57 @@ function parseArguments(args: unknown): unknown {
   return args ?? {};
 }
 
+/**
+ * OpenAI strict function schemas require every property to be listed in
+ * `required`. Recall has three mutually exclusive modes, so the properties
+ * omitted by a mode must be represented as nullable instead.
+ */
+function buildStrictRecallParameters(
+  inputSchema: Record<string, unknown>,
+): Record<string, unknown> {
+  const schema = { ...inputSchema };
+  delete schema.anyOf;
+  const sourceProperties =
+    schema.properties &&
+    typeof schema.properties === "object" &&
+    !Array.isArray(schema.properties)
+      ? (schema.properties as Record<string, unknown>)
+      : {};
+  const properties = Object.fromEntries(
+    Object.entries(sourceProperties).map(([name, value]) => {
+      const property =
+        value && typeof value === "object" && !Array.isArray(value)
+          ? (value as Record<string, unknown>)
+          : {};
+      const sourceTypes = Array.isArray(property.type)
+        ? property.type
+        : typeof property.type === "string"
+          ? [property.type]
+          : [];
+      const type = [...sourceTypes.filter((item) => item !== "null"), "null"];
+      return [
+        name,
+        {
+          ...property,
+          type,
+          ...(Array.isArray(property.enum)
+            ? {
+                enum: property.enum.includes(null)
+                  ? property.enum
+                  : [...property.enum, null],
+              }
+            : {}),
+        },
+      ];
+    }),
+  );
+  return {
+    ...schema,
+    properties,
+    required: Object.keys(properties),
+  };
+}
+
 // ---------------------------------------------------------------------------
 // GatewayRequest → OpenAI Responses API upstream request
 // ---------------------------------------------------------------------------
@@ -889,28 +940,12 @@ export function buildOpenAIResponsesUpstreamRequest(
           parameters: t.inputSchema,
         };
       }
-      const properties = t.inputSchema.properties as Record<
-        string,
-        Record<string, unknown>
-      >;
       return {
         type: "function",
         name: t.name,
         description: t.description,
         strict: true,
-        parameters: {
-          ...t.inputSchema,
-          properties: {
-            ...properties,
-            scope: {
-              ...properties.scope,
-              type: ["string", "null"],
-              enum: [...((properties.scope.enum as unknown[]) ?? []), null],
-            },
-            id: { ...properties.id, type: ["string", "null"] },
-          },
-          required: Object.keys(properties),
-        },
+        parameters: buildStrictRecallParameters(t.inputSchema),
       };
     });
   }

--- a/packages/gateway/src/translate/openai-responses.ts
+++ b/packages/gateway/src/translate/openai-responses.ts
@@ -868,7 +868,16 @@ function buildStrictRecallParameters(
         : typeof property.type === "string"
           ? [property.type]
           : [];
-      const type = [...sourceTypes.filter((item) => item !== "null"), "null"];
+      const nonNullTypes = sourceTypes.filter((item) => item !== "null");
+      if (
+        nonNullTypes.length === 0 ||
+        nonNullTypes.some((item) => typeof item !== "string")
+      ) {
+        throw new Error(
+          `Recall schema property "${name}" must declare a non-null type`,
+        );
+      }
+      const type = [...nonNullTypes, "null"];
       return [
         name,
         {

--- a/packages/gateway/test/openai-responses-recall-aware-stream.test.ts
+++ b/packages/gateway/test/openai-responses-recall-aware-stream.test.ts
@@ -6741,37 +6741,116 @@ describe("streamResponsesRecallAware", () => {
     expect(out).not.toContain('"name":"recall"');
   });
 
-  test("accepts nullable strict optional recall arguments", async () => {
-    let seen: { scope?: string; id?: string } | undefined;
-    const client = streamResponsesRecallAware(
-      streamFrom([
-        created("resp_nullable_args", "gpt-5.6-terra"),
-        recallCall(0, { query: "architecture", scope: null, id: null }),
-        completed("resp_nullable_args"),
-      ]),
-      {
-        onComplete: () => {},
-        onRecall: async ({ scope, id }) => {
-          seen = { scope, id };
-          return {
-            anchorText: buildAnchor("architecture"),
-            resultText: "results",
-          };
-        },
-        runFollowUp: async () => ({
-          reader: streamFrom([
-            created("resp_nullable_followup", "gpt-5.6-terra"),
-            textItem(0, "answer"),
-            completed("resp_nullable_followup"),
-          ]).body!.getReader(),
-        }),
+  test.each([
+    {
+      mode: "query",
+      args: {
+        query: "architecture",
+        scope: null,
+        id: null,
+        ids: null,
+        detailOffset: null,
+        detailLimit: null,
       },
-    );
+      expected: {
+        query: "architecture",
+        scope: undefined,
+        id: undefined,
+        ids: undefined,
+        detailOffset: undefined,
+        detailLimit: undefined,
+      },
+    },
+    {
+      mode: "single-id detail",
+      args: {
+        query: null,
+        scope: null,
+        id: "k:one",
+        ids: null,
+        detailOffset: 10,
+        detailLimit: 20,
+      },
+      expected: {
+        query: "",
+        scope: undefined,
+        id: "k:one",
+        ids: undefined,
+        detailOffset: 10,
+        detailLimit: 20,
+      },
+    },
+    {
+      mode: "batch-id",
+      args: {
+        query: null,
+        scope: null,
+        id: null,
+        ids: ["k:one", "k:two"],
+        detailOffset: null,
+        detailLimit: null,
+      },
+      expected: {
+        query: "",
+        scope: undefined,
+        id: undefined,
+        ids: ["k:one", "k:two"],
+        detailOffset: undefined,
+        detailLimit: undefined,
+      },
+    },
+  ])(
+    "accepts nullable strict $mode recall arguments",
+    async ({ args, expected }) => {
+      let seen:
+        | {
+            query: string;
+            scope?: string;
+            id?: string;
+            ids?: string[];
+            detailOffset?: number;
+            detailLimit?: number;
+          }
+        | undefined;
+      const client = streamResponsesRecallAware(
+        streamFrom([
+          created("resp_nullable_args", "gpt-5.6-terra"),
+          recallCall(0, args),
+          completed("resp_nullable_args"),
+        ]),
+        {
+          onComplete: () => {},
+          onRecall: async ({
+            query,
+            scope,
+            id,
+            ids,
+            detailOffset,
+            detailLimit,
+          }) => {
+            seen = { query, scope, id, ids, detailOffset, detailLimit };
+            return {
+              anchorText: buildAnchor(query || "detail"),
+              resultText: "results",
+            };
+          },
+          runFollowUp: async () => {
+            const response = streamFrom([
+              created("resp_nullable_followup", "gpt-5.6-terra"),
+              textItem(0, "answer"),
+              completed("resp_nullable_followup"),
+            ]);
+            if (!response.body) throw new Error("missing follow-up body");
+            return { reader: response.body.getReader() };
+          },
+        },
+      );
 
-    const out = await drain(client);
-    expect(seen).toEqual({ scope: undefined, id: undefined });
-    expect(out).toContain("answer");
-  });
+      const out = await drain(client);
+      expect(seen).toEqual(expected);
+      expect(out).toContain("answer");
+    },
+  );
 
   test("holds no-index continuation events after chained recall detection", async () => {
     const malformed = streamFrom([

--- a/packages/gateway/test/openai-responses.test.ts
+++ b/packages/gateway/test/openai-responses.test.ts
@@ -1224,6 +1224,26 @@ describe("buildOpenAIResponsesUpstreamRequest", () => {
     expect(RECALL_GATEWAY_TOOL.inputSchema).not.toHaveProperty("required");
   });
 
+  test("rejects a null-only strict projection for an ill-formed recall property", () => {
+    const req = parseOpenAIResponsesRequest(
+      { model: "gpt-4o", input: "Hello" },
+      {},
+    );
+    req.tools.push({
+      name: "recall",
+      description: "Recall memory",
+      inputSchema: {
+        type: "object",
+        properties: { query: { anyOf: [{ type: "string" }] } },
+        additionalProperties: false,
+      },
+    });
+
+    expect(() =>
+      buildOpenAIResponsesUpstreamRequest(req, "https://api.openai.com"),
+    ).toThrow('Recall schema property "query" must declare a non-null type');
+  });
+
   test("does NOT forward previous_response_id (gateway is stateless full-history)", () => {
     // The gateway always sends the complete conversation as `input`. Forwarding
     // previous_response_id would make the upstream ALSO prepend its server-stored

--- a/packages/gateway/test/openai-responses.test.ts
+++ b/packages/gateway/test/openai-responses.test.ts
@@ -10,7 +10,7 @@
  *    (the gateway is a stateless full-history proxy)
  */
 import { afterEach, describe, test, expect } from "vitest";
-import { log } from "@loreai/core";
+import { log, MAX_RECALL_BATCH_IDS } from "@loreai/core";
 import {
   parseOpenAIResponsesRequest,
   parseOpenAIResponsesRequestChunks,
@@ -33,6 +33,7 @@ import {
   gatewayMessagesToLore,
   resolveToolResults,
 } from "../src/temporal-adapter";
+import { RECALL_GATEWAY_TOOL } from "../src/recall";
 import type {
   GatewayResponse,
   GatewayContentBlock,
@@ -1165,7 +1166,7 @@ describe("buildOpenAIResponsesUpstreamRequest", () => {
     expect(tools[0].parameters).toEqual({ type: "object", properties: {} });
   });
 
-  test("marks the closed recall schema strict without changing client tools", () => {
+  test("projects the real recall tool into OpenAI's strict schema dialect", () => {
     const req = parseOpenAIResponsesRequest(
       {
         model: "gpt-4o",
@@ -1181,20 +1182,10 @@ describe("buildOpenAIResponsesUpstreamRequest", () => {
       },
       {},
     );
-    req.tools.push({
-      name: "recall",
-      description: "Recall memory",
-      inputSchema: {
-        type: "object",
-        properties: {
-          query: { type: "string" },
-          scope: { type: "string" },
-          id: { type: "string" },
-        },
-        required: ["query"],
-        additionalProperties: false,
-      },
-    });
+    const originalRecallSchema = structuredClone(
+      RECALL_GATEWAY_TOOL.inputSchema,
+    );
+    req.tools.push(RECALL_GATEWAY_TOOL);
 
     const body = buildOpenAIResponsesUpstreamRequest(
       req,
@@ -1203,14 +1194,34 @@ describe("buildOpenAIResponsesUpstreamRequest", () => {
 
     expect(body.tools[0]).not.toHaveProperty("strict");
     expect(body.tools[1]).toMatchObject({ name: "recall", strict: true });
-    expect(body.tools[1].parameters).toMatchObject({
-      required: ["query", "scope", "id"],
+    const parameters = body.tools[1].parameters as Record<string, unknown>;
+    expect(parameters).not.toHaveProperty("anyOf");
+    expect(parameters).toMatchObject({
+      required: ["query", "scope", "id", "ids", "detailOffset", "detailLimit"],
       additionalProperties: false,
       properties: {
-        scope: { type: ["string", "null"], enum: [null] },
+        query: { type: ["string", "null"] },
+        scope: {
+          type: ["string", "null"],
+          enum: ["all", "session", "project", "knowledge", null],
+        },
         id: { type: ["string", "null"] },
+        ids: {
+          type: ["array", "null"],
+          minItems: 1,
+          maxItems: MAX_RECALL_BATCH_IDS,
+          items: { type: "string" },
+        },
+        detailOffset: { type: ["integer", "null"], minimum: 0 },
+        detailLimit: {
+          type: ["integer", "null"],
+          minimum: 1,
+          maximum: 16_000,
+        },
       },
     });
+    expect(RECALL_GATEWAY_TOOL.inputSchema).toEqual(originalRecallSchema);
+    expect(RECALL_GATEWAY_TOOL.inputSchema).not.toHaveProperty("required");
   });
 
   test("does NOT forward previous_response_id (gateway is stateless full-history)", () => {

--- a/packages/gateway/test/recall-already-in-ltm.test.ts
+++ b/packages/gateway/test/recall-already-in-ltm.test.ts
@@ -19,18 +19,19 @@ import type { GatewayToolUseBlock } from "../src/translate/types";
 
 describe("executeRecall — alreadyInLtmIds identity across calls", () => {
   let captured: Array<ReadonlySet<string> | undefined>;
+  let capturedInputs: Array<Parameters<typeof core.runRecallWithMetadata>[0]>;
   let spy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
     captured = [];
+    capturedInputs = [];
     spy = vi
       .spyOn(core, "runRecallWithMetadata")
-      .mockImplementation(
-        async (input: { alreadyInLtmIds?: ReadonlySet<string> }) => {
-          captured.push(input.alreadyInLtmIds);
-          return { result: "OK", coverage: [] };
-        },
-      );
+      .mockImplementation(async (input) => {
+        capturedInputs.push(input);
+        captured.push(input.alreadyInLtmIds);
+        return { result: "OK", coverage: [] };
+      });
   });
 
   test("the same Set instance is forwarded verbatim to the metadata runner", async () => {
@@ -71,4 +72,83 @@ describe("executeRecall — alreadyInLtmIds identity across calls", () => {
 
     spy.mockRestore();
   });
+
+  test.each([
+    {
+      mode: "query",
+      input: {
+        query: "architecture",
+        scope: null,
+        id: null,
+        ids: null,
+        detailOffset: null,
+        detailLimit: null,
+      },
+      expected: {
+        query: "architecture",
+        scope: "all",
+        id: undefined,
+        ids: undefined,
+        detailOffset: undefined,
+        detailLimit: undefined,
+      },
+    },
+    {
+      mode: "single-id detail",
+      input: {
+        query: null,
+        scope: null,
+        id: "k:one",
+        ids: null,
+        detailOffset: 10,
+        detailLimit: 20,
+      },
+      expected: {
+        query: "",
+        scope: "all",
+        id: "k:one",
+        ids: undefined,
+        detailOffset: 10,
+        detailLimit: 20,
+      },
+    },
+    {
+      mode: "batch-id",
+      input: {
+        query: null,
+        scope: null,
+        id: null,
+        ids: ["k:one", "k:two"],
+        detailOffset: null,
+        detailLimit: null,
+      },
+      expected: {
+        query: "",
+        scope: "all",
+        id: undefined,
+        ids: ["k:one", "k:two"],
+        detailOffset: undefined,
+        detailLimit: undefined,
+      },
+    },
+  ])(
+    "normalizes strict OpenAI nulls for $mode mode",
+    async ({ input, expected }) => {
+      const result = await executeRecall(
+        {
+          type: "tool_use",
+          id: "toolu_nullable",
+          name: RECALL_TOOL_NAME,
+          input,
+        },
+        "/tmp/proj",
+        "sess",
+      );
+
+      expect(result.result).toBe("OK");
+      expect(capturedInputs).toHaveLength(1);
+      expect(capturedInputs[0]).toMatchObject(expected);
+      spy.mockRestore();
+    },
+  );
 });

--- a/packages/gateway/test/recall.test.ts
+++ b/packages/gateway/test/recall.test.ts
@@ -196,6 +196,7 @@ describe("RECALL_GATEWAY_TOOL", () => {
       { required: ["id"] },
       { required: ["ids"] },
     ]);
+    expect(schema).not.toHaveProperty("required");
     expect(schema.additionalProperties).toBe(false);
   });
 


### PR DESCRIPTION
## Summary

- preserve the canonical recall `anyOf` contract for non-OpenAI providers
- project recall into OpenAI's strict-schema dialect by stripping the root combinator, requiring every field, and making mode-optional fields nullable
- normalize strict-mode `null` sentinels in both buffered and streaming recall execution
- fail fast if a future recall property lacks a usable type
- test the real exported tool schema plus query, single-ID/paged-detail, and batch-ID modes

## Root cause

The recent batched-detail recall change added a root `anyOf` and new optional fields. The OpenAI Responses translator copied that unsupported root combinator into a strict function schema, then marked every field required without making the new fields nullable. ChatGPT/Codex rejected the tool definition with HTTP 400 before generation.

## Validation

- complete CI and Docs Preview workflows passed
- full test suite and coverage passed; patch coverage 100%
- build, typecheck, lint, format, npm bundle, standalone and cross-platform binary smoke tests passed
- independent adversarial review: MERGE
- independent security review: MERGE
- Seer finding fixed with regression coverage; thread resolved