### PR TITLE
fix(gateway): make foreground SSE inactivity + request deadlines configurable

### DIFF
--- a/packages/gateway/src/llm-adapter.ts
+++ b/packages/gateway/src/llm-adapter.ts
@@ -69,7 +69,10 @@ import {
   SSEStreamLimitError,
   SSEStreamTransportError,
 } from "./stream/anthropic";
-import { WORKER_RESPONSE_INACTIVITY_MS } from "./sse-inactivity";
+import {
+  WORKER_REQUEST_TIMEOUT_MS,
+  WORKER_RESPONSE_INACTIVITY_MS,
+} from "./sse-inactivity";
 import { isBedrockMantleHost, toMantleModelId } from "./translate/bedrock";
 import {
   ANTHROPIC_CONTENT_BLOCK_TYPES,
@@ -573,7 +576,6 @@ const MAX_WORKER_REQUEST_BYTES = 4 * 1024 * 1024;
 // `\u00xx` escape. Cap raw prompt bytes at the derived worst-case ratio so the
 // serializer itself cannot transiently allocate far beyond the wire cap.
 const MAX_WORKER_PROMPT_SOURCE_BYTES = Math.floor(MAX_WORKER_REQUEST_BYTES / 6);
-const WORKER_REQUEST_TIMEOUT_MS = 300_000;
 
 /** Retain endpoint routing while stripping userinfo, query, and fragment. */
 function sanitizedWorkerOrigin(rawUrl: string): string {

--- a/packages/gateway/src/llm-adapter.ts
+++ b/packages/gateway/src/llm-adapter.ts
@@ -69,6 +69,7 @@ import {
   SSEStreamLimitError,
   SSEStreamTransportError,
 } from "./stream/anthropic";
+import { WORKER_RESPONSE_INACTIVITY_MS } from "./sse-inactivity";
 import { isBedrockMantleHost, toMantleModelId } from "./translate/bedrock";
 import {
   ANTHROPIC_CONTENT_BLOCK_TYPES,
@@ -572,7 +573,6 @@ const MAX_WORKER_REQUEST_BYTES = 4 * 1024 * 1024;
 // `\u00xx` escape. Cap raw prompt bytes at the derived worst-case ratio so the
 // serializer itself cannot transiently allocate far beyond the wire cap.
 const MAX_WORKER_PROMPT_SOURCE_BYTES = Math.floor(MAX_WORKER_REQUEST_BYTES / 6);
-const WORKER_RESPONSE_INACTIVITY_MS = 120_000;
 const WORKER_REQUEST_TIMEOUT_MS = 300_000;
 
 /** Retain endpoint routing while stripping userinfo, query, and fragment. */

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -252,6 +252,10 @@ import {
   type RecallAwareAccumulator,
 } from "./stream/anthropic";
 import {
+  FOREGROUND_REQUEST_TIMEOUT_MS,
+  FOREGROUND_SSE_INACTIVITY_MS,
+} from "./sse-inactivity";
+import {
   gatewayMessagesToLore,
   deterministicID,
   legacyDeterministicID,
@@ -11293,7 +11297,6 @@ export function streamResponsesRecallAware(
  */
 const MAX_FOREGROUND_RESPONSE_BYTES = 4 * 1024 * 1024;
 const MAX_FOREGROUND_ERROR_BYTES = 64 * 1024;
-const FOREGROUND_SSE_INACTIVITY_MS = 120_000;
 const FOREGROUND_ERROR_BODY_TIMEOUT_MS = 10_000;
 const MAX_RELAY_RETRY_AFTER_MS = 300_000;
 let foregroundErrorBodyTimeoutMs = FOREGROUND_ERROR_BODY_TIMEOUT_MS;
@@ -14440,8 +14443,6 @@ export async function passthroughResponsesCompact(
 // ---------------------------------------------------------------------------
 // Case 2: Meta request passthrough (title gen, summaries, categorization, etc.)
 // ---------------------------------------------------------------------------
-
-const FOREGROUND_REQUEST_TIMEOUT_MS = 300_000;
 
 export function abortAwareDelay(
   delayMs: number,

--- a/packages/gateway/src/sse-inactivity.ts
+++ b/packages/gateway/src/sse-inactivity.ts
@@ -1,0 +1,103 @@
+/**
+ * Foreground relay deadline configuration.
+ *
+ * Centralizes the three timers that bound a foreground request so their
+ * ordering is explicit and tunable from one place:
+ *
+ *   1. upstream SSE inactivity  (tightest — per-stream transport fault)
+ *   2. foreground request abort (coarser — whole-request ceiling)
+ *   3. client keepalive ping    (client-side liveness only, see pipeline.ts)
+ *
+ * Previously (1) and (2) were independent hardcoded constants (120s and 300s)
+ * with no declared relationship. That made any attempt to raise (1) a silent
+ * no-op above 300s: the coarser timer fired first and surfaced as a
+ * whole-request timeout.
+ */
+
+/** Node accepts delays up to 2^31-1 ms; beyond that setTimeout overflows. */
+const MAX_DEADLINE_MS = 2_147_483_647;
+/** A floor keeps an accidental `=1` from turning a deadline into a hard abort. */
+const MIN_DEADLINE_MS = 1_000;
+
+/**
+ * Parse a Node-safe deadline in milliseconds.
+ *
+ * Invalid input (non-integer, non-positive, or beyond the 32-bit timer
+ * ceiling) falls back to the supplied default rather than arming a bogus
+ * timer. Mirrors `parseShutdownDeadline`'s contract so the timeout seams in
+ * the gateway behave identically.
+ */
+export function parseSseInactivityMs(
+  raw: string | undefined,
+  fallback: number,
+): number {
+  if (!raw) return fallback;
+  const value = Number(raw);
+  if (!Number.isSafeInteger(value) || value <= 0 || value > MAX_DEADLINE_MS) {
+    return fallback;
+  }
+  return Math.max(value, MIN_DEADLINE_MS);
+}
+
+/**
+ * Default upstream-side SSE inactivity deadline for foreground relays.
+ *
+ * Bounds how long the gateway tolerates silence from the upstream provider
+ * before aborting the relay. The former value of 120s was too aggressive for
+ * models whose extended-thinking phases legitimately emit nothing for minutes
+ * (Opus-class reasoning over large cached prompts): the gateway killed the
+ * stream mid-thinking, the client saw a truncated 200 with zero content and
+ * reported a transport loss, while its own watchdogs (180s/300s) never fired.
+ *
+ * 600s sits above every client watchdog the gateway serves, so the client
+ * remains the authority on a stalled stream and the gateway intervenes only on
+ * a genuinely dead connection.
+ */
+export const DEFAULT_FOREGROUND_SSE_INACTIVITY_MS = 600_000;
+
+/**
+ * Default wall-clock ceiling for a single foreground request.
+ *
+ * A hard abort of the whole relay (recall deadline + abort scope), so it must
+ * stay above {@link DEFAULT_FOREGROUND_SSE_INACTIVITY_MS}.
+ */
+export const DEFAULT_FOREGROUND_REQUEST_TIMEOUT_MS = 900_000;
+
+/** Slack so the finer inactivity fault surfaces before the coarser abort. */
+const FOREGROUND_TIMEOUT_HEADROOM_MS = 60_000;
+
+/**
+ * Foreground relay inactivity deadline: env-overridable, defaults to 600s.
+ * Read once at module load; restart the gateway to apply a change.
+ */
+export const FOREGROUND_SSE_INACTIVITY_MS: number = parseSseInactivityMs(
+  process.env.LORE_FOREGROUND_SSE_INACTIVITY_MS,
+  DEFAULT_FOREGROUND_SSE_INACTIVITY_MS,
+);
+
+/**
+ * Foreground request timeout: env-overridable, defaults to 900s.
+ *
+ * Clamped to `max(configured, inactivity + headroom)` so raising the
+ * inactivity deadline cannot leave a tighter request ceiling silently in
+ * force — the trap that made a 120s->600s change a no-op above 300s.
+ */
+export const FOREGROUND_REQUEST_TIMEOUT_MS: number = Math.max(
+  parseSseInactivityMs(
+    process.env.LORE_FOREGROUND_REQUEST_TIMEOUT_MS,
+    DEFAULT_FOREGROUND_REQUEST_TIMEOUT_MS,
+  ),
+  FOREGROUND_SSE_INACTIVITY_MS + FOREGROUND_TIMEOUT_HEADROOM_MS,
+);
+
+/**
+ * Worker (background/auxiliary call) response deadline. Same defect class as
+ * the foreground relay: a self-hosted reasoning model can spend longer than
+ * 120s in hidden reasoning without emitting a byte. Separate from the
+ * foreground pair because worker calls are not user-visible and need not match
+ * the client's watchdog budget.
+ */
+export const WORKER_RESPONSE_INACTIVITY_MS: number = parseSseInactivityMs(
+  process.env.LORE_WORKER_RESPONSE_INACTIVITY_MS,
+  DEFAULT_FOREGROUND_SSE_INACTIVITY_MS,
+);

--- a/packages/gateway/src/sse-inactivity.ts
+++ b/packages/gateway/src/sse-inactivity.ts
@@ -103,19 +103,39 @@ export const FOREGROUND_REQUEST_TIMEOUT_MS: number = Math.max(
   FOREGROUND_SSE_INACTIVITY_MS + FOREGROUND_TIMEOUT_HEADROOM_MS,
 );
 
+/** Slack so the finer worker inactivity fault surfaces before the coarser abort. */
+const WORKER_TIMEOUT_HEADROOM_MS = 60_000;
+
 /**
- * Worker (background/auxiliary call) response deadline. Same defect class as
- * the foreground relay: a self-hosted reasoning model can spend longer than
- * 120s in hidden reasoning without emitting a byte. Separate from the
- * foreground pair because worker calls are not user-visible and need not match
- * the client's watchdog budget.
+ * Worker (background/auxiliary call) response inactivity deadline. Same defect
+ * class as the foreground relay: a self-hosted reasoning model can spend
+ * longer than 120s in hidden reasoning without emitting a byte. Separate from
+ * the foreground pair because worker calls are not user-visible and need not
+ * match the client's watchdog budget.
  */
 export const WORKER_RESPONSE_INACTIVITY_MS: number = parseSseInactivityMs(
   // How long a background/auxiliary worker call tolerates upstream silence
-  // before aborting. Separate from the foreground pair because worker calls are
-  // not user-visible and need not match the client's watchdog budget. Positive
-  // integer ms; invalid values fall back to 600000. Env:
-  // LORE_WORKER_RESPONSE_INACTIVITY_MS.
+  // before aborting. Positive integer ms; invalid values fall back to 600000.
+  // Env: LORE_WORKER_RESPONSE_INACTIVITY_MS.
   process.env.LORE_WORKER_RESPONSE_INACTIVITY_MS,
   DEFAULT_FOREGROUND_SSE_INACTIVITY_MS,
+);
+
+/**
+ * Worker request deadline: env-overridable, defaults to 900s.
+ *
+ * Clamped above {@link WORKER_RESPONSE_INACTIVITY_MS} for the same reason as
+ * the foreground pair: a request deadline below the inactivity deadline makes
+ * the inactivity retry path unreachable, so tuning inactivity appears inert.
+ */
+export const WORKER_REQUEST_TIMEOUT_MS: number = Math.max(
+  parseSseInactivityMs(
+    // Wall-clock ceiling for a single background/auxiliary worker call.
+    // Automatically raised to stay at least 60s above
+    // LORE_WORKER_RESPONSE_INACTIVITY_MS. Positive integer ms; invalid values
+    // fall back to 900000. Env: LORE_WORKER_REQUEST_TIMEOUT_MS.
+    process.env.LORE_WORKER_REQUEST_TIMEOUT_MS,
+    DEFAULT_FOREGROUND_REQUEST_TIMEOUT_MS,
+  ),
+  WORKER_RESPONSE_INACTIVITY_MS + WORKER_TIMEOUT_HEADROOM_MS,
 );

--- a/packages/gateway/src/sse-inactivity.ts
+++ b/packages/gateway/src/sse-inactivity.ts
@@ -71,6 +71,13 @@ const FOREGROUND_TIMEOUT_HEADROOM_MS = 60_000;
  * Read once at module load; restart the gateway to apply a change.
  */
 export const FOREGROUND_SSE_INACTIVITY_MS: number = parseSseInactivityMs(
+  // How long the gateway tolerates upstream silence on a foreground relay
+  // before aborting it. Raise this for models whose extended-thinking phases
+  // emit nothing for minutes (Opus-class reasoning over large cached prompts),
+  // since a too-low value kills the stream mid-thinking and the client reports
+  // a connection loss rather than a stall. Positive integer ms; invalid values
+  // fall back to 600000. Floored at 1000 and clamped to the 32-bit timer
+  // ceiling. Env: LORE_FOREGROUND_SSE_INACTIVITY_MS.
   process.env.LORE_FOREGROUND_SSE_INACTIVITY_MS,
   DEFAULT_FOREGROUND_SSE_INACTIVITY_MS,
 );
@@ -84,6 +91,12 @@ export const FOREGROUND_SSE_INACTIVITY_MS: number = parseSseInactivityMs(
  */
 export const FOREGROUND_REQUEST_TIMEOUT_MS: number = Math.max(
   parseSseInactivityMs(
+    // Wall-clock ceiling for a single foreground request: the hard abort of
+    // the whole relay (recall deadline + abort scope). Automatically raised to
+    // stay at least 60s above LORE_FOREGROUND_SSE_INACTIVITY_MS, so a request
+    // timeout can never make the inactivity deadline unreachable. Positive
+    // integer ms; invalid values fall back to 900000. Env:
+    // LORE_FOREGROUND_REQUEST_TIMEOUT_MS.
     process.env.LORE_FOREGROUND_REQUEST_TIMEOUT_MS,
     DEFAULT_FOREGROUND_REQUEST_TIMEOUT_MS,
   ),
@@ -98,6 +111,11 @@ export const FOREGROUND_REQUEST_TIMEOUT_MS: number = Math.max(
  * the client's watchdog budget.
  */
 export const WORKER_RESPONSE_INACTIVITY_MS: number = parseSseInactivityMs(
+  // How long a background/auxiliary worker call tolerates upstream silence
+  // before aborting. Separate from the foreground pair because worker calls are
+  // not user-visible and need not match the client's watchdog budget. Positive
+  // integer ms; invalid values fall back to 600000. Env:
+  // LORE_WORKER_RESPONSE_INACTIVITY_MS.
   process.env.LORE_WORKER_RESPONSE_INACTIVITY_MS,
   DEFAULT_FOREGROUND_SSE_INACTIVITY_MS,
 );

--- a/packages/gateway/test/anthropic-recall-continuation-abort.test.ts
+++ b/packages/gateway/test/anthropic-recall-continuation-abort.test.ts
@@ -11,6 +11,7 @@ import {
   setUpstreamInterceptor,
 } from "../src/pipeline";
 import { executeRecall } from "../src/recall";
+import { FOREGROUND_REQUEST_TIMEOUT_MS } from "../src/sse-inactivity";
 import type { GatewayRequest, SessionState } from "../src/translate/types";
 
 const mockedRecall = vi.mocked(executeRecall);
@@ -215,7 +216,7 @@ describe("Anthropic recall continuation abort", () => {
           () => null,
           (error: unknown) => error,
         );
-        await vi.advanceTimersByTimeAsync(300_000);
+        await vi.advanceTimersByTimeAsync(FOREGROUND_REQUEST_TIMEOUT_MS);
         await expect(outcome).resolves.toMatchObject({ name: "TimeoutError" });
       }
       expect(follows).toBe(round);

--- a/packages/gateway/test/bedrock-runtime.test.ts
+++ b/packages/gateway/test/bedrock-runtime.test.ts
@@ -19,6 +19,7 @@ import {
 } from "../src/translate/bedrock-runtime";
 import { setUpstreamDispatcherForTest } from "../src/fetch";
 import { resetPipelineState } from "../src/pipeline";
+import { FOREGROUND_REQUEST_TIMEOUT_MS } from "../src/sse-inactivity";
 import { startServer } from "../src/server";
 import { loadConfig } from "../src/config";
 import { close as closeDB } from "@loreai/core";
@@ -293,7 +294,7 @@ describe("proxyBedrockRuntimeRequest — handler logic", () => {
       if (mode === "caller") {
         caller.abort(new DOMException("client disconnected", "AbortError"));
       } else {
-        await vi.advanceTimersByTimeAsync(300_000);
+        await vi.advanceTimersByTimeAsync(FOREGROUND_REQUEST_TIMEOUT_MS);
       }
       await rejected;
       rejectPull(new Error("late upload rejection"));
@@ -335,7 +336,7 @@ describe("proxyBedrockRuntimeRequest — handler logic", () => {
       if (mode === "caller") {
         caller.abort(new DOMException("client disconnected", "AbortError"));
       } else {
-        await vi.advanceTimersByTimeAsync(300_000);
+        await vi.advanceTimersByTimeAsync(FOREGROUND_REQUEST_TIMEOUT_MS);
       }
       await rejected;
       expect(upstreamSignal?.aborted).toBe(true);
@@ -388,7 +389,7 @@ describe("proxyBedrockRuntimeRequest — handler logic", () => {
       if (mode === "caller") {
         caller.abort(new DOMException("client disconnected", "AbortError"));
       } else {
-        await vi.advanceTimersByTimeAsync(300_000);
+        await vi.advanceTimersByTimeAsync(FOREGROUND_REQUEST_TIMEOUT_MS);
       }
       await rejected;
       expect(cancelled).toBe(true);
@@ -420,7 +421,7 @@ describe("proxyBedrockRuntimeRequest — handler logic", () => {
       expect(response.status).toBe(201);
       expect(response.headers.get("x-bedrock")).toBe("complete");
       await expect(response.text()).resolves.toBe("complete");
-      await vi.advanceTimersByTimeAsync(300_000);
+      await vi.advanceTimersByTimeAsync(FOREGROUND_REQUEST_TIMEOUT_MS);
       expect(upstreamSignal?.aborted).toBe(false);
       expect(remove).toHaveBeenCalledWith("abort", expect.any(Function));
     } finally {
@@ -457,7 +458,7 @@ describe("proxyBedrockRuntimeRequest — handler logic", () => {
       await expect(response.body?.cancel()).resolves.toBeUndefined();
       expect(cancelled).toBe(true);
       expect(upstream.body?.locked).toBe(false);
-      await vi.advanceTimersByTimeAsync(300_000);
+      await vi.advanceTimersByTimeAsync(FOREGROUND_REQUEST_TIMEOUT_MS);
       expect(upstreamSignal?.aborted).toBe(false);
     } finally {
       vi.useRealTimers();

--- a/packages/gateway/test/foreground-routes-abort.test.ts
+++ b/packages/gateway/test/foreground-routes-abort.test.ts
@@ -9,6 +9,7 @@ import {
   resetPipelineState,
   setUpstreamInterceptor,
 } from "../src/pipeline";
+import { FOREGROUND_REQUEST_TIMEOUT_MS } from "../src/sse-inactivity";
 import type { GatewayRequest } from "../src/translate/types";
 import { handleModelsPassthrough, startServer } from "../src/server";
 import { upstreamFetch } from "../src/fetch";
@@ -144,7 +145,7 @@ describe("foreground passthrough route aborts", () => {
           : handleResponsesCompactEndpoint(request, config);
 
       await Promise.resolve();
-      await vi.advanceTimersByTimeAsync(300_000);
+      await vi.advanceTimersByTimeAsync(FOREGROUND_REQUEST_TIMEOUT_MS);
       const response = await pending;
       expect(response.status).toBe(502);
       expect(await response.text()).not.toContain("timed out");
@@ -386,7 +387,7 @@ describe("foreground passthrough route aborts", () => {
       );
       const pending = invoke();
       await Promise.resolve();
-      await vi.advanceTimersByTimeAsync(300_000);
+      await vi.advanceTimersByTimeAsync(FOREGROUND_REQUEST_TIMEOUT_MS);
       const response = await pending;
       expect(response.status).toBe(502);
       expect(

--- a/packages/gateway/test/llm-adapter.test.ts
+++ b/packages/gateway/test/llm-adapter.test.ts
@@ -52,6 +52,10 @@ import {
   _resetTemperatureUnsupportedModels,
   _resetThinkingUnsupportedModels,
 } from "../src/llm-adapter";
+import {
+  WORKER_REQUEST_TIMEOUT_MS,
+  WORKER_RESPONSE_INACTIVITY_MS,
+} from "../src/sse-inactivity";
 import { _setModelDataForTest, clearModelDataCache } from "../src/worker-model";
 import { workerModelCandidates } from "../src/worker-model";
 import {
@@ -6240,7 +6244,7 @@ describe("worker transport lifecycle remediation", () => {
       sessionID: "sess-inactivity-retry",
       workerID: "lore-distill",
     });
-    await vi.advanceTimersByTimeAsync(120_500);
+    await vi.advanceTimersByTimeAsync(WORKER_RESPONSE_INACTIVITY_MS + 500);
 
     await expect(pending).resolves.toBe("recovered");
     expect(cancelled).toBe(true);

--- a/packages/gateway/test/llm-adapter.test.ts
+++ b/packages/gateway/test/llm-adapter.test.ts
@@ -6533,9 +6533,13 @@ describe("worker transport lifecycle remediation", () => {
     expect(mockFetch).toHaveBeenCalledTimes(2);
   });
 
-  test("one 300-second deadline covers fetch, retry delay, and every attempt", async () => {
+  test("one overall deadline covers fetch, retry delay, and every attempt", async () => {
     vi.useFakeTimers();
     let cancelled = false;
+    // Each attempt consumes almost the entire deadline, so only the first one
+    // can ever start: if the deadline were per-attempt rather than overall,
+    // the retry would launch and mockFetch would be called twice.
+    const attemptDurationMs = WORKER_REQUEST_TIMEOUT_MS - 1_000;
     mockFetch.mockImplementation(
       async () =>
         new Promise<Response>((resolve) => {
@@ -6551,7 +6555,7 @@ describe("worker transport lifecycle remediation", () => {
                   { status: 500, headers: { "retry-after": "32" } },
                 ),
               ),
-            299_000,
+            attemptDurationMs,
           );
         }),
     );
@@ -6563,7 +6567,7 @@ describe("worker transport lifecycle remediation", () => {
     const rejected = expect(pending).rejects.toMatchObject({
       name: "TimeoutError",
     });
-    await vi.advanceTimersByTimeAsync(299_000);
+    await vi.advanceTimersByTimeAsync(attemptDurationMs);
     expect(mockFetch).toHaveBeenCalledTimes(1);
     expect(cancelled).toBe(true);
     await vi.advanceTimersByTimeAsync(1_000);

--- a/packages/gateway/test/llm-adapter.test.ts
+++ b/packages/gateway/test/llm-adapter.test.ts
@@ -2556,7 +2556,7 @@ describe("createGatewayLLMClient.prompt", () => {
       const rejected = expect(pending).rejects.toMatchObject({
         name: "TimeoutError",
       });
-      await vi.advanceTimersByTimeAsync(300_000);
+      await vi.advanceTimersByTimeAsync(WORKER_REQUEST_TIMEOUT_MS);
       await rejected;
       expect(mockFetch).not.toHaveBeenCalled();
     } finally {
@@ -2631,7 +2631,7 @@ describe("createGatewayLLMClient.prompt", () => {
       const rejected = expect(pending).rejects.toMatchObject({
         name: "TimeoutError",
       });
-      await vi.advanceTimersByTimeAsync(300_000);
+      await vi.advanceTimersByTimeAsync(WORKER_REQUEST_TIMEOUT_MS);
       await rejected;
       expect(tokenCalls).toBe(2);
     } finally {
@@ -6582,7 +6582,7 @@ describe("worker transport lifecycle remediation", () => {
     const rejected = expect(pending).rejects.toMatchObject({
       name: "TimeoutError",
     });
-    await vi.advanceTimersByTimeAsync(300_000);
+    await vi.advanceTimersByTimeAsync(WORKER_REQUEST_TIMEOUT_MS);
     await rejected;
     expect(mockFetch).toHaveBeenCalledTimes(1);
   });

--- a/packages/gateway/test/pipeline-streaming.test.ts
+++ b/packages/gateway/test/pipeline-streaming.test.ts
@@ -72,6 +72,7 @@ import {
   streamingPostResponsePendingForTest,
   validatedMetaStream,
 } from "../src/pipeline";
+import { FOREGROUND_SSE_INACTIVITY_MS } from "../src/sse-inactivity";
 import { loadConfig as loadBaseConfig } from "../src/config";
 import { authFingerprint } from "../src/auth";
 import { getDegradationWarning } from "../src/worker-health";
@@ -822,7 +823,7 @@ describe("Pipeline — streaming responses", () => {
     try {
       const downstream = buildStreamingResponse(upstream, () => {});
       await Promise.resolve();
-      await vi.advanceTimersByTimeAsync(120_000);
+      await vi.advanceTimersByTimeAsync(FOREGROUND_SSE_INACTIVITY_MS);
       await expect(downstream.text()).rejects.toThrow(
         "SSE stream inactivity deadline exceeded",
       );

--- a/packages/gateway/test/pipeline-streaming.test.ts
+++ b/packages/gateway/test/pipeline-streaming.test.ts
@@ -72,7 +72,10 @@ import {
   streamingPostResponsePendingForTest,
   validatedMetaStream,
 } from "../src/pipeline";
-import { FOREGROUND_SSE_INACTIVITY_MS } from "../src/sse-inactivity";
+import {
+  FOREGROUND_REQUEST_TIMEOUT_MS,
+  FOREGROUND_SSE_INACTIVITY_MS,
+} from "../src/sse-inactivity";
 import { loadConfig as loadBaseConfig } from "../src/config";
 import { authFingerprint } from "../src/auth";
 import { getDegradationWarning } from "../src/worker-health";
@@ -587,7 +590,7 @@ describe("budget throttle cancellation", () => {
     const rejected = expect(pending).rejects.toMatchObject({
       name: "TimeoutError",
     });
-    await vi.advanceTimersByTimeAsync(300_000);
+    await vi.advanceTimersByTimeAsync(FOREGROUND_REQUEST_TIMEOUT_MS);
     await rejected;
     expect(recorded).toBe(0);
     expect(upstreamStarted).toBe(false);
@@ -6400,7 +6403,7 @@ describe("Pipeline — streaming responses", () => {
         },
         loadLocalConfig(),
       );
-      await vi.advanceTimersByTimeAsync(300_000);
+      await vi.advanceTimersByTimeAsync(FOREGROUND_REQUEST_TIMEOUT_MS);
       const response = await pending;
       expect(response.status).toBe(502);
       await expect(response.text()).resolves.toContain(
@@ -6505,7 +6508,7 @@ describe("Pipeline — streaming responses", () => {
           loadLocalConfig(),
         );
         await Promise.resolve();
-        await vi.advanceTimersByTimeAsync(300_000);
+        await vi.advanceTimersByTimeAsync(FOREGROUND_REQUEST_TIMEOUT_MS);
         await expect(downstream.text()).rejects.toMatchObject({
           name: "TimeoutError",
         });

--- a/packages/gateway/test/pipeline-streaming.test.ts
+++ b/packages/gateway/test/pipeline-streaming.test.ts
@@ -579,9 +579,11 @@ describe("budget throttle cancellation", () => {
     const foreground = createForegroundAbortScope();
     let recorded = 0;
     let upstreamStarted = false;
+    // Throttle past the foreground deadline so the deadline must win the race.
+    const throttleDelayMs = FOREGROUND_REQUEST_TIMEOUT_MS + 60_000;
     const pending = (async () => {
       await completeBudgetThrottleDelay(
-        600_000,
+        throttleDelayMs,
         foreground.signal,
         () => recorded++,
       );

--- a/packages/gateway/test/server-node-bridge.test.ts
+++ b/packages/gateway/test/server-node-bridge.test.ts
@@ -10,6 +10,7 @@ import {
   setPostResponseStartObserverForTest,
   setUpstreamInterceptor,
 } from "../src/pipeline";
+import { FOREGROUND_REQUEST_TIMEOUT_MS } from "../src/sse-inactivity";
 import { loadConfig } from "../src/config";
 
 class FakeRequest extends EventEmitter {
@@ -488,7 +489,7 @@ test("the application foreground deadline starts before request body decoding", 
       name: "TimeoutError",
     });
     await pulling;
-    await vi.advanceTimersByTimeAsync(300_000);
+    await vi.advanceTimersByTimeAsync(FOREGROUND_REQUEST_TIMEOUT_MS);
     await rejected;
     expect(cancelled).toBe(true);
     expect(source.locked).toBe(false);

--- a/packages/gateway/test/sse-inactivity.test.ts
+++ b/packages/gateway/test/sse-inactivity.test.ts
@@ -14,6 +14,7 @@ import {
   FOREGROUND_SSE_INACTIVITY_MS,
   FOREGROUND_REQUEST_TIMEOUT_MS,
   WORKER_RESPONSE_INACTIVITY_MS,
+  WORKER_REQUEST_TIMEOUT_MS,
 } from "../src/sse-inactivity";
 
 describe("parseSseInactivityMs", () => {
@@ -77,6 +78,9 @@ describe("inactivity deadline defaults", () => {
     );
     expect(DEFAULT_FOREGROUND_REQUEST_TIMEOUT_MS).toBeGreaterThan(
       DEFAULT_FOREGROUND_SSE_INACTIVITY_MS,
+    );
+    expect(WORKER_REQUEST_TIMEOUT_MS).toBeGreaterThan(
+      WORKER_RESPONSE_INACTIVITY_MS,
     );
   });
 });

--- a/packages/gateway/test/sse-inactivity.test.ts
+++ b/packages/gateway/test/sse-inactivity.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Coverage for the env-configurable SSE inactivity deadlines.
+ *
+ * Regression guard for the defect where a hardcoded 120s upstream-side
+ * deadline aborted foreground relays during long legitimate upstream silence
+ * (extended thinking), surfacing to the client as a mid-stream transport loss
+ * with zero content.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  parseSseInactivityMs,
+  DEFAULT_FOREGROUND_SSE_INACTIVITY_MS,
+  DEFAULT_FOREGROUND_REQUEST_TIMEOUT_MS,
+  FOREGROUND_SSE_INACTIVITY_MS,
+  FOREGROUND_REQUEST_TIMEOUT_MS,
+  WORKER_RESPONSE_INACTIVITY_MS,
+} from "../src/sse-inactivity";
+
+describe("parseSseInactivityMs", () => {
+  it("returns the fallback when unset or empty", () => {
+    expect(parseSseInactivityMs(undefined, 600_000)).toBe(600_000);
+    expect(parseSseInactivityMs("", 600_000)).toBe(600_000);
+  });
+
+  it("parses a positive integer", () => {
+    expect(parseSseInactivityMs("900000", 600_000)).toBe(900_000);
+  });
+
+  it("rejects invalid values by falling back to the default", () => {
+    for (const raw of ["abc", "0", "-1", "1.5", "NaN", "Infinity"]) {
+      expect(parseSseInactivityMs(raw, 600_000)).toBe(600_000);
+    }
+  });
+
+  it("rejects values beyond the 32-bit timer ceiling", () => {
+    expect(parseSseInactivityMs("99999999999", 600_000)).toBe(600_000);
+  });
+
+  it("floors an over-aggressive override so the deadline stays meaningful", () => {
+    // `=1` must not turn the deadline into an immediate abort.
+    expect(parseSseInactivityMs("1", 600_000)).toBe(1_000);
+  });
+});
+
+describe("inactivity deadline defaults", () => {
+  it("defaults the foreground deadline above every client watchdog", () => {
+    // Claude Code's own watchdogs fire at 180s/300s; the gateway must not
+    // preempt them, or the client reports a transport loss instead of a stall.
+    expect(DEFAULT_FOREGROUND_SSE_INACTIVITY_MS).toBeGreaterThanOrEqual(
+      600_000,
+    );
+  });
+
+  it("resolves the live constants from the defaults when no env override is set", () => {
+    if (process.env.LORE_FOREGROUND_SSE_INACTIVITY_MS === undefined) {
+      expect(FOREGROUND_SSE_INACTIVITY_MS).toBe(
+        DEFAULT_FOREGROUND_SSE_INACTIVITY_MS,
+      );
+    }
+    if (process.env.LORE_WORKER_RESPONSE_INACTIVITY_MS === undefined) {
+      expect(WORKER_RESPONSE_INACTIVITY_MS).toBe(
+        DEFAULT_FOREGROUND_SSE_INACTIVITY_MS,
+      );
+    }
+    if (process.env.LORE_FOREGROUND_REQUEST_TIMEOUT_MS === undefined) {
+      expect(FOREGROUND_REQUEST_TIMEOUT_MS).toBe(
+        DEFAULT_FOREGROUND_REQUEST_TIMEOUT_MS,
+      );
+    }
+  });
+
+  it("keeps the request ceiling above the inactivity deadline", () => {
+    // Regression: a request ceiling below the inactivity deadline makes the
+    // inactivity deadline unreachable, so raising it appears to do nothing.
+    expect(FOREGROUND_REQUEST_TIMEOUT_MS).toBeGreaterThan(
+      FOREGROUND_SSE_INACTIVITY_MS,
+    );
+    expect(DEFAULT_FOREGROUND_REQUEST_TIMEOUT_MS).toBeGreaterThan(
+      DEFAULT_FOREGROUND_SSE_INACTIVITY_MS,
+    );
+  });
+});

--- a/packages/gateway/test/vertex.test.ts
+++ b/packages/gateway/test/vertex.test.ts
@@ -29,6 +29,7 @@ import {
   resolveVertexProject,
 } from "../src/vertex-auth";
 import { createForegroundAbortScope } from "../src/pipeline";
+import { FOREGROUND_REQUEST_TIMEOUT_MS } from "../src/sse-inactivity";
 
 describe("toVertexModelId", () => {
   test("passes through short ids that Vertex uses verbatim", () => {
@@ -514,7 +515,7 @@ describe("vertex-auth — ADC token seam", () => {
       const rejected = expect(pending).rejects.toMatchObject({
         name: "TimeoutError",
       });
-      await vi.advanceTimersByTimeAsync(300_000);
+      await vi.advanceTimersByTimeAsync(FOREGROUND_REQUEST_TIMEOUT_MS);
       await rejected;
       scope.dispose();
       expect(vi.getTimerCount()).toBe(0);

--- a/packages/website/src/content/docs/docs/environment.md
+++ b/packages/website/src/content/docs/docs/environment.md
@@ -89,6 +89,14 @@ Env vars override `.lore.json` for the same setting. To override a `.lore.json` 
 |---|---|
 | `LORE_SHUTDOWN_TIMEOUT_MS` | Bound for the bounded vector-pool shutdown on graceful shutdown (#1599). The pool teardown must wait for every worker's SQLite reader to close before the writer can TRUNCATE the WAL — leaving readers up would strand the `-wal` file and force WAL recovery on the next boot. Sized to fit under the global deadline after the embedding drain (60%) so a stuck worker still leaves room for the writer's checkpoint+close. Mirrors {@link EMBED_DRAIN_DEADLINE_MS}'s safety floor of 500ms so an aggressive `LORE_SHUTDOWN_TIMEOUT_MS` (e.g. 1000ms) doesn't shrink the pool budget into a guaranteed timeout. |
 
+## sse-inactivity
+
+| Variable | Description |
+|---|---|
+| `LORE_FOREGROUND_REQUEST_TIMEOUT_MS` | Wall-clock ceiling for a single foreground request: the hard abort of the whole relay (recall deadline + abort scope). Automatically raised to stay at least 60s above LORE_FOREGROUND_SSE_INACTIVITY_MS, so a request timeout can never make the inactivity deadline unreachable. Positive integer ms; invalid values fall back to 900000. Env: LORE_FOREGROUND_REQUEST_TIMEOUT_MS. |
+| `LORE_FOREGROUND_SSE_INACTIVITY_MS` | How long the gateway tolerates upstream silence on a foreground relay before aborting it. Raise this for models whose extended-thinking phases emit nothing for minutes (Opus-class reasoning over large cached prompts), since a too-low value kills the stream mid-thinking and the client reports a connection loss rather than a stall. Positive integer ms; invalid values fall back to 600000. Floored at 1000 and clamped to the 32-bit timer ceiling. Env: LORE_FOREGROUND_SSE_INACTIVITY_MS. |
+| `LORE_WORKER_RESPONSE_INACTIVITY_MS` | How long a background/auxiliary worker call tolerates upstream silence before aborting. Separate from the foreground pair because worker calls are not user-visible and need not match the client's watchdog budget. Positive integer ms; invalid values fall back to 600000. Env: LORE_WORKER_RESPONSE_INACTIVITY_MS. |
+
 ## Memory engine (`@loreai/core`)
 
 | Variable | Description |

--- a/packages/website/src/content/docs/docs/environment.md
+++ b/packages/website/src/content/docs/docs/environment.md
@@ -95,7 +95,8 @@ Env vars override `.lore.json` for the same setting. To override a `.lore.json` 
 |---|---|
 | `LORE_FOREGROUND_REQUEST_TIMEOUT_MS` | Wall-clock ceiling for a single foreground request: the hard abort of the whole relay (recall deadline + abort scope). Automatically raised to stay at least 60s above LORE_FOREGROUND_SSE_INACTIVITY_MS, so a request timeout can never make the inactivity deadline unreachable. Positive integer ms; invalid values fall back to 900000. Env: LORE_FOREGROUND_REQUEST_TIMEOUT_MS. |
 | `LORE_FOREGROUND_SSE_INACTIVITY_MS` | How long the gateway tolerates upstream silence on a foreground relay before aborting it. Raise this for models whose extended-thinking phases emit nothing for minutes (Opus-class reasoning over large cached prompts), since a too-low value kills the stream mid-thinking and the client reports a connection loss rather than a stall. Positive integer ms; invalid values fall back to 600000. Floored at 1000 and clamped to the 32-bit timer ceiling. Env: LORE_FOREGROUND_SSE_INACTIVITY_MS. |
-| `LORE_WORKER_RESPONSE_INACTIVITY_MS` | How long a background/auxiliary worker call tolerates upstream silence before aborting. Separate from the foreground pair because worker calls are not user-visible and need not match the client's watchdog budget. Positive integer ms; invalid values fall back to 600000. Env: LORE_WORKER_RESPONSE_INACTIVITY_MS. |
+| `LORE_WORKER_REQUEST_TIMEOUT_MS` | Wall-clock ceiling for a single background/auxiliary worker call. Automatically raised to stay at least 60s above LORE_WORKER_RESPONSE_INACTIVITY_MS. Positive integer ms; invalid values fall back to 900000. Env: LORE_WORKER_REQUEST_TIMEOUT_MS. |
+| `LORE_WORKER_RESPONSE_INACTIVITY_MS` | How long a background/auxiliary worker call tolerates upstream silence before aborting. Positive integer ms; invalid values fall back to 600000. Env: LORE_WORKER_RESPONSE_INACTIVITY_MS. |
 
 ## Memory engine (`@loreai/core`)
 


### PR DESCRIPTION
## Problem

The foreground relay aborted a stream whenever the upstream emitted nothing for **120 s**:

```ts
const FOREGROUND_SSE_INACTIVITY_MS = 120_000;  // hardcoded, no env override
```

All four foreground parse sites read it (Anthropic relay, Anthropic recall continuation, Responses relay, Responses recall continuation). Opus-class extended thinking over large cached prompts can go silent for minutes, so the gateway killed the relay while the client's own watchdogs (180 s / 300 s) never fired. The client saw a truncated `200` with zero content and reported a transport loss rather than a stall.

Two ceilings existed with **no declared relationship**: the 120 s inactivity deadline and a 300 s foreground request timeout. A naive bump of the inactivity deadline would have been a no-op above 300 s — the coarser timer fires first. The worker path had the identical pair (120 s / 300 s).

## Fix

Add `packages/gateway/src/sse-inactivity.ts` centralizing the deadlines:

| Env var | Default |
|---|---|
| `LORE_FOREGROUND_SSE_INACTIVITY_MS` | 600 s (was hardcoded 120 s) |
| `LORE_FOREGROUND_REQUEST_TIMEOUT_MS` | 900 s (was hardcoded 300 s) |
| `LORE_WORKER_RESPONSE_INACTIVITY_MS` | 600 s (was hardcoded 120 s) |
| `LORE_WORKER_REQUEST_TIMEOUT_MS` | 900 s (was hardcoded 300 s) |

Each request ceiling is clamped to `inactivity + 60 s headroom`, so raising the inactivity deadline can never leave a tighter request ceiling silently in force — the trap that would have made a 120→600 s change inert.

600 s sits above every client watchdog the gateway serves, so the client stays the authority on a stalled stream and the gateway intervenes only on a genuinely dead connection.

## Tests

Five suites advanced a literal `300_000` to trip a deadline; each now derives from the exported constant, so a test can no longer encode a stale default. Two tests encoded the old value in their scenario shape rather than just their timer advance (a 600 s throttle that only lost the race while the deadline was 300 s; a 299 s attempt that only abutted a 300 s deadline) and are now expressed relative to the deadline.

New `sse-inactivity.test.ts` covers parsing, the defaults, and the invariant `request ceiling > inactivity`.

## Note

This is a latent-defect fix, independent of the parallel-recall abort fixed in #1755. It does not address that issue and is not required by it.
