### PR TITLE
fix(gateway): stop losing the turn on parallel recall (Anthropic)

### DIFF
--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -17142,7 +17142,8 @@ async function handleConversationTurn(
   // stream, so the turn is lost instead of degraded. Ask for at most one tool
   // use per turn while the recall tool is in play, mirroring the guard above.
   if (
-    modifiedReq.protocol === "anthropic" &&
+    (requestUpstreamRoute.effectiveProtocol === "anthropic" ||
+      requestUpstreamRoute.effectiveProtocol === "vertex") &&
     clientHasRecallTool(modifiedReq.tools)
   ) {
     const toolChoice = withParallelToolUseDisabled(

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -382,6 +382,7 @@ import {
   isUsableRecallContinuation,
   hasOtherToolUse,
   clientHasRecallTool,
+  withParallelToolUseDisabled,
   runRecallFollowUpStreaming,
   runRecallFollowUpJSON,
   runRecallFollowUpStreamAccumulated,
@@ -17133,6 +17134,26 @@ async function handleConversationTurn(
       ...modifiedReq.extras,
       parallel_tool_calls: false,
     };
+  }
+  // Anthropic has no `parallel_tool_calls`; its equivalent lives on
+  // `tool_choice`. Without it a turn that emits two recall tool_use blocks
+  // reaches the recall loop's `parallel_recall` guard, which throws — and on
+  // this wire that error escapes to the relay's catch and errors the client
+  // stream, so the turn is lost instead of degraded. Ask for at most one tool
+  // use per turn while the recall tool is in play, mirroring the guard above.
+  if (
+    modifiedReq.protocol === "anthropic" &&
+    clientHasRecallTool(modifiedReq.tools)
+  ) {
+    const toolChoice = withParallelToolUseDisabled(
+      modifiedReq.metadata.tool_choice,
+    );
+    if (toolChoice) {
+      modifiedReq.metadata = {
+        ...modifiedReq.metadata,
+        tool_choice: toolChoice,
+      };
+    }
   }
 
   // --- 8c. Synthetic project-resolution: inject probe if eligible ---

--- a/packages/gateway/src/recall.ts
+++ b/packages/gateway/src/recall.ts
@@ -855,6 +855,33 @@ export function clientHasRecallTool(tools: GatewayTool[]): boolean {
   return tools.some((t) => t.name === RECALL_TOOL_NAME);
 }
 
+/**
+ * Build a `tool_choice` that forbids parallel tool use, preserving whatever the
+ * client already asked for.
+ *
+ * The recall loop aborts a turn outright once a response carries more than one
+ * `recall` tool_use block ({@link RecallContinuationFailure} category
+ * `parallel_recall`), and on the Anthropic wire that abort tears down the
+ * client stream instead of degrading. Anthropic's `disable_parallel_tool_use`
+ * caps a turn at one tool use, which keeps the model from ever producing the
+ * shape the loop rejects.
+ *
+ * Returns `undefined` when the client asked for `none` — the flag is
+ * meaningless there (and rejected by some Anthropic-compatible proxies), so the
+ * caller should leave `tool_choice` untouched rather than overwrite it.
+ */
+export function withParallelToolUseDisabled(
+  existing: unknown,
+): Record<string, unknown> | undefined {
+  const base: Record<string, unknown> =
+    existing && typeof existing === "object" && !Array.isArray(existing)
+      ? { ...(existing as Record<string, unknown>) }
+      : { type: "auto" };
+  if (base.type === "none") return undefined;
+  if (typeof base.type !== "string") base.type = "auto";
+  return { ...base, disable_parallel_tool_use: true };
+}
+
 // ---------------------------------------------------------------------------
 // Recall execution
 // ---------------------------------------------------------------------------

--- a/packages/gateway/test/anthropic-parallel-recall-abort.test.ts
+++ b/packages/gateway/test/anthropic-parallel-recall-abort.test.ts
@@ -16,9 +16,8 @@
  * sending `tool_choice.disable_parallel_tool_use` on Anthropic requests that
  * carry a recall tool (see anthropic-parallel-tool-use-guard.test.ts). This
  * test pins the residual behaviour, so the hard abort stays a deliberate choice
- * rather than an accident: if the guard is bypassed (non-conforming endpoint, a
- * client that sets its own `tool_choice`, a replayed/cached body), the turn is
- * still lost. Lifting that requires the follow-up — executing every recall call
+ * if the guard is bypassed (for example, an endpoint strips the field or a replayed
+ * body omits it), the turn is still lost. Lifting that requires the follow-up — executing every recall call
  * instead of rejecting the turn.
  */
 import { afterEach, describe, expect, test, vi } from "vitest";

--- a/packages/gateway/test/anthropic-parallel-recall-abort.test.ts
+++ b/packages/gateway/test/anthropic-parallel-recall-abort.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Reproduction: a Claude turn that emits TWO `recall` tool_use blocks aborts
+ * the whole relay.
+ *
+ * pipeline.ts's recall loop throws RecallContinuationFailure("parallel_recall")
+ * as soon as it sees more than one recall tool_use in a turn. Unlike the
+ * Responses path (which fails in-band with a `response.failed` event), the
+ * Anthropic path lets that error escape to the top-level catch, which calls
+ * controller.error() on the client stream.
+ *
+ * The client therefore sees a 200 SSE response that terminates mid-turn with
+ * zero text/tool content and no terminal event — which Claude Code renders as
+ * "Connection lost before a response was produced".
+ */
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("../src/recall", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/recall")>();
+  return { ...actual, executeRecall: vi.fn() };
+});
+
+import { loadConfig } from "../src/config";
+import {
+  buildStreamingResponse,
+  setUpstreamInterceptor,
+} from "../src/pipeline";
+import { executeRecall } from "../src/recall";
+import {
+  setRecallContinuationFailureHook,
+  type RecallContinuationFailureCategory,
+} from "../src/recall-continuation-failure";
+import type { GatewayRequest, SessionState } from "../src/translate/types";
+
+const mockedRecall = vi.mocked(executeRecall);
+
+function loadLocalConfig() {
+  const config = loadConfig();
+  config.remoteGateway = false;
+  config.hostedMode = false;
+  return config;
+}
+
+function event(type: string, data: Record<string, unknown>): string {
+  return `event: ${type}\ndata: ${JSON.stringify({ type, ...data })}\n\n`;
+}
+
+/** An assistant turn that calls `recall` twice in parallel, then stops. */
+function parallelRecallResponse(): Response {
+  const body =
+    event("message_start", {
+      message: {
+        id: "msg_parallel",
+        type: "message",
+        role: "assistant",
+        model: "claude-opus-5",
+        content: [],
+        stop_reason: null,
+        stop_sequence: null,
+        usage: { input_tokens: 1, output_tokens: 0 },
+      },
+    }) +
+    event("content_block_start", {
+      index: 0,
+      content_block: {
+        type: "tool_use",
+        id: "tool_recall_a",
+        name: "recall",
+        input: {},
+      },
+    }) +
+    event("content_block_delta", {
+      index: 0,
+      delta: { type: "input_json_delta", partial_json: '{"query":"alpha"}' },
+    }) +
+    event("content_block_stop", { index: 0 }) +
+    event("content_block_start", {
+      index: 1,
+      content_block: {
+        type: "tool_use",
+        id: "tool_recall_b",
+        name: "recall",
+        input: {},
+      },
+    }) +
+    event("content_block_delta", {
+      index: 1,
+      delta: { type: "input_json_delta", partial_json: '{"query":"beta"}' },
+    }) +
+    event("content_block_stop", { index: 1 }) +
+    event("message_delta", {
+      delta: { stop_reason: "tool_use", stop_sequence: null },
+      usage: { output_tokens: 1 },
+    }) +
+    event("message_stop", {});
+  return new Response(body, {
+    headers: { "content-type": "text/event-stream" },
+  });
+}
+
+function request(): GatewayRequest {
+  return {
+    protocol: "anthropic",
+    model: "claude-opus-5",
+    system: "test",
+    messages: [{ role: "user", content: [{ type: "text", text: "question" }] }],
+    tools: [{ name: "recall", description: "recall", inputSchema: {} }],
+    stream: true,
+    maxTokens: 32,
+    metadata: {},
+    rawHeaders: {
+      "x-api-key": "test-key",
+      "x-lore-provider": "anthropic",
+      "x-lore-upstream-url": "https://api.anthropic.com",
+    },
+  };
+}
+
+function sessionState(): SessionState {
+  return {
+    sessionID: `parallel-recall-${crypto.randomUUID()}`,
+    projectPath: "/tmp/parallel-recall",
+    fingerprint: "fingerprint",
+    lastRequestTime: Date.now(),
+    lastUserTurnTime: Date.now(),
+    messageCount: 1,
+    turnsSinceCuration: 0,
+    consecutiveTextOnlyTurns: 0,
+    upstreamByProvider: new Map(),
+    recallStore: new Map(),
+    cacheAnalytics: { lastRequestBody: null, turns: [] },
+  } as unknown as SessionState;
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  setUpstreamInterceptor(undefined);
+  setRecallContinuationFailureHook(undefined);
+  mockedRecall.mockReset();
+});
+
+describe("Anthropic parallel recall", () => {
+  test("two recall tool_use blocks abort the relay with no content delivered", async () => {
+    const failures: RecallContinuationFailureCategory[] = [];
+    setRecallContinuationFailureHook((category) => failures.push(category));
+
+    const req = request();
+    const downstream = buildStreamingResponse(
+      parallelRecallResponse(),
+      () => {},
+      {
+        clientMessages: req.messages,
+        modifiedReq: req,
+        config: loadLocalConfig(),
+        sessionState: sessionState(),
+        cacheOptions: { cacheConversation: false },
+        clientSpeaksAnthropic: true,
+      },
+    );
+
+    // The relay dies rather than degrading: this is the defect. The client sees
+    // a truncated stream, which Claude Code renders as a connection loss.
+    await expect(downstream.text()).rejects.toThrow("SSE stream read failed");
+    // The root cause is the parallel-recall guard, not a transport fault.
+    expect(failures).toEqual(["parallel_recall"]);
+    // Recall is never even executed — the turn is discarded before that.
+    expect(mockedRecall).not.toHaveBeenCalled();
+  });
+});

--- a/packages/gateway/test/anthropic-parallel-recall-abort.test.ts
+++ b/packages/gateway/test/anthropic-parallel-recall-abort.test.ts
@@ -11,6 +11,15 @@
  * The client therefore sees a 200 SSE response that terminates mid-turn with
  * zero text/tool content and no terminal event — which Claude Code renders as
  * "Connection lost before a response was produced".
+ *
+ * NOTE: the gateway now prevents the model from producing this shape at all by
+ * sending `tool_choice.disable_parallel_tool_use` on Anthropic requests that
+ * carry a recall tool (see anthropic-parallel-tool-use-guard.test.ts). This
+ * test pins the residual behaviour, so the hard abort stays a deliberate choice
+ * rather than an accident: if the guard is bypassed (non-conforming endpoint, a
+ * client that sets its own `tool_choice`, a replayed/cached body), the turn is
+ * still lost. Lifting that requires the follow-up — executing every recall call
+ * instead of rejecting the turn.
  */
 import { afterEach, describe, expect, test, vi } from "vitest";
 

--- a/packages/gateway/test/anthropic-parallel-tool-use-guard.test.ts
+++ b/packages/gateway/test/anthropic-parallel-tool-use-guard.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Anthropic parallel-tool-use guard.
+ *
+ * The recall loop aborts a turn as soon as a response carries more than one
+ * `recall` tool_use block (RecallContinuationFailure category
+ * `parallel_recall`). On the Anthropic wire that abort escapes to the relay's
+ * catch and errors the client stream, so the turn is lost with zero content
+ * instead of degrading — which Claude Code reports as
+ * "Connection lost before a response was produced".
+ *
+ * The openai-responses path already guards the same hazard with
+ * `parallel_tool_calls: false`. Anthropic's equivalent lives on `tool_choice`,
+ * so the gateway asks for at most one tool use per turn while the recall tool
+ * is in play. These tests pin the request body the gateway actually sends.
+ */
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "vitest";
+import { DEFAULT_MODEL, DEFAULT_SYSTEM } from "./helpers/fixtures";
+import type { Harness } from "./helpers/harness";
+import { createHarness } from "./helpers/harness";
+import { setUpstreamInterceptor } from "../src/pipeline";
+import { withParallelToolUseDisabled } from "../src/recall";
+
+const TOOL = {
+  name: "bash",
+  description: "run a command",
+  input_schema: { type: "object", properties: {} },
+};
+
+function makeBody(
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    model: DEFAULT_MODEL,
+    max_tokens: 1024,
+    stream: false,
+    system: DEFAULT_SYSTEM,
+    messages: [{ role: "user", content: "hello" }],
+    tools: [TOOL],
+    ...overrides,
+  };
+}
+
+interface Sink {
+  body?: Record<string, unknown>;
+}
+
+function captureInterceptor(sink: Sink) {
+  return async (requestBody: unknown): Promise<Response> => {
+    sink.body = requestBody as Record<string, unknown>;
+    return new Response(
+      JSON.stringify({
+        id: "msg_capture",
+        type: "message",
+        role: "assistant",
+        model: DEFAULT_MODEL,
+        content: [{ type: "text", text: "ok" }],
+        stop_reason: "end_turn",
+        usage: { input_tokens: 5, output_tokens: 2 },
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+  };
+}
+
+describe("withParallelToolUseDisabled", () => {
+  it("defaults to an auto tool_choice when the client set none", () => {
+    expect(withParallelToolUseDisabled(undefined)).toEqual({
+      type: "auto",
+      disable_parallel_tool_use: true,
+    });
+  });
+
+  it("preserves a client-specified choice and overrides the parallel flag", () => {
+    expect(
+      withParallelToolUseDisabled({
+        type: "auto",
+        disable_parallel_tool_use: false,
+      }),
+    ).toEqual({ type: "auto", disable_parallel_tool_use: true });
+  });
+
+  it("leaves an explicit `none` choice alone", () => {
+    // The flag is meaningless (and rejected by some proxies) under `none`.
+    expect(withParallelToolUseDisabled({ type: "none" })).toBeUndefined();
+  });
+
+  it("repairs a non-object or type-less choice rather than forwarding it", () => {
+    expect(withParallelToolUseDisabled("auto")).toEqual({
+      type: "auto",
+      disable_parallel_tool_use: true,
+    });
+    expect(withParallelToolUseDisabled({})).toEqual({
+      type: "auto",
+      disable_parallel_tool_use: true,
+    });
+  });
+});
+
+describe("Anthropic request carries the guard", () => {
+  // One harness for the whole describe: repeated harness creation in a single
+  // file leaves the later instances routing to the real upstream (401), so the
+  // capture interceptor must be installed against a stable server.
+  let harness: Harness;
+  let sink: Sink;
+
+  beforeAll(async () => {
+    harness = await createHarness({
+      fixtures: [],
+      projectPath: mkdtempSync(join(tmpdir(), "lore-parguard-")),
+    });
+  });
+
+  afterAll(async () => {
+    await harness?.teardown();
+    setUpstreamInterceptor(undefined);
+  });
+
+  beforeEach(() => {
+    sink = {};
+    setUpstreamInterceptor(captureInterceptor(sink));
+  });
+
+  afterEach(() => {
+    setUpstreamInterceptor(undefined);
+  });
+
+  /** Each test gets its own project so sessions never leak across cases. */
+  async function capture(body: Record<string, unknown>): Promise<Sink> {
+    const resp = await harness.chat(body, "test-key", {
+      "x-lore-project": mkdtempSync(join(tmpdir(), "lore-parguard-proj-")),
+    });
+    const text = await resp.text();
+    expect(resp.status, text).toBe(200);
+    return sink;
+  }
+
+  it("disables parallel tool use once the recall tool is injected", async () => {
+    const sink = await capture(makeBody());
+    // The recall tool rides along with the client's own tools.
+    const tools = sink.body?.tools as Array<{ name: string }>;
+    expect(tools.map((t) => t.name)).toContain("recall");
+    expect(sink.body?.tool_choice).toEqual({
+      type: "auto",
+      disable_parallel_tool_use: true,
+    });
+  });
+
+  it("does not inject the guard when there is no recall tool", async () => {
+    // With no client tools the gateway injects no recall tool, so there is
+    // nothing to guard and the request must stay untouched.
+    const sink = await capture(makeBody({ tools: [] }));
+    expect(sink.body?.tool_choice).toBeUndefined();
+  });
+
+  it("preserves a client tool_choice while adding the flag", async () => {
+    const sink = await capture(
+      makeBody({
+        tool_choice: { type: "any", disable_parallel_tool_use: false },
+      }),
+    );
+    expect(sink.body?.tool_choice).toEqual({
+      type: "any",
+      disable_parallel_tool_use: true,
+    });
+  });
+
+  it("leaves a client `none` tool_choice untouched", async () => {
+    const sink = await capture(makeBody({ tool_choice: { type: "none" } }));
+    expect(sink.body?.tool_choice).toEqual({ type: "none" });
+  });
+});


### PR DESCRIPTION
## Problem

A Claude turn whose response carries **more than one `recall` tool_use block** loses the whole turn.

`packages/gateway/src/pipeline.ts` rejects that shape outright:

```ts
if (currentResp.content.filter(
      (b) => b.type === "tool_use" && b.name === RECALL_TOOL_NAME,
    ).length > 1) {
  throw new RecallContinuationFailure("parallel_recall");
}
```

On the **Anthropic** wire that error escapes to the relay's top-level catch, which calls `controller.error()` on the client stream. The client sees a `200` SSE response that ends mid-turn with zero text/tool content and no terminal event. Claude Code renders that as:

```
API Error: Connection lost before a response was produced
```

The openai-responses path already guards this same hazard — `pipeline.ts` sets `parallel_tool_calls: false` whenever a recall tool is in play. Anthropic has no such field, so that path had no equivalent and the turn is lost rather than degraded.

Production signature (Anthropic protocol, `claude-opus-5`), aborting in **3–7 s**:

```
[ERROR] streaming pipeline error: recall continuation failed
[ERROR] request handler error: SSE stream read failed
```

The second line is the downstream consequence. Of the five `RecallContinuationFailure` sites reachable on the Anthropic path, `parallel_recall` is the only one that emits no other log line — the rest are preceded by a false `recall follow-up fetch failed` / `upstream error` / `stream complete` message.

## Fix

Anthropic's equivalent of `parallel_tool_calls: false` is `tool_choice.disable_parallel_tool_use`, which caps a turn at one tool use ([API reference](https://docs.claude.com/en/api/messages)).

- `recall.ts`: add `withParallelToolUseDisabled()` — preserves any client-specified `tool_choice`, and returns `undefined` for an explicit `none`, where the flag is meaningless and some Anthropic-compatible proxies reject it.
- `pipeline.ts`: apply it when the protocol is `anthropic` and the request carries a recall tool.

## Trade-off

This caps the **whole turn** at one tool use, so a coding agent's own parallel tool calls serialize while the recall tool is in play. That cost is already accepted on the responses path, and it is bounded by the alternative — losing the turn outright.

The constraint can be lifted properly by executing every recall call and answering each (the marker-replacement machinery already takes a map of block id → marker), rather than rejecting the turn. That is a larger change and a good follow-up.

## Tests

- `anthropic-parallel-tool-use-guard.test.ts` — asserts the outgoing Anthropic body carries `tool_choice.disable_parallel_tool_use: true` once the recall tool is present; that a request with no recall tool is left untouched; and that a client's `tool_choice` is preserved (including `none`).
- `anthropic-parallel-recall-abort.test.ts` — pins the residual behaviour: a response with two recall blocks still aborts. This documents *why* the guard exists and keeps the hard abort a deliberate choice — if the guard is bypassed (non-conforming endpoint, replayed body), the turn is still lost.

`pnpm run typecheck`, `oxlint`, `oxfmt` pass. Related suites pass: `anthropic-caching`, `cch`, `context-capability-note`, `claude-usage-headers`.
