### PR TITLE
fix(gateway): distinguish principal stream failures

### DIFF
--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -8331,6 +8331,10 @@ export function streamResponsesRecallAware(
     event: string,
     parsed: Record<string, unknown>,
     state: ResponsesAccState,
+    onDoneOnlyItem?: (
+      outputIndex: number,
+      item: Record<string, unknown>,
+    ) => void,
   ): number | undefined => {
     const requiresOutputIndex =
       /^response\.(?:output_item|output_text|function_call_arguments|content_part|reasoning_(?:summary|text)|refusal)/.test(
@@ -8357,6 +8361,7 @@ export function streamResponsesRecallAware(
       if (doneItem.type === "message" && doneItem.role === undefined) {
         doneItem.role = "assistant";
       }
+      onDoneOnlyItem?.(outputIndex, doneItem);
       const seedItem = { ...doneItem };
       delete seedItem.status;
       if (seedItem.type === "message") delete seedItem.content;
@@ -9335,6 +9340,7 @@ export function streamResponsesRecallAware(
   const assertTerminalOutputMatches = (
     acc: ResponsesAccState,
     parsed: Record<string, unknown>,
+    onMatched?: (outputIndex: number, item: Record<string, unknown>) => void,
     onSynthesizedDone?: (
       outputIndex: number,
       item: Record<string, unknown>,
@@ -9405,6 +9411,7 @@ export function streamResponsesRecallAware(
       }
       const [outputIndex, streamed] = expected[matchIndex];
       const lifecycle = lifecyclesFor(acc).get(outputIndex);
+      onMatched?.(outputIndex, actual);
       if (
         !isReference &&
         opts.validation === "codex" &&
@@ -10005,6 +10012,26 @@ export function streamResponsesRecallAware(
           | RecallContinuationFailureCategory
           | undefined;
         let continuationFailureReported = false;
+        let recallDetected = false;
+        type PrincipalFailureCategory =
+          | "principal_transport"
+          | "principal_resource_limit"
+          | "principal_protocol"
+          | "principal_missing_terminal"
+          | "principal_unexpected";
+        let principalFailureCategory: PrincipalFailureCategory =
+          "principal_unexpected";
+        const classifyPrincipalFailure = (
+          error: unknown,
+        ): PrincipalFailureCategory => {
+          if (error instanceof SSEStreamTransportError) {
+            return "principal_transport";
+          }
+          if (error instanceof SSEStreamLimitError) {
+            return "principal_resource_limit";
+          }
+          return principalFailureCategory;
+        };
         const reportContinuationFailure = (
           category: RecallContinuationFailureCategory,
         ): void => {
@@ -10015,6 +10042,7 @@ export function streamResponsesRecallAware(
         // Recall items are gateway-internal and must stay hidden on every exit,
         // including failures raised before marker replacement.
         const recallIndices = new Set<number>();
+        const unresolvedToolIndices = new Set<number>();
         const referenceIndices = new Map<number, ReferenceLifecycle>();
 
         try {
@@ -10032,7 +10060,6 @@ export function streamResponsesRecallAware(
           const pendingRecalls: PendingResponsesRecall[] = [];
           // Whether any NON-recall function_call appeared (mixed-tools case).
           let otherToolSeen = false;
-          const unresolvedToolIndices = new Set<number>();
           const unresolvedToolBytes = new Map<number, number>();
           const deferredEvents: Array<{
             chunk: Uint8Array;
@@ -10050,7 +10077,9 @@ export function streamResponsesRecallAware(
             hiddenRecallBytes += unresolvedToolBytes.get(outputIndex) ?? 0;
             unresolvedToolBytes.delete(outputIndex);
             if (hiddenRecallBytes > maxHiddenRecallBytes) {
-              throw new Error("recall stream exceeded deferred event limit");
+              throw new SSEStreamLimitError(
+                "recall stream exceeded deferred event limit",
+              );
             }
           };
 
@@ -10068,9 +10097,12 @@ export function streamResponsesRecallAware(
               formatResponsesEvent(event, data),
             ).byteLength;
             if (streamBytes > maxStreamBytes) {
-              throw new Error("Responses stream exceeded byte limit");
+              throw new SSEStreamLimitError(
+                "Responses stream exceeded byte limit",
+              );
             }
 
+            principalFailureCategory = "principal_protocol";
             let parsed: Record<string, unknown>;
             try {
               parsed = JSON.parse(data) as Record<string, unknown>;
@@ -10084,7 +10116,7 @@ export function streamResponsesRecallAware(
                 if (recallIndices.size > 0 || unresolvedToolIndices.size > 0) {
                   deferredBytes += chunk.byteLength;
                   if (deferredBytes > maxDeferredBytes) {
-                    throw new Error(
+                    throw new SSEStreamLimitError(
                       "recall stream exceeded deferred event limit",
                     );
                   }
@@ -10098,6 +10130,15 @@ export function streamResponsesRecallAware(
             if (parsed.type !== event) {
               throw new Error(`Responses payload type does not match ${event}`);
             }
+            if (
+              (event === "response.output_item.added" ||
+                event === "response.output_item.done") &&
+              (parsed.item as Record<string, unknown> | undefined)?.type ===
+                "function_call" &&
+              (parsed.item as Record<string, unknown>).name === RECALL_TOOL_NAME
+            ) {
+              recallDetected = true;
+            }
             const normalizationState = normalizeCodexEvent(
               state,
               event,
@@ -10110,11 +10151,27 @@ export function streamResponsesRecallAware(
               continue;
             }
 
-            const outputIndex = outputIndexForEvent(event, parsed, state);
+            const outputIndex = outputIndexForEvent(
+              event,
+              parsed,
+              state,
+              (index, item) => {
+                if (
+                  item.type !== "function_call" ||
+                  item.name !== RECALL_TOOL_NAME
+                ) {
+                  return;
+                }
+                recallDetected = true;
+                recallIndices.add(index);
+              },
+            );
             if (outputIndex !== undefined) {
               retainedStateBytes += encoder.encode(data).byteLength;
               if (retainedStateBytes > maxRetainedStateBytes) {
-                throw new Error("Responses retained state exceeded byte limit");
+                throw new SSEStreamLimitError(
+                  "Responses retained state exceeded byte limit",
+                );
               }
               const implicitItem = state.rawItems.get(outputIndex);
               if (
@@ -10128,7 +10185,8 @@ export function streamResponsesRecallAware(
               }
             }
 
-            let resolvedVisibleTool = false;
+            let resolvingRecallTool = false;
+            let resolvingVisibleTool = false;
             // Detect recall and unresolved sparse function-call identities.
             if (
               (event === "response.output_item.added" ||
@@ -10139,10 +10197,9 @@ export function streamResponsesRecallAware(
               const isRecallCall =
                 item?.type === "function_call" && item?.name === "recall";
               if (isRecallCall) {
-                unresolvedToolIndices.delete(outputIndex);
-                discardDeferredCandidate(outputIndex);
-                promoteDeferredCandidate(outputIndex);
+                recallDetected = true;
                 recallIndices.add(outputIndex);
+                resolvingRecallTool = true;
               } else if (item?.type === "function_call") {
                 if (
                   event === "response.output_item.added" &&
@@ -10151,12 +10208,29 @@ export function streamResponsesRecallAware(
                 ) {
                   unresolvedToolIndices.add(outputIndex);
                 } else {
-                  resolvedVisibleTool =
-                    unresolvedToolIndices.delete(outputIndex);
-                  unresolvedToolBytes.delete(outputIndex);
-                  otherToolSeen = true;
+                  resolvingVisibleTool = true;
                 }
               }
+            }
+
+            // Always accumulate into the internal state for postResponse.
+            applyResponsesEvent(state, event, parsed);
+            if (
+              event === "response.output_item.done" &&
+              outputIndex !== undefined
+            ) {
+              preserveStreamedReasoning(state, outputIndex);
+            }
+
+            let resolvedVisibleTool = false;
+            if (outputIndex !== undefined && resolvingRecallTool) {
+              discardDeferredCandidate(outputIndex);
+              promoteDeferredCandidate(outputIndex);
+              unresolvedToolIndices.delete(outputIndex);
+            } else if (outputIndex !== undefined && resolvingVisibleTool) {
+              resolvedVisibleTool = unresolvedToolIndices.delete(outputIndex);
+              unresolvedToolBytes.delete(outputIndex);
+              otherToolSeen = true;
             }
 
             if (
@@ -10176,15 +10250,6 @@ export function streamResponsesRecallAware(
             const isUnresolvedToolEvent =
               outputIndex !== undefined &&
               unresolvedToolIndices.has(outputIndex);
-
-            // Always accumulate into the internal state for postResponse.
-            applyResponsesEvent(state, event, parsed);
-            if (
-              event === "response.output_item.done" &&
-              outputIndex !== undefined
-            ) {
-              preserveStreamedReasoning(state, outputIndex);
-            }
 
             // Suppress all events belonging to a recall item, but still count
             // them so malformed argument streams cannot grow without bound.
@@ -10209,7 +10274,9 @@ export function streamResponsesRecallAware(
                 deferredBytes > maxDeferredBytes ||
                 hiddenRecallBytes > maxHiddenRecallBytes
               ) {
-                throw new Error("recall stream exceeded deferred event limit");
+                throw new SSEStreamLimitError(
+                  "recall stream exceeded deferred event limit",
+                );
               }
               if (
                 event === "response.function_call_arguments.done" &&
@@ -10248,17 +10315,45 @@ export function streamResponsesRecallAware(
               event === "response.failed"
             ) {
               const terminalParsed = stripHiddenReferenceOutput(parsed);
+              const terminalResponse = terminalParsed.response as
+                | Record<string, unknown>
+                | undefined;
+              if (
+                Array.isArray(terminalResponse?.output) &&
+                terminalResponse.output.some(
+                  (item) =>
+                    item !== null &&
+                    typeof item === "object" &&
+                    !Array.isArray(item) &&
+                    (item as Record<string, unknown>).type ===
+                      "function_call" &&
+                    (item as Record<string, unknown>).name === RECALL_TOOL_NAME,
+                )
+              ) {
+                recallDetected = true;
+              }
               if (opts.validation === "codex") {
                 assertTerminalOutputMatches(
                   state,
                   terminalParsed,
                   (outputIndex, item) => {
+                    if (
+                      item.type !== "function_call" ||
+                      item.name !== RECALL_TOOL_NAME ||
+                      (!recallIndices.has(outputIndex) &&
+                        !unresolvedToolIndices.has(outputIndex))
+                    ) {
+                      return;
+                    }
+                    recallDetected = true;
+                    recallIndices.add(outputIndex);
+                    unresolvedToolIndices.delete(outputIndex);
+                    discardDeferredCandidate(outputIndex);
+                    promoteDeferredCandidate(outputIndex);
+                  },
+                  (outputIndex, item) => {
                     if (item.type !== "function_call") return;
                     if (item.name === RECALL_TOOL_NAME) {
-                      unresolvedToolIndices.delete(outputIndex);
-                      discardDeferredCandidate(outputIndex);
-                      promoteDeferredCandidate(outputIndex);
-                      recallIndices.add(outputIndex);
                       collectCompletedRecall(
                         state,
                         outputIndex,
@@ -10672,7 +10767,8 @@ export function streamResponsesRecallAware(
                               contUnresolvedToolIndices.add(ci);
                             }
                           }
-                          let resolvedVisibleTool = false;
+                          let resolvingRecallTool = false;
+                          let resolvingVisibleTool = false;
                           if (
                             (ce === "response.output_item.added" ||
                               ce === "response.output_item.done") &&
@@ -10685,10 +10781,8 @@ export function streamResponsesRecallAware(
                               item?.type === "function_call" &&
                               item.name === RECALL_TOOL_NAME
                             ) {
-                              contUnresolvedToolIndices.delete(ci);
-                              discardContinuationCandidate(ci);
-                              promoteContinuationCandidate(ci);
                               contRecallIndices.add(ci);
+                              resolvingRecallTool = true;
                             } else if (item?.type === "function_call") {
                               if (
                                 ce === "response.output_item.added" &&
@@ -10697,20 +10791,9 @@ export function streamResponsesRecallAware(
                               ) {
                                 contUnresolvedToolIndices.add(ci);
                               } else {
-                                resolvedVisibleTool =
-                                  contUnresolvedToolIndices.delete(ci);
-                                promoteVisibleContinuationCandidate(ci);
-                                contUnresolvedToolBytes.delete(ci);
-                                contOtherTool = true;
+                                resolvingVisibleTool = true;
                               }
                             }
-                          }
-                          if (
-                            resolvedVisibleTool &&
-                            contRecallIndices.size === 0 &&
-                            contUnresolvedToolIndices.size === 0
-                          ) {
-                            flushHeldContinuation();
                           }
                           applyResponsesEvent(contState, ce, cparsed);
                           if (
@@ -10718,6 +10801,25 @@ export function streamResponsesRecallAware(
                             ci !== undefined
                           ) {
                             preserveStreamedReasoning(contState, ci);
+                          }
+                          let resolvedVisibleTool = false;
+                          if (ci !== undefined && resolvingRecallTool) {
+                            discardContinuationCandidate(ci);
+                            promoteContinuationCandidate(ci);
+                            contUnresolvedToolIndices.delete(ci);
+                          } else if (ci !== undefined && resolvingVisibleTool) {
+                            promoteVisibleContinuationCandidate(ci);
+                            resolvedVisibleTool =
+                              contUnresolvedToolIndices.delete(ci);
+                            contUnresolvedToolBytes.delete(ci);
+                            contOtherTool = true;
+                          }
+                          if (
+                            resolvedVisibleTool &&
+                            contRecallIndices.size === 0 &&
+                            contUnresolvedToolIndices.size === 0
+                          ) {
+                            flushHeldContinuation();
                           }
                           const isContRecall =
                             ci !== undefined && contRecallIndices.has(ci);
@@ -10805,14 +10907,20 @@ export function streamResponsesRecallAware(
                                 contState,
                                 terminalParsed,
                                 (outputIndex, item) => {
+                                  if (
+                                    item.type !== "function_call" ||
+                                    item.name !== RECALL_TOOL_NAME
+                                  ) {
+                                    return;
+                                  }
+                                  contRecallIndices.add(outputIndex);
+                                  contUnresolvedToolIndices.delete(outputIndex);
+                                  discardContinuationCandidate(outputIndex);
+                                  promoteContinuationCandidate(outputIndex);
+                                },
+                                (outputIndex, item) => {
                                   if (item.type !== "function_call") return;
                                   if (item.name === RECALL_TOOL_NAME) {
-                                    contUnresolvedToolIndices.delete(
-                                      outputIndex,
-                                    );
-                                    discardContinuationCandidate(outputIndex);
-                                    promoteContinuationCandidate(outputIndex);
-                                    contRecallIndices.add(outputIndex);
                                     collectCompletedRecall(
                                       contState,
                                       outputIndex,
@@ -11223,6 +11331,7 @@ export function streamResponsesRecallAware(
                     text: anchorTexts[anchorIndex++] ?? "",
                   };
                 }),
+                rawOutputItems: buildOutputItems(),
               };
               if (continuationAttempted) {
                 continuationFailureCategory = "delivery";
@@ -11297,7 +11406,9 @@ export function streamResponsesRecallAware(
             if (recallIndices.size > 0 || unresolvedToolIndices.size > 0) {
               deferredBytes += chunk.byteLength;
               if (deferredBytes > maxDeferredBytes) {
-                throw new Error("recall stream exceeded deferred event limit");
+                throw new SSEStreamLimitError(
+                  "recall stream exceeded deferred event limit",
+                );
               }
               deferredEvents.push({ chunk });
             } else if (!(await safeEnqueue(chunk))) {
@@ -11305,6 +11416,7 @@ export function streamResponsesRecallAware(
             }
           }
 
+          principalFailureCategory = "principal_missing_terminal";
           throw new Error(
             "upstream Responses stream ended without a terminal event",
           );
@@ -11350,7 +11462,7 @@ export function streamResponsesRecallAware(
                 ? err.category
                 : continuationAttempted
                   ? (continuationFailureCategory ?? "unexpected")
-                  : undefined;
+                  : classifyPrincipalFailure(err);
             log.error(
               `openai-responses recall-aware stream failed${category ? ` category=${category}` : ""}${sessionID ? ` (session=${sessionID.slice(0, 16)})` : ""}`,
             );
@@ -11364,6 +11476,10 @@ export function streamResponsesRecallAware(
               );
             }
           }
+          const recallFailure =
+            recallDetected ||
+            continuationAttempted ||
+            err instanceof RecallContinuationFailure;
           const failedResponse = finalizeResponsesAcc(state);
           try {
             assertUsageMergeable(
@@ -11379,14 +11495,41 @@ export function streamResponsesRecallAware(
             );
           }
           transactionProviderUsage = { ...ZERO_USAGE };
+          const hiddenOutputIndices = new Set([
+            ...recallIndices,
+            ...unresolvedToolIndices,
+          ]);
+          const hiddenOutputIdentities = new Set<string>();
+          for (const outputIndex of hiddenOutputIndices) {
+            const item = state.items.get(outputIndex);
+            const raw = state.rawItems.get(outputIndex);
+            for (const identity of [
+              item?.id,
+              item?.type === "tool_use" ? item.callId : undefined,
+              raw?.id,
+              raw?.call_id,
+            ]) {
+              if (typeof identity === "string" && identity) {
+                hiddenOutputIdentities.add(identity);
+              }
+            }
+          }
           failedResponse.content = failedResponse.content.filter(
             (block) =>
-              (block.type !== "tool_use" || block.name !== RECALL_TOOL_NAME) &&
+              (block.type !== "tool_use" ||
+                (block.name !== RECALL_TOOL_NAME &&
+                  !hiddenOutputIdentities.has(block.id))) &&
               (block.type !== "text" || !parseRecallAnchor(block.text)),
           );
           failedResponse.rawOutputItems = failedResponse.rawOutputItems?.filter(
             (item) =>
-              item.type !== "function_call" || item.name !== RECALL_TOOL_NAME,
+              item.type !== "function_call" ||
+              (item.name !== RECALL_TOOL_NAME &&
+                ![item.id, item.call_id].some(
+                  (identity) =>
+                    typeof identity === "string" &&
+                    hiddenOutputIdentities.has(identity),
+                )),
           );
           await safeEnqueue(
             encoder.encode(
@@ -11400,12 +11543,13 @@ export function streamResponsesRecallAware(
                     created_at: Math.floor(Date.now() / 1000),
                     model: state.model,
                     status: "failed",
-                    output: buildOutputItems(recallIndices),
+                    output: buildOutputItems(hiddenOutputIndices),
                     usage: null,
                     error: {
                       type: "server_error",
-                      message:
-                        "Lore could not continue the response after recall",
+                      message: recallFailure
+                        ? "Lore could not continue the response after recall"
+                        : "Gateway request failed",
                     },
                   },
                 }),

--- a/packages/gateway/test/openai-responses-recall-aware-stream.test.ts
+++ b/packages/gateway/test/openai-responses-recall-aware-stream.test.ts
@@ -166,6 +166,7 @@ const doneWithStatus = (id: string, status: string) =>
   });
 
 const PUBLIC_RECALL_ERROR = "Lore could not continue the response after recall";
+const PUBLIC_GATEWAY_ERROR = "Gateway request failed";
 
 const textItem = (
   outputIndex: number,
@@ -399,6 +400,7 @@ describe("streamResponsesRecallAware", () => {
   );
 
   test("suppresses a recall function_call and emits a marker (mixed tools)", async () => {
+    let completedResponse: GatewayResponse | undefined;
     const client = streamResponsesRecallAware(
       streamFrom([
         created("resp_mixed", "gpt-5.6-terra"),
@@ -433,7 +435,9 @@ describe("streamResponsesRecallAware", () => {
         completed("resp_mixed"),
       ]),
       {
-        onComplete: () => {},
+        onComplete: (response) => {
+          completedResponse = response;
+        },
         onRecall: async ({ query }) => ({
           anchorText: buildAnchor(query),
           resultText: "some results",
@@ -463,6 +467,17 @@ describe("streamResponsesRecallAware", () => {
       "msg_resp_mixed_0",
       "fc_1",
     ]);
+    const completedJSON = JSON.stringify(completedResponse);
+    expect(completedResponse?.rawOutputItems).toContainEqual(
+      expect.objectContaining({
+        id: "fc_1",
+        call_id: "call_1",
+        name: "read",
+      }),
+    );
+    expect(completedJSON).not.toContain("what is lore");
+    expect(completedJSON).not.toContain("fc_0");
+    expect(completedJSON).not.toContain("call_0");
   });
 
   test("binds parallel recalls to their own call IDs and fails before an invalid follow-up", async () => {
@@ -620,8 +635,7 @@ describe("streamResponsesRecallAware", () => {
       },
     );
 
-    const out = await drain(client);
-    expect(out).toContain(PUBLIC_RECALL_ERROR);
+    expect(await drain(client)).toContain(PUBLIC_RECALL_ERROR);
   });
 
   test("bounds suppressed recall argument events", async () => {
@@ -655,11 +669,17 @@ describe("streamResponsesRecallAware", () => {
       },
     );
 
-    const out = await drain(client);
-    expect(out).toContain(PUBLIC_RECALL_ERROR);
+    expect(await drain(client)).toContain(PUBLIC_RECALL_ERROR);
   });
 
   test("bounds retained output before recall detection", async () => {
+    const errors: string[] = [];
+    log.registerSink({
+      info: () => {},
+      warn: () => {},
+      error: (message) => errors.push(message),
+      captureException: () => {},
+    });
     const client = streamResponsesRecallAware(
       streamFrom([
         created("resp_retained", "gpt-5.6-terra"),
@@ -675,10 +695,25 @@ describe("streamResponsesRecallAware", () => {
         },
       },
     );
-    expect(await drain(client)).toContain("response.failed");
+    const out = await drain(client);
+    expect(out).toContain("response.failed");
+    expect(out).toContain(PUBLIC_GATEWAY_ERROR);
+    expect(out).not.toContain(PUBLIC_RECALL_ERROR);
+    expect(errors).toEqual([
+      "openai-responses recall-aware stream failed category=principal_resource_limit",
+    ]);
   });
 
   test("rejects an SSE event name that disagrees with the payload type", async () => {
+    const failures: RecallContinuationFailureCategory[] = [];
+    const errors: string[] = [];
+    setRecallContinuationFailureHook((category) => failures.push(category));
+    log.registerSink({
+      info: () => {},
+      warn: () => {},
+      error: (message) => errors.push(message),
+      captureException: () => {},
+    });
     const client = streamResponsesRecallAware(
       streamFrom([
         created("resp_type_mismatch", "gpt-5.6-terra"),
@@ -696,7 +731,86 @@ describe("streamResponsesRecallAware", () => {
         },
       },
     );
-    expect(await drain(client)).toContain("response.failed");
+    const out = await drain(client);
+    expect(out.match(/^event: response\.failed$/gm)).toHaveLength(1);
+    expect(out).toContain(PUBLIC_GATEWAY_ERROR);
+    expect(out).not.toContain(PUBLIC_RECALL_ERROR);
+    expect(failures).toEqual([]);
+    expect(errors).toEqual([
+      "openai-responses recall-aware stream failed category=principal_protocol",
+    ]);
+  });
+
+  test("sanitizes a principal transport failure before recall", async () => {
+    const failures: RecallContinuationFailureCategory[] = [];
+    const errors: string[] = [];
+    setRecallContinuationFailureHook((category) => failures.push(category));
+    log.registerSink({
+      info: () => {},
+      warn: () => {},
+      error: (message) => errors.push(message),
+      captureException: () => {},
+    });
+    const privateCause = "private principal socket failure";
+    const upstream = new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(
+            new TextEncoder().encode(
+              created("resp_principal_transport", "gpt-5.6-terra"),
+            ),
+          );
+          controller.error(new Error(privateCause));
+        },
+      }),
+      { headers: { "content-type": "text/event-stream" } },
+    );
+    const client = streamResponsesRecallAware(upstream, {
+      onComplete: () => {},
+      onRecall: async () => ({ anchorText: "", resultText: "" }),
+      runFollowUp: async () => {
+        throw new Error("should not run");
+      },
+    });
+
+    const out = await drain(client);
+    expect(out.match(/^event: response\.failed$/gm)).toHaveLength(1);
+    expect(out).toContain(PUBLIC_GATEWAY_ERROR);
+    expect(out).not.toContain(PUBLIC_RECALL_ERROR);
+    expect(out).not.toContain(privateCause);
+    expect(failures).toEqual([]);
+    expect(errors).toEqual([
+      "openai-responses recall-aware stream failed category=principal_transport",
+    ]);
+  });
+
+  test("classifies a missing principal response body as unexpected", async () => {
+    const failures: RecallContinuationFailureCategory[] = [];
+    const errors: string[] = [];
+    setRecallContinuationFailureHook((category) => failures.push(category));
+    log.registerSink({
+      info: () => {},
+      warn: () => {},
+      error: (message) => errors.push(message),
+      captureException: () => {},
+    });
+    const client = streamResponsesRecallAware(new Response(null), {
+      onComplete: () => {},
+      onRecall: async () => ({ anchorText: "", resultText: "" }),
+      runFollowUp: async () => {
+        throw new Error("should not run");
+      },
+    });
+
+    const out = await drain(client);
+    expect(out.match(/^event: response\.failed$/gm)).toHaveLength(1);
+    expect(out).toContain(PUBLIC_GATEWAY_ERROR);
+    expect(out).not.toContain(PUBLIC_RECALL_ERROR);
+    expect(out).not.toContain("Upstream response has no body");
+    expect(failures).toEqual([]);
+    expect(errors).toEqual([
+      "openai-responses recall-aware stream failed category=principal_unexpected",
+    ]);
   });
 
   test("rejects response.in_progress changing the created response identity", async () => {
@@ -1230,6 +1344,8 @@ describe("streamResponsesRecallAware", () => {
   });
 
   test("rejects terminal function calls changing the streamed tool name", async () => {
+    let completedResponse: GatewayResponse | undefined;
+    let recallCalls = 0;
     const client = streamResponsesRecallAware(
       streamFrom([
         created("resp_terminal_name", "gpt-5.6-terra"),
@@ -1277,15 +1393,40 @@ describe("streamResponsesRecallAware", () => {
         }),
       ]),
       {
-        onComplete: () => {},
-        onRecall: async () => ({ anchorText: "", resultText: "" }),
+        validation: "codex",
+        onComplete: (response) => {
+          completedResponse = response;
+        },
+        onRecall: async () => {
+          recallCalls++;
+          return { anchorText: "", resultText: "" };
+        },
         runFollowUp: async () => {
           throw new Error("should not run");
         },
       },
     );
 
-    expect(await drain(client)).toContain("response.failed");
+    const output = await drain(client);
+    const terminal = JSON.parse(
+      /event: response\.failed\ndata: (.+)/.exec(output)?.[1] ?? "{}",
+    ) as { response?: { output?: Array<Record<string, unknown>> } };
+    expect(output.match(/^event: response\.failed$/gm)).toHaveLength(1);
+    expect(terminal.response?.output).toContainEqual(
+      expect.objectContaining({
+        id: "fc_terminal_name",
+        call_id: "call_terminal_name",
+        name: "read",
+      }),
+    );
+    expect(completedResponse?.rawOutputItems).toContainEqual(
+      expect.objectContaining({
+        id: "fc_terminal_name",
+        call_id: "call_terminal_name",
+        name: "read",
+      }),
+    );
+    expect(recallCalls).toBe(0);
   });
 
   test("rejects malformed terminal output items", async () => {
@@ -1791,6 +1932,129 @@ describe("streamResponsesRecallAware", () => {
     ).toEqual(["ciphertext-B", "ciphertext-D"]);
   });
 
+  test("redacts a done-only failed Codex recall before lifecycle validation", async () => {
+    const privateArguments = JSON.stringify({
+      query: "private done-only query",
+    });
+    let completedResponse: GatewayResponse | undefined;
+    let successful: boolean | undefined;
+    let recallCalls = 0;
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_done_only_failed_recall", "gpt-5.6-terra"),
+        sseEvent("response.output_item.done", {
+          item: {
+            type: "function_call",
+            id: "fc_done_only_failed_recall",
+            call_id: "call_done_only_failed_recall",
+            name: "recall",
+            arguments: privateArguments,
+            status: "failed",
+          },
+        }),
+      ]),
+      {
+        validation: "codex",
+        onComplete: (response, didSucceed) => {
+          completedResponse = response;
+          successful = didSucceed;
+        },
+        onRecall: async () => {
+          recallCalls++;
+          return { anchorText: "anchor", resultText: "result" };
+        },
+        runFollowUp: async () => {
+          throw new Error("should not run");
+        },
+      },
+    );
+
+    const output = await drain(client);
+    const completedJSON = JSON.stringify(completedResponse);
+    expect(output.match(/^event: response\.failed$/gm)).toHaveLength(1);
+    expect(output).toContain(PUBLIC_RECALL_ERROR);
+    expect(output).not.toContain(PUBLIC_GATEWAY_ERROR);
+    expect(output).not.toContain("private done-only query");
+    expect(output).not.toContain("fc_done_only_failed_recall");
+    expect(output).not.toContain("call_done_only_failed_recall");
+    expect(completedJSON).not.toContain("private done-only query");
+    expect(completedJSON).not.toContain("fc_done_only_failed_recall");
+    expect(completedJSON).not.toContain("call_done_only_failed_recall");
+    expect(recallCalls).toBe(0);
+    expect(successful).toBe(false);
+  });
+
+  test("redacts a sparse principal recall when promotion exceeds the hidden budget", async () => {
+    const privateArguments = JSON.stringify({
+      query: "private direct promotion query",
+    });
+    let completedResponse: GatewayResponse | undefined;
+    let successful: boolean | undefined;
+    let recallCalls = 0;
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_sparse_promotion_limit", "gpt-5.6-terra"),
+        sseEvent("response.output_item.added", {
+          output_index: 0,
+          item: {
+            type: "function_call",
+            id: "fc_sparse_promotion_limit",
+            call_id: "",
+            name: "",
+            arguments: "",
+          },
+        }),
+        sseEvent("response.function_call_arguments.delta", {
+          output_index: 0,
+          item_id: "fc_sparse_promotion_limit",
+          delta: privateArguments,
+        }),
+        sseEvent("response.output_item.done", {
+          output_index: 0,
+          item: {
+            type: "function_call",
+            id: "fc_sparse_promotion_limit",
+            call_id: "call_sparse_promotion_limit",
+            name: "recall",
+            arguments: privateArguments,
+            status: "completed",
+          },
+        }),
+        completed("resp_sparse_promotion_limit"),
+      ]),
+      {
+        validation: "codex",
+        maxDeferredBytes: 16 * 1024,
+        maxHiddenRecallBytes: 1,
+        maxRetainedStateBytes: 64 * 1024,
+        onComplete: (response, didSucceed) => {
+          completedResponse = response;
+          successful = didSucceed;
+        },
+        onRecall: async () => {
+          recallCalls++;
+          return { anchorText: "anchor", resultText: "result" };
+        },
+        runFollowUp: async () => {
+          throw new Error("should not run");
+        },
+      },
+    );
+
+    const output = await drain(client);
+    const completedJSON = JSON.stringify(completedResponse);
+    expect(output).toContain(PUBLIC_RECALL_ERROR);
+    expect(output).not.toContain(PUBLIC_GATEWAY_ERROR);
+    expect(output).not.toContain("private direct promotion query");
+    expect(output).not.toContain("fc_sparse_promotion_limit");
+    expect(output).not.toContain("call_sparse_promotion_limit");
+    expect(completedJSON).not.toContain("private direct promotion query");
+    expect(completedJSON).not.toContain("fc_sparse_promotion_limit");
+    expect(completedJSON).not.toContain("call_sparse_promotion_limit");
+    expect(recallCalls).toBe(0);
+    expect(successful).toBe(false);
+  });
+
   test("seeds data-only Codex items on principal and continuation streams", async () => {
     let recallContent = "";
     let completedResponse: GatewayResponse | undefined;
@@ -2041,6 +2305,336 @@ describe("streamResponsesRecallAware", () => {
     expect(output).not.toContain('"name":"recall"');
     expect(output).not.toContain("fc_terminal_recall");
     expect(output).not.toContain("call_terminal_recall");
+  });
+
+  test("redacts a sparse terminal-discovered recall before status validation", async () => {
+    let recallCalls = 0;
+    let completedResponse: GatewayResponse | undefined;
+    const privateArguments = JSON.stringify({
+      query: "private terminal query",
+    });
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_terminal_failed_sparse_recall", "gpt-5.6-terra"),
+        sseEvent("response.output_item.added", {
+          output_index: 0,
+          item: {
+            type: "function_call",
+            id: "fc_terminal_failed_sparse_recall",
+            call_id: "",
+            name: "",
+            arguments: "",
+            status: "in_progress",
+          },
+        }),
+        sseEvent("response.function_call_arguments.delta", {
+          output_index: 0,
+          item_id: "fc_terminal_failed_sparse_recall",
+          delta: privateArguments,
+        }),
+        sseEvent("response.completed", {
+          response: {
+            id: "resp_terminal_failed_sparse_recall",
+            model: "gpt-5.6-terra",
+            status: "completed",
+            output: [
+              {
+                type: "function_call",
+                id: "fc_terminal_failed_sparse_recall",
+                call_id: "call_terminal_failed_sparse_recall",
+                name: "recall",
+                arguments: privateArguments,
+                status: "failed",
+              },
+            ],
+          },
+        }),
+      ]),
+      {
+        validation: "codex",
+        onComplete: (response) => {
+          completedResponse = response;
+        },
+        onRecall: async () => {
+          recallCalls++;
+          return { anchorText: "", resultText: "" };
+        },
+        runFollowUp: async () => {
+          throw new Error("should not run");
+        },
+      },
+    );
+
+    const output = await drain(client);
+    const completedJSON = JSON.stringify(completedResponse);
+    expect(output).toContain(PUBLIC_RECALL_ERROR);
+    expect(output).not.toContain(PUBLIC_GATEWAY_ERROR);
+    expect(output).not.toContain("private terminal query");
+    expect(output).not.toContain("fc_terminal_failed_sparse_recall");
+    expect(output).not.toContain("call_terminal_failed_sparse_recall");
+    expect(completedJSON).not.toContain("private terminal query");
+    expect(completedJSON).not.toContain("fc_terminal_failed_sparse_recall");
+    expect(completedJSON).not.toContain("call_terminal_failed_sparse_recall");
+    expect(recallCalls).toBe(0);
+  });
+
+  test("redacts a sparse terminal recall that changes item identity", async () => {
+    let recallCalls = 0;
+    let completedResponse: GatewayResponse | undefined;
+    const privateArguments = JSON.stringify({
+      query: "private changed identity query",
+    });
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_terminal_changed_recall", "gpt-5.6-terra"),
+        sseEvent("response.output_item.added", {
+          output_index: 0,
+          item: {
+            type: "function_call",
+            id: "fc_streamed_changed_recall",
+            call_id: "",
+            name: "",
+            arguments: "",
+            status: "in_progress",
+          },
+        }),
+        sseEvent("response.function_call_arguments.delta", {
+          output_index: 0,
+          item_id: "fc_streamed_changed_recall",
+          delta: privateArguments,
+        }),
+        sseEvent("response.completed", {
+          response: {
+            id: "resp_terminal_changed_recall",
+            model: "gpt-5.6-terra",
+            status: "completed",
+            output: [
+              {
+                type: "function_call",
+                id: "fc_terminal_changed_recall",
+                call_id: "call_terminal_changed_recall",
+                name: "recall",
+                arguments: privateArguments,
+                status: "completed",
+              },
+            ],
+          },
+        }),
+      ]),
+      {
+        validation: "codex",
+        onComplete: (response) => {
+          completedResponse = response;
+        },
+        onRecall: async () => {
+          recallCalls++;
+          return { anchorText: "", resultText: "" };
+        },
+        runFollowUp: async () => {
+          throw new Error("should not run");
+        },
+      },
+    );
+
+    const output = await drain(client);
+    const completedJSON = JSON.stringify(completedResponse);
+    expect(output).toContain(PUBLIC_RECALL_ERROR);
+    expect(output).not.toContain(PUBLIC_GATEWAY_ERROR);
+    expect(output).not.toContain("private changed identity query");
+    expect(output).not.toContain("fc_streamed_changed_recall");
+    expect(output).not.toContain("fc_terminal_changed_recall");
+    expect(output).not.toContain("call_terminal_changed_recall");
+    expect(completedJSON).not.toContain("private changed identity query");
+    expect(completedJSON).not.toContain("fc_streamed_changed_recall");
+    expect(completedJSON).not.toContain("fc_terminal_changed_recall");
+    expect(completedJSON).not.toContain("call_terminal_changed_recall");
+    expect(recallCalls).toBe(0);
+  });
+
+  test("redacts a sparse call replaced by a terminal item reference", async () => {
+    let recallCalls = 0;
+    let completedResponse: GatewayResponse | undefined;
+    const privateArguments = JSON.stringify({
+      query: "private referenced query",
+    });
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_terminal_sparse_reference", "gpt-5.6-terra"),
+        sseEvent("response.output_item.added", {
+          output_index: 0,
+          item: {
+            type: "function_call",
+            id: "fc_terminal_sparse_reference",
+            call_id: "",
+            name: "",
+            arguments: "",
+            status: "in_progress",
+          },
+        }),
+        sseEvent("response.function_call_arguments.delta", {
+          output_index: 0,
+          item_id: "fc_terminal_sparse_reference",
+          delta: privateArguments,
+        }),
+        sseEvent("response.completed", {
+          response: {
+            id: "resp_terminal_sparse_reference",
+            model: "gpt-5.6-terra",
+            status: "completed",
+            output: [
+              {
+                type: "item_reference",
+                id: "fc_terminal_sparse_reference",
+              },
+            ],
+          },
+        }),
+      ]),
+      {
+        validation: "codex",
+        onComplete: (response) => {
+          completedResponse = response;
+        },
+        onRecall: async () => {
+          recallCalls++;
+          return { anchorText: "", resultText: "" };
+        },
+        runFollowUp: async () => {
+          throw new Error("should not run");
+        },
+      },
+    );
+
+    const output = await drain(client);
+    const completedJSON = JSON.stringify(completedResponse);
+    expect(output).toContain(PUBLIC_GATEWAY_ERROR);
+    expect(output).not.toContain(PUBLIC_RECALL_ERROR);
+    expect(output).not.toContain("private referenced query");
+    expect(output).not.toContain("fc_terminal_sparse_reference");
+    expect(completedJSON).not.toContain("private referenced query");
+    expect(completedJSON).not.toContain("fc_terminal_sparse_reference");
+    expect(recallCalls).toBe(0);
+  });
+
+  test("redacts a sparse call whose terminal item changes type", async () => {
+    let recallCalls = 0;
+    let completedResponse: GatewayResponse | undefined;
+    const privateArguments = JSON.stringify({
+      query: "private changed type query",
+    });
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_terminal_sparse_changed_type", "gpt-5.6-terra"),
+        sseEvent("response.output_item.added", {
+          output_index: 0,
+          item: {
+            type: "function_call",
+            id: "fc_terminal_sparse_changed_type",
+            call_id: "",
+            name: "",
+            arguments: "",
+            status: "in_progress",
+          },
+        }),
+        sseEvent("response.function_call_arguments.delta", {
+          output_index: 0,
+          item_id: "fc_terminal_sparse_changed_type",
+          delta: privateArguments,
+        }),
+        sseEvent("response.completed", {
+          response: {
+            id: "resp_terminal_sparse_changed_type",
+            model: "gpt-5.6-terra",
+            status: "completed",
+            output: [
+              {
+                type: "message",
+                id: "fc_terminal_sparse_changed_type",
+                role: "assistant",
+                status: "completed",
+                content: [],
+              },
+            ],
+          },
+        }),
+      ]),
+      {
+        validation: "codex",
+        onComplete: (response) => {
+          completedResponse = response;
+        },
+        onRecall: async () => {
+          recallCalls++;
+          return { anchorText: "", resultText: "" };
+        },
+        runFollowUp: async () => {
+          throw new Error("should not run");
+        },
+      },
+    );
+
+    const output = await drain(client);
+    const completedJSON = JSON.stringify(completedResponse);
+    expect(output).toContain(PUBLIC_GATEWAY_ERROR);
+    expect(output).not.toContain(PUBLIC_RECALL_ERROR);
+    expect(output).not.toContain("private changed type query");
+    expect(output).not.toContain("fc_terminal_sparse_changed_type");
+    expect(completedJSON).not.toContain("private changed type query");
+    expect(completedJSON).not.toContain("fc_terminal_sparse_changed_type");
+    expect(recallCalls).toBe(0);
+  });
+
+  test("redacts a sparse call omitted from the terminal output", async () => {
+    let recallCalls = 0;
+    let completedResponse: GatewayResponse | undefined;
+    const privateArguments = JSON.stringify({
+      query: "private omitted query",
+    });
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_terminal_sparse_omitted", "gpt-5.6-terra"),
+        sseEvent("response.output_item.added", {
+          output_index: 0,
+          item: {
+            type: "function_call",
+            id: "fc_terminal_sparse_omitted",
+            call_id: "",
+            name: "",
+            arguments: "",
+            status: "in_progress",
+          },
+        }),
+        sseEvent("response.function_call_arguments.delta", {
+          output_index: 0,
+          item_id: "fc_terminal_sparse_omitted",
+          delta: privateArguments,
+        }),
+        completed("resp_terminal_sparse_omitted"),
+      ]),
+      {
+        validation: "codex",
+        onComplete: (response) => {
+          completedResponse = response;
+        },
+        onRecall: async () => {
+          recallCalls++;
+          return { anchorText: "", resultText: "" };
+        },
+        runFollowUp: async () => {
+          throw new Error("should not run");
+        },
+      },
+    );
+
+    const output = await drain(client);
+    const completedJSON = JSON.stringify(completedResponse);
+    expect(output).toContain(PUBLIC_GATEWAY_ERROR);
+    expect(output).not.toContain(PUBLIC_RECALL_ERROR);
+    expect(output).not.toContain("private omitted query");
+    expect(output).not.toContain("fc_terminal_sparse_omitted");
+    expect(completedJSON).not.toContain("private omitted query");
+    expect(completedJSON).not.toContain("fc_terminal_sparse_omitted");
+    expect(recallCalls).toBe(0);
   });
 
   test("rejects terminal recall arguments that contradict an established final value", async () => {
@@ -3315,7 +3909,8 @@ describe("streamResponsesRecallAware", () => {
       },
     );
 
-    expect(await drain(client)).toContain(PUBLIC_RECALL_ERROR);
+    const out = await drain(client);
+    expect(out).toContain(PUBLIC_RECALL_ERROR);
   });
 
   test("rejects content-part declarations after value deltas", async () => {
@@ -5762,7 +6357,9 @@ describe("streamResponsesRecallAware", () => {
         },
       },
     );
-    expect(await drain(client)).toContain(PUBLIC_RECALL_ERROR);
+    const out = await drain(client);
+    expect(out).toContain(PUBLIC_GATEWAY_ERROR);
+    expect(out).not.toContain(PUBLIC_RECALL_ERROR);
   });
 
   test("intercepts a chained recall before streaming its final continuation", async () => {
@@ -7012,6 +7609,64 @@ describe("streamResponsesRecallAware", () => {
     expect(failures).toEqual(["follow_up_failed"]);
   });
 
+  test("redacts a done-only failed Codex recall in a continuation", async () => {
+    const privateArguments = JSON.stringify({
+      query: "private done-only continuation query",
+    });
+    const followUp = streamFrom([
+      created("resp_done_only_failed_followup", "gpt-5.6-terra"),
+      sseEvent("response.output_item.done", {
+        item: {
+          type: "function_call",
+          id: "fc_done_only_failed_followup",
+          call_id: "call_done_only_failed_followup",
+          name: "recall",
+          arguments: privateArguments,
+          status: "failed",
+        },
+      }),
+    ]);
+    let completedResponse: GatewayResponse | undefined;
+    let successful: boolean | undefined;
+    let recallCalls = 0;
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_done_only_failed_principal", "gpt-5.6-terra"),
+        recallCall(0, { query: "principal query" }),
+        completed("resp_done_only_failed_principal"),
+      ]),
+      {
+        validation: "codex",
+        onComplete: (response, didSucceed) => {
+          completedResponse = response;
+          successful = didSucceed;
+        },
+        onRecall: async () => {
+          recallCalls++;
+          return {
+            anchorText: buildAnchor("principal query"),
+            resultText: "result",
+          };
+        },
+        runFollowUp: async () => ({ reader: followUp.body!.getReader() }),
+      },
+    );
+
+    const output = await drain(client);
+    const completedJSON = JSON.stringify(completedResponse);
+    expect(output.match(/^event: response\.failed$/gm)).toHaveLength(1);
+    expect(output).toContain(PUBLIC_RECALL_ERROR);
+    expect(output).not.toContain("response.completed");
+    expect(output).not.toContain("private done-only continuation query");
+    expect(output).not.toContain("fc_done_only_failed_followup");
+    expect(output).not.toContain("call_done_only_failed_followup");
+    expect(completedJSON).not.toContain("private done-only continuation query");
+    expect(completedJSON).not.toContain("fc_done_only_failed_followup");
+    expect(completedJSON).not.toContain("call_done_only_failed_followup");
+    expect(recallCalls).toBe(1);
+    expect(successful).toBe(false);
+  });
+
   test("recall continuation diagnostics never alter the fixed public failure", async () => {
     setRecallContinuationFailureHook(() => {
       throw new Error("private telemetry failure");
@@ -7349,6 +8004,13 @@ describe("streamResponsesRecallAware", () => {
   });
 
   test("emits response.failed when upstream closes without a terminal event", async () => {
+    const errors: string[] = [];
+    log.registerSink({
+      info: () => {},
+      warn: () => {},
+      error: (message) => errors.push(message),
+      captureException: () => {},
+    });
     const client = streamResponsesRecallAware(
       streamFrom([
         created("resp_eof", "gpt-5.6-terra"),
@@ -7365,8 +8027,12 @@ describe("streamResponsesRecallAware", () => {
 
     const out = await drain(client);
     expect(out).toContain("response.failed");
-    expect(out).toContain(PUBLIC_RECALL_ERROR);
+    expect(out).toContain(PUBLIC_GATEWAY_ERROR);
+    expect(out).not.toContain(PUBLIC_RECALL_ERROR);
     expect(out).not.toContain("ended without a terminal event");
+    expect(errors).toEqual([
+      "openai-responses recall-aware stream failed category=principal_missing_terminal",
+    ]);
   });
 
   test("does NOT emit a second response.completed when the follow-up has none and no recall", async () => {


### PR DESCRIPTION
## Summary

Distinguishes principal OpenAI Responses failures from recall-continuation failures and keeps hidden recall calls out of every downstream response view.

## Changes

- Returns the canonical `Gateway request failed` envelope for principal failures before recall while preserving fixed recall wording after structural recall detection.
- Classifies principal transport, protocol, resource-limit, missing-terminal, and unexpected failures with closed privacy-safe categories.
- Redacts sparse, done-only, malformed-terminal, and successfully executed recall calls from wire output, `onComplete`, and post-response `rawOutputItems` without losing the complete processing accumulator.
- Prevents hostile terminal snapshots from renaming an established visible tool to `recall` and hiding it.
- Preserves transactional continuation isolation, exact-once terminal delivery, bounded cleanup, and existing recall-chain accounting.

## Regression Evidence

- Failing-first principal regression reproduced the wrong recall error before the fix.
- Failing-first sparse and done-only regressions reproduced private query and item/call identity leaks before their guards.
- Strengthened successful-recall and hostile-terminal-rename tests failed on the prior candidate and pass with the final fix.
- Focused suite: 199/199, repeated 10 times.
- Exhaustive suite: 463 files and 10,203 tests passed; 17 files and 230 tests skipped.
- Format, lint, typecheck, and gateway build passed.