### PR TITLE
Fix OpenCode lifecycle regression and SIGTERM shutdown

### DIFF
--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -12,9 +12,8 @@ import {
 // (`undefined is not an object (evaluating 'A.event')`). See ./internal.ts.
 import {
   applyLoreProviderConfig,
-  EmbeddedGatewayLifecycle,
-  type EmbeddedGatewayLease,
   gatewayAccessHeadersForRemote,
+  installEmbeddedGatewaySigtermHandler,
   probeGateway,
   shouldForwardUpstreamExtraHeader,
   surfaceGatewayUnavailable,
@@ -96,10 +95,11 @@ async function startInProcess(): Promise<string | null> {
     const gw = "@loreai/gateway";
     const { startGateway } = await import(/* webpackIgnore: true */ gw);
     const handle = await startGateway({ quiet: true, local: true });
-    processLifecycle.ownGateway(handle);
     const url = `http://127.0.0.1:${handle.port}`;
 
-    if (!handle.owned) {
+    if (handle.owned) {
+      installEmbeddedGatewaySigtermHandler(handle.shutdown);
+    } else {
       log.info(`reusing existing gateway at ${url}`);
     }
 
@@ -222,19 +222,6 @@ async function resolveParentSession(
 /** Memoized lore init promise — ensures concurrent plugin calls don't race. */
 let loreInitPromise: Promise<string | null> | null = null;
 
-function resetProcessState(): void {
-  processInitDone = false;
-  processLoreActive = false;
-  processLoreBase = "";
-  loreInitPromise = null;
-  lastGatewayStartError = null;
-  currentProject = undefined;
-  projectState.clear();
-  sessionParent.clear();
-}
-
-const processLifecycle = new EmbeddedGatewayLifecycle(resetProcessState);
-
 /**
  * Whether the plugin should stay inert (skip gateway probe/start and the
  * process-wide fetch interceptor). True under test runners — `NODE_ENV=test`
@@ -255,10 +242,7 @@ function isInertTestEnv(): boolean {
   );
 }
 
-async function initializeLorePlugin(
-  ctx: PluginInput,
-  lifecycleLease: EmbeddedGatewayLease,
-): Promise<Hooks> {
+export const LorePlugin: Plugin = async (ctx) => {
   // Initialize lore — only probe/start once per process.
   const loreDisabled =
     process.env.LORE_DISABLED === "1" || process.env.LORE_DISABLED === "true";
@@ -354,11 +338,7 @@ async function initializeLorePlugin(
   currentProject = { path: thisProjectPath, gitRemote: thisGitRemote };
 
   try {
-    // OpenCode 1.18+ awaits this hook from its instance finalizer. Keep the
-    // local intersection until our minimum supported plugin SDK declares it.
-    const hooks: Hooks & { dispose: () => Promise<void> } = {
-      dispose: lifecycleLease.release,
-
+    const hooks: Hooks = {
       // Disable built-in compaction (gateway handles it), register hidden
       // worker agents, and redirect all provider baseURLs through the gateway.
       config: async (input) => {
@@ -490,24 +470,22 @@ async function initializeLorePlugin(
         // Install the fetch interceptor once per process. It transparently
         // reroutes outgoing LLM API calls through the gateway while
         // preserving original auth headers and URLs.
-        processLifecycle.ownFetchInterceptor(
-          installFetchInterceptor({
-            gatewayBase,
-            getHeaders: () => {
-              const headers: Record<string, string> = {
-                ...gatewayAccessHeadersForRemote(gatewayBase),
-              };
-              const cur = currentProject;
-              if (cur?.path) {
-                headers["x-lore-project"] = cur.path;
-                // Only emit the remote paired with the path it was resolved FOR,
-                // never a remote left over from a different project's plugin call.
-                if (cur.gitRemote) headers["x-lore-git-remote"] = cur.gitRemote;
-              }
-              return headers;
-            },
-          }),
-        );
+        installFetchInterceptor({
+          gatewayBase,
+          getHeaders: () => {
+            const headers: Record<string, string> = {
+              ...gatewayAccessHeadersForRemote(gatewayBase),
+            };
+            const cur = currentProject;
+            if (cur?.path) {
+              headers["x-lore-project"] = cur.path;
+              // Only emit the remote paired with the path it was resolved FOR,
+              // never a remote left over from a different project's plugin call.
+              if (cur.gitRemote) headers["x-lore-git-remote"] = cur.gitRemote;
+            }
+            return headers;
+          },
+        });
         log.info(`routing through ${gatewayBase}`);
         log.info(`dashboard: ${gatewayBase}/ui`);
       }
@@ -524,24 +502,6 @@ async function initializeLorePlugin(
     const detail = e instanceof Error ? e.stack || e.message : String(e);
     log.error(`init failed: ${detail}`);
     throw e;
-  }
-}
-
-export const LorePlugin: Plugin = async (ctx) => {
-  const lifecycleLease = await processLifecycle.acquire();
-  try {
-    return await initializeLorePlugin(ctx, lifecycleLease);
-  } catch (error) {
-    try {
-      await lifecycleLease.release();
-    } catch (cleanupError) {
-      const detail =
-        cleanupError instanceof Error
-          ? cleanupError.stack || cleanupError.message
-          : String(cleanupError);
-      log.error(`cleanup after init failure failed: ${detail}`);
-    }
-    throw error;
   }
 };
 

--- a/packages/opencode/src/internal.ts
+++ b/packages/opencode/src/internal.ts
@@ -19,72 +19,48 @@ import { GATEWAY_AUTH_HEADER, log } from "@loreai/core";
 import * as http from "node:http";
 import * as https from "node:https";
 
-export interface EmbeddedGatewayResource {
-  owned: boolean;
-  shutdown: () => Promise<void>;
-}
-
-export interface EmbeddedGatewayLease {
-  release: () => Promise<void>;
+export interface SigtermHost {
+  prependOnceListener: (event: "SIGTERM", listener: () => void) => unknown;
+  removeListener: (event: "SIGTERM", listener: () => void) => unknown;
+  exit: (code?: number) => unknown;
 }
 
 /**
- * Own process-wide resources shared by every OpenCode plugin instance.
+ * Bridge the host process' SIGTERM to an embedded gateway's bounded shutdown.
  *
- * OpenCode creates one plugin instance per workspace, while Lore embeds one
- * gateway per host process. The last plugin disposer therefore owns teardown;
- * earlier disposers must leave the shared gateway and fetch interceptor alive.
+ * OpenCode's plugin `dispose` hook follows its per-workspace instance cache and
+ * can run during ordinary reloads, so it cannot own a process-wide gateway.
+ * Its headless `serve` command also does not dispose that cache on SIGTERM.
+ * Start Lore teardown first, then explicitly finish the requested process exit.
  */
-export class EmbeddedGatewayLifecycle {
-  private leases = 0;
-  private gatewayShutdown: (() => Promise<void>) | undefined;
-  private fetchCleanup: (() => void) | undefined;
-  private teardown: Promise<void> | undefined;
+export function installEmbeddedGatewaySigtermHandler(
+  shutdown: () => Promise<void>,
+  host: SigtermHost = process,
+): () => void {
+  let installed = true;
+  const onSigterm = (): void => {
+    if (!installed) return;
+    installed = false;
+    host.removeListener("SIGTERM", onSigterm);
+    void (async () => {
+      try {
+        await shutdown();
+      } catch {
+        // The process is terminating anyway. Record only a categorical error;
+        // process exit is the final bounded worker/thread cleanup mechanism.
+        log.error("embedded gateway shutdown failed during SIGTERM");
+      } finally {
+        host.exit(0);
+      }
+    })();
+  };
 
-  constructor(private readonly onIdle: () => void = () => {}) {}
-
-  async acquire(): Promise<EmbeddedGatewayLease> {
-    if (this.teardown) await this.teardown;
-    this.leases += 1;
-    let released = false;
-
-    return {
-      release: async () => {
-        if (released) return;
-        released = true;
-        this.leases -= 1;
-        if (this.leases !== 0) return;
-
-        const shutdown = this.gatewayShutdown;
-        const cleanup = this.fetchCleanup;
-        this.gatewayShutdown = undefined;
-        this.fetchCleanup = undefined;
-
-        const teardown = (async () => {
-          try {
-            await shutdown?.();
-          } finally {
-            cleanup?.();
-          }
-        })();
-        this.teardown = teardown;
-        this.onIdle();
-        try {
-          await teardown;
-        } finally {
-          if (this.teardown === teardown) this.teardown = undefined;
-        }
-      },
-    };
-  }
-
-  ownGateway(resource: EmbeddedGatewayResource): void {
-    if (resource.owned) this.gatewayShutdown = resource.shutdown;
-  }
-
-  ownFetchInterceptor(cleanup: () => void): void {
-    this.fetchCleanup = cleanup;
-  }
+  host.prependOnceListener("SIGTERM", onSigterm);
+  return () => {
+    if (!installed) return;
+    installed = false;
+    host.removeListener("SIGTERM", onSigterm);
+  };
 }
 
 function isLoopbackUrl(value: string): boolean {

--- a/packages/opencode/test/index.test.ts
+++ b/packages/opencode/test/index.test.ts
@@ -47,12 +47,7 @@ async function initPlugin() {
   return {
     hooks,
     tmpDir,
-    cleanup: async () => {
-      await (
-        hooks as typeof hooks & { dispose?: () => Promise<void> }
-      ).dispose?.();
-      rmSync(tmpDir, { recursive: true, force: true });
-    },
+    cleanup: () => rmSync(tmpDir, { recursive: true, force: true }),
   };
 }
 
@@ -65,7 +60,7 @@ describe("LorePlugin config hook", () => {
 
       expect(cfg.compaction).toEqual({ auto: false, prune: false });
     } finally {
-      await cleanup();
+      cleanup();
     }
   });
 
@@ -107,7 +102,7 @@ describe("LorePlugin config hook", () => {
         expect(agents[name].hidden).toBe(true);
       }
     } finally {
-      await cleanup();
+      cleanup();
     }
   });
 
@@ -126,7 +121,7 @@ describe("LorePlugin config hook", () => {
       });
       expect(agents["lore-distill"]).toBeDefined();
     } finally {
-      await cleanup();
+      cleanup();
     }
   });
 
@@ -255,14 +250,14 @@ describe("LorePlugin config hook", () => {
 });
 
 describe("LorePlugin hooks", () => {
-  test("exposes an awaited disposal hook for host shutdown", async () => {
+  test("does not bind process-wide gateway ownership to instance disposal", async () => {
     const { hooks, cleanup } = await initPlugin();
     try {
       expect(
         (hooks as typeof hooks & { dispose?: () => Promise<void> }).dispose,
-      ).toBeTypeOf("function");
+      ).toBeUndefined();
     } finally {
-      await cleanup();
+      cleanup();
     }
   });
 
@@ -271,7 +266,7 @@ describe("LorePlugin hooks", () => {
     try {
       expect(hooks.tool).toEqual({});
     } finally {
-      await cleanup();
+      cleanup();
     }
   });
 
@@ -286,7 +281,7 @@ describe("LorePlugin hooks", () => {
       expect(hooks["experimental.chat.messages.transform"]).toBeUndefined();
       expect(hooks["experimental.session.compacting"]).toBeUndefined();
     } finally {
-      await cleanup();
+      cleanup();
     }
   });
 });

--- a/packages/opencode/test/internal.test.ts
+++ b/packages/opencode/test/internal.test.ts
@@ -1,87 +1,82 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { EventEmitter } from "node:events";
 import type { PluginInput } from "@opencode-ai/plugin";
 import { log } from "@loreai/core";
 import {
-  EmbeddedGatewayLifecycle,
   gatewayAccessHeadersForRemote,
+  installEmbeddedGatewaySigtermHandler,
   shouldForwardUpstreamExtraHeader,
   surfaceGatewayUnavailable,
 } from "../src/internal";
 
-describe("embedded gateway lifecycle", () => {
-  test("the final plugin lease shuts down shared process resources once", async () => {
-    const shutdown = vi.fn(async () => {});
-    const cleanup = vi.fn();
-    const onIdle = vi.fn();
-    const lifecycle = new EmbeddedGatewayLifecycle(onIdle);
-    const first = await lifecycle.acquire();
-    const second = await lifecycle.acquire();
-    lifecycle.ownGateway({ owned: true, shutdown });
-    lifecycle.ownFetchInterceptor(cleanup);
+describe("embedded gateway SIGTERM", () => {
+  function fakeHost() {
+    const events = new EventEmitter();
+    let resolveExit: ((code: number | undefined) => void) | undefined;
+    const exited = new Promise<number | undefined>((resolve) => {
+      resolveExit = resolve;
+    });
+    return {
+      events,
+      exited,
+      host: {
+        prependOnceListener: (event: "SIGTERM", listener: () => void) =>
+          events.prependOnceListener(event, listener),
+        removeListener: (event: "SIGTERM", listener: () => void) =>
+          events.removeListener(event, listener),
+        exit: (code?: number) => resolveExit?.(code),
+      },
+    };
+  }
 
-    await first.release();
-    expect(shutdown).not.toHaveBeenCalled();
-    expect(cleanup).not.toHaveBeenCalled();
-
-    await second.release();
-    await second.release();
-    expect(shutdown).toHaveBeenCalledTimes(1);
-    expect(cleanup).toHaveBeenCalledTimes(1);
-    expect(onIdle).toHaveBeenCalledTimes(1);
-  });
-
-  test("does not stop a gateway owned by another process", async () => {
-    const shutdown = vi.fn(async () => {});
-    const lifecycle = new EmbeddedGatewayLifecycle();
-    const lease = await lifecycle.acquire();
-    lifecycle.ownGateway({ owned: false, shutdown });
-
-    await lease.release();
-    expect(shutdown).not.toHaveBeenCalled();
-  });
-
-  test("a new lease waits until the previous teardown settles", async () => {
+  test("awaits embedded gateway shutdown before completing SIGTERM", async () => {
     let finishShutdown: (() => void) | undefined;
-    const lifecycle = new EmbeddedGatewayLifecycle();
-    const first = await lifecycle.acquire();
-    lifecycle.ownGateway({
-      owned: true,
-      shutdown: () =>
+    const shutdown = vi.fn(
+      () =>
         new Promise<void>((resolve) => {
           finishShutdown = resolve;
         }),
-    });
+    );
+    const { events, exited, host } = fakeHost();
+    installEmbeddedGatewaySigtermHandler(shutdown, host);
 
-    const release = first.release();
-    let acquired = false;
-    const next = lifecycle.acquire().then((lease) => {
-      acquired = true;
-      return lease;
+    events.emit("SIGTERM");
+    expect(shutdown).toHaveBeenCalledTimes(1);
+    let didExit = false;
+    void exited.then(() => {
+      didExit = true;
     });
     await Promise.resolve();
-    expect(acquired).toBe(false);
+    expect(didExit).toBe(false);
 
     finishShutdown?.();
-    await release;
-    const second = await next;
-    expect(acquired).toBe(true);
-    await second.release();
+    await expect(exited).resolves.toBe(0);
   });
 
-  test("restores the fetch interceptor even when gateway shutdown fails", async () => {
-    const cleanup = vi.fn();
-    const lifecycle = new EmbeddedGatewayLifecycle();
-    const lease = await lifecycle.acquire();
-    lifecycle.ownGateway({
-      owned: true,
-      shutdown: async () => {
+  test("still completes termination when gateway shutdown fails", async () => {
+    const { events, exited, host } = fakeHost();
+    const stderr = vi.spyOn(console, "error").mockImplementation(() => {});
+    log.silenceStderr(false);
+    try {
+      installEmbeddedGatewaySigtermHandler(async () => {
         throw new Error("shutdown failed");
-      },
-    });
-    lifecycle.ownFetchInterceptor(cleanup);
+      }, host);
+      events.emit("SIGTERM");
+      await expect(exited).resolves.toBe(0);
+    } finally {
+      stderr.mockRestore();
+      log.silenceStderr(false);
+    }
+  });
 
-    await expect(lease.release()).rejects.toThrow("shutdown failed");
-    expect(cleanup).toHaveBeenCalledTimes(1);
+  test("cleanup removes the process signal listener", () => {
+    const shutdown = vi.fn(async () => {});
+    const { events, host } = fakeHost();
+    const cleanup = installEmbeddedGatewaySigtermHandler(shutdown, host);
+
+    cleanup();
+    events.emit("SIGTERM");
+    expect(shutdown).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary

Fix the OpenCode plugin regression introduced by #1767 and shut down an **owned, in-process** Lore gateway when a systemd-managed OpenCode server receives SIGTERM.

OpenCode's plugin `dispose()` hook belongs to its per-workspace instance cache and can run during ordinary invalidation/reload. #1767 incorrectly used that hook to own a process-wide gateway, allowing Lore to stop while OpenCode remained alive.

This replacement:

- removes the plugin disposal hook, workspace ref-counting, and process-state reset from #1767
- leaves ordinary plugin initialization and instance-cache lifecycle unchanged
- installs one process-lifetime, one-shot SIGTERM bridge only after this process starts and owns the embedded gateway
- runs Lore's existing bounded gateway/worker/SQLite shutdown before completing process exit
- still exits if graceful shutdown rejects, so systemd cannot wait indefinitely
- does not stop an external/reused Lore gateway
- does not intercept SIGINT or change interactive TUI behavior

Net diff against merged `main`: **124 additions / 198 deletions = -74 lines**.

## Validation

- regression forbids attaching process-wide ownership to plugin `dispose()`
- OpenCode package suite: 47/47 passed
- signal/plugin tests: 10 consecutive passes
- monorepo typecheck, lint, formatting, and generated-doc checks: passed
- `git diff --check`: passed
- branch is one commit ahead of current `main`, with no divergence

## Scope

The observed systemd cgroup contained only OpenCode's main process during stop, so this targets the host process directly. Lore's shutdown deadline is still event-loop driven; if synchronous work prevents JavaScript from handling SIGTERM at all, systemd's `TimeoutStopSec` remains the outer backstop and the next fix is removing that main-loop blocker.